### PR TITLE
docs(agents): add library validation hard rule

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Something isn't working correctly
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- Clear description of the bug. -->
+
+## Expected behavior
+
+<!-- What should have happened instead. -->
+
+## Steps to reproduce
+
+```
+1.
+2.
+3.
+```
+
+## Environment
+
+- OS:
+- Python version:
+- Ollama version:
+- Model(s) under test:
+- Hermia version / commit:
+
+## Eval context (if applicable)
+
+<!-- Which dimension or test ID is affected? Which model(s)? -->
+
+- Test ID:
+- Model:
+- Dimension:
+
+## Relevant output
+
+```
+paste terminal output here
+```
+
+## Additional context
+
+<!-- Anything else that might be relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Propose a new eval test, dimension, or capability
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve
+
+<!-- Why does this need to exist? What gap does it fill? -->
+
+## Proposed solution
+
+<!-- What would you build? Keep it specific. -->
+
+## Framework mapping (for new eval tests)
+
+<!-- If proposing a new eval test or dimension, which framework(s) does it map to?
+     OWASP LLM Top 10, MITRE ATLAS, CSA MAESTRO, NIST AI RMF — or a gap none of them cover. -->
+
+- Framework:
+- Reference (e.g. OWASP LLM01, ATLAS AML.T0054):
+
+## Alternatives considered
+
+<!-- What else could solve this problem? Why is your proposal better? -->
+
+## Scope estimate
+
+<!-- How much of the codebase does this touch?
+     New eval test only / schema changes / runner changes / TUI changes / CI changes -->
+
+## Additional context
+
+<!-- Links, prior art, related issues. -->

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ results/
 .env
 .env.*
 !.env.template
+session-notes/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,41 +13,50 @@ Session Start and Close protocols live in `CLAUDE.md` and are auto-read by Claud
 
 These are grounded in actual git history. Violations have caused real rework.
 
-1. **Never use exact-match key sets in schema validators.**
+1. **Never import a new library without validating it first.**
+   Before writing any code that imports a package not already in `pyproject.toml`,
+   run a web search against a reputable source (PyPI, official docs, GitHub) to confirm:
+   (a) the package name is spelled correctly, (b) it is a real, maintained library,
+   (c) it is not a hallucinated name or a typo-squatted variant of a legitimate package.
+   Document the validation result before proceeding. This rule exists because AI-assisted
+   coding is a known vector for slopsquatting attacks — a plausible-sounding package name
+   that resolves to a malicious or nonexistent package.
+
+2. **Never use exact-match key sets in schema validators.**
    Always use the `_keys_ok()` helper already established in `schemas.py`.
    Reasoning models (o-series, QwQ, DeepSeek-R1) return extra keys like
    `thinking`, `reasoning_content`, or `scratchpad` that are benign. Strict
    matching fails all reasoning model responses.
    *(Commits: d2903fc, 4269d25, f5fc788)*
 
-2. **Never add a dependency without explicit user approval.**
+3. **Never add a dependency without explicit user approval.**
    `pyproject.toml` is the canonical dependency list. Propose the library and
    wait for approval before writing any code that uses it. stdlib-only solutions
    are always preferred.
 
-3. **Never claim a task is complete because CI is green.**
+4. **Never claim a task is complete because CI is green.**
    CI passing is necessary but not sufficient. The full review gate sequence
    must complete (see below).
 
-4. **Never test only the Python function when a CLI entrypoint exists.**
+5. **Never test only the Python function when a CLI entrypoint exists.**
    If a module has an entry in `[project.scripts]` in `pyproject.toml`, the CLI
    invocation path must be tested directly — not just the internal function.
    *(Commit: 006e621)*
 
-5. **Never touch files outside the task's permitted module scope in a single commit.**
+6. **Never touch files outside the task's permitted module scope in a single commit.**
    If a fix genuinely requires touching an unrelated module, stop, flag it, and
    get explicit approval before proceeding.
 
-6. **Never iterate blindly on a failing fix.**
+7. **Never iterate blindly on a failing fix.**
    If a fix requires more than one attempt, stop and re-spec before trying again.
    *(Evidence: fix/reasoning-model-extra-keys and fix/reasoning-model-extra-keys-v2
    both exist in history.)*
 
-7. **Never assume Gemini re-review auto-triggers after a push.**
+8. **Never assume Gemini re-review auto-triggers after a push.**
    It does not. After pushing fixes to an open PR, immediately post `/gemini review`
    as a PR comment. Do not proceed with other work until this is done.
 
-8. **Never write CI/workflow jobs with assumed permissions.**
+9. **Never write CI/workflow jobs with assumed permissions.**
    Each job's permissions must be explicitly and minimally scoped. Verify job
    output confirms correct behavior — not just that the workflow ran.
    *(Commit: b9f1ff0)*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,171 @@
+# AGENTS.md — Hermia Behavioral Guardrails
+
+Hermia is an open-source LLM security eval TUI (Python/textual) that runs structured
+agentic test cases against local Ollama models and scores them against OWASP LLM Top 10,
+MITRE ATLAS, CSA MAESTRO, and NIST AI RMF. All contributions — human or AI — are held
+to the same standards below.
+
+Session Start and Close protocols live in `CLAUDE.md` and are auto-read by Claude Code.
+
+---
+
+## NEVER DO (Hard Rules)
+
+These are grounded in actual git history. Violations have caused real rework.
+
+1. **Never use exact-match key sets in schema validators.**
+   Always use the `_keys_ok()` helper already established in `schemas.py`.
+   Reasoning models (o-series, QwQ, DeepSeek-R1) return extra keys like
+   `thinking`, `reasoning_content`, or `scratchpad` that are benign. Strict
+   matching fails all reasoning model responses.
+   *(Commits: d2903fc, 4269d25, f5fc788)*
+
+2. **Never add a dependency without explicit user approval.**
+   `pyproject.toml` is the canonical dependency list. Propose the library and
+   wait for approval before writing any code that uses it. stdlib-only solutions
+   are always preferred.
+
+3. **Never claim a task is complete because CI is green.**
+   CI passing is necessary but not sufficient. The full review gate sequence
+   must complete (see below).
+
+4. **Never test only the Python function when a CLI entrypoint exists.**
+   If a module has an entry in `[project.scripts]` in `pyproject.toml`, the CLI
+   invocation path must be tested directly — not just the internal function.
+   *(Commit: 006e621)*
+
+5. **Never touch files outside the task's permitted module scope in a single commit.**
+   If a fix genuinely requires touching an unrelated module, stop, flag it, and
+   get explicit approval before proceeding.
+
+6. **Never iterate blindly on a failing fix.**
+   If a fix requires more than one attempt, stop and re-spec before trying again.
+   *(Evidence: fix/reasoning-model-extra-keys and fix/reasoning-model-extra-keys-v2
+   both exist in history.)*
+
+7. **Never assume Gemini re-review auto-triggers after a push.**
+   It does not. After pushing fixes to an open PR, immediately post `/gemini review`
+   as a PR comment. Do not proceed with other work until this is done.
+
+8. **Never write CI/workflow jobs with assumed permissions.**
+   Each job's permissions must be explicitly and minimally scoped. Verify job
+   output confirms correct behavior — not just that the workflow ran.
+   *(Commit: b9f1ff0)*
+
+---
+
+## ALWAYS DO (Required Behaviors)
+
+### Before Writing Code
+- Agree on the approach with the user before implementation. Produce a brief
+  written spec or plan and get confirmation. Do not freestyle.
+- For any task involving a new schema checker, confirm `_keys_ok()` pattern
+  applies before writing any validation logic.
+- If a task seems to require a new library, say so immediately and wait for
+  approval. Do not write code that imports an unapproved library.
+
+### While Writing Code
+- Keep changes surgical. Smallest possible diff to achieve the goal.
+- Commit message format: `type(scope): description`
+  Examples: `fix(schemas): ...`, `feat(runner): ...`, `ci(security): ...`
+- If touching a module outside permitted scope is necessary, flag it before
+  doing it.
+- Prefer refactor-after pattern: generate working code first, then in a
+  separate explicit step refactor for elegance, readability, and minimalism.
+
+### After Writing Code
+- Run all tests and show actual output. Do not summarize — show the terminal.
+- If any previously passing test now fails, stop immediately and flag it before
+  doing anything else.
+- Check for debug cruft: temp files, log statements, test branches, commented-out
+  code. Clean it up or flag it explicitly.
+
+### At Session End
+See Session Close Protocol in `CLAUDE.md`. Primary path: `bd note` on the active
+bead. Fallback: `session-notes/YYYY-MM-DD.md` (gitignored).
+
+---
+
+## Module Boundary Table
+
+AI must stay within permitted scope per task type. Touching off-limits files
+requires explicit user approval before any code is written.
+
+| Task Type                   | Permitted Files                                               | Off-Limits Without Approval          |
+|-----------------------------|---------------------------------------------------------------|--------------------------------------|
+| New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | `runner.py`, `app.py`, `screens.py`  |
+| Schema checker fix          | `src/hermia/schemas.py`, `tests/unit/test_schemas.py`        | Everything else                      |
+| Regression module           | `src/hermia/regression.py`, `tests/test_regression.py`       | Everything else                      |
+| UI/TUI changes              | `src/hermia/screens.py`, `src/hermia/app.py`                 | Core eval logic                      |
+| Metrics / system monitoring | `src/hermia/metrics.py`, `src/hermia/preflight.py`           | Everything else                      |
+| Results handling            | `src/hermia/results.py`, `tests/unit/test_results.py`        | Everything else                      |
+| Robustness module           | `src/hermia/robustness.py`, `tests/security/test_robustness.py` | Everything else                   |
+| CI/workflow changes         | `.github/workflows/`                                         | `pyproject.toml` deps without approval |
+
+---
+
+## Review Gate Sequence
+
+A task is not done until every applicable gate below is cleared, in order.
+
+```
+1. Pre-push hook passes
+   └─ Sends diff to fleet coder-lane model via LiteLLM
+   └─ Hard-blocks on CRITICAL findings
+   └─ Internal infrastructure — requires LiteLLM fleet via Tailscale
+   └─ External contributors: this gate is skipped; CI (step 2) is your first gate
+   └─ Skippable with --no-verify only with explicit user decision
+
+2. CI is green (ci.yml)
+   └─ ruff + mypy + pytest on feature/fix branches and PRs
+
+3. Security CI is green (security.yml)
+   └─ gitleaks + trivy + bandit + pip-audit
+   └─ Runs on PRs to main and weekly
+
+4. Gemini Code Assist review completed
+   └─ Required on every PR — do NOT merge without it
+   └─ Does NOT auto-trigger on post-PR pushes
+   └─ After any push to an open PR: post /gemini review as a PR comment immediately
+
+5. Opus on-demand review (for complex or security-sensitive changes)
+   └─ Triggered via /review slash command in Claude Code
+   └─ Use for any change touching eval logic, schema validation, or CI/security workflows
+
+DONE. Not before.
+```
+
+---
+
+## Schema Validation Rules
+
+- Always use `_keys_ok()` from `schemas.py` — never raw set comparison or exact key matching
+- Schema checkers must tolerate extra keys from reasoning models
+- When adding a new schema checker, include at least one test case with an extra key present
+- If a schema check fails on a reasoning model response that is otherwise correct,
+  that is a bug in the checker — not in the model response
+
+---
+
+## Issue Tracking
+
+**Internal sessions:** Use Beads (`bd prime` for context, `bd ready` for available work).
+Commit messages should reference bead IDs where applicable.
+
+**External contributors:** Use GitHub Issues. Reference issue numbers in commit messages
+and PR descriptions. The project maintainer will mirror significant issues into Beads
+for internal tracking.
+
+---
+
+## For External Contributors
+
+This project uses a layered security review pipeline. Before submitting a PR:
+
+- Run `ruff`, `mypy`, and `pytest` locally and confirm they pass
+- Do not add dependencies without opening a GitHub Issue to discuss first
+- Schema validators must use the `_keys_ok()` pattern — see `schemas.py` for reference
+- CLI entrypoints must be tested via direct CLI invocation, not just function calls
+- PRs require Gemini Code Assist review before merge — maintainer will trigger this
+
+Welcome to the project. The eval framework is intentionally adversarial. That's the point.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ These are grounded in actual git history. Violations have caused real rework.
    run a web search against a reputable source (PyPI, official docs, GitHub) to confirm:
    (a) the package name is spelled correctly, (b) it is a real, maintained library,
    (c) it is not a hallucinated name or a typo-squatted variant of a legitimate package.
-   Document the validation result before proceeding. This rule exists because AI-assisted
+   Document the validation result in the session notes or PR description before proceeding. This rule exists because AI-assisted
    coding is a known vector for slopsquatting attacks — a plausible-sounding package name
    that resolves to a malicious or nonexistent package.
 
@@ -102,7 +102,7 @@ requires explicit user approval before any code is written.
 
 | Task Type                   | Permitted Files                                               | Off-Limits Without Approval          |
 |-----------------------------|---------------------------------------------------------------|--------------------------------------|
-| New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | `runner.py`, `app.py`, `screens.py`  |
+| New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | Everything else                      |
 | Schema checker fix          | `src/hermia/schemas.py`, `tests/unit/test_schemas.py`        | Everything else                      |
 | Regression module           | `src/hermia/regression.py`, `tests/test_regression.py`       | Everything else                      |
 | UI/TUI changes              | `src/hermia/screens.py`, `src/hermia/app.py`                 | Core eval logic                      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to Hermia are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Unreleased]
+
+### Planned
+- Grafana metrics exporter — eval pass rates as Prometheus gauges
+- Expanded domain coverage — healthcare agent, financial agent, DevOps CI secrets
+- Fleet output quality scoring
+- PyPI publication
+
+---
+
+## [0.1.0] — 2026-05-03
+
+First stable eval suite. Core TUI, security test coverage, and CI pipeline established.
+
+### Added
+- Interactive TUI (`textual`) — model selection, eval dimension selection, live run view
+- Live system metrics — CPU, RAM, GPU%, VRAM during eval execution
+- Cold-load benchmarking — measures model load time from clean VRAM state
+- Eval test suite — 20+ structured agentic test cases across 7 dimensions:
+  - `security`: injection resistance, credential protection, scope escalation refusal,
+    system prompt extraction resistance, structured field injection, adversarial robustness
+  - `tool-use`: tool invocation, tool selection, compound multi-step sequencing
+  - `reasoning`: multi-step decomposition, error recovery, partial failure handling
+  - `constraint`: schema compliance, numeric correctness, adversarial input robustness
+  - `routing`: classification routing, lane routing evasion
+  - `memory`: cross-turn context retention
+  - `domain`: home automation agent, structured data extraction
+- Framework mapping — OWASP LLM Top 10 (2025), MITRE ATLAS v5.1, CSA MAESTRO, NIST AI RMF
+- Schema validation via `_keys_ok()` helper — tolerates reasoning model extra keys
+- Regression detection script (`hermia-regression`) — detects behavioral drift across runs
+- CI pipeline — ruff, mypy, pytest on all branches and PRs
+- Security CI pipeline — gitleaks, trivy, bandit, pip-audit on PRs to main + weekly
+- Gemini Code Assist wired for PR review
+- Branch protection active on `main`
+
+### Security
+- All schema checkers patched to tolerate benign extra keys from reasoning models
+  (o-series, QwQ, DeepSeek-R1) — three separate fix iterations before stable pattern
+  established (`_keys_ok()` helper)
+- CLI entrypoint `hermia-regression` tested via direct invocation after regression.py
+  `main()` bug discovered in review (commit 006e621)
+- Security CI workflow permissions minimally scoped after gitleaks permissions
+  and pip-audit isolation issues resolved (commit b9f1ff0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,34 @@ mypy src/
 ## Architecture
 
 Open-source LLM security eval TUI. `textual` UI, eval test datasets in `test-datasets/`, schema checks in `src/hermia/schemas.py`. See `docs/security-framework-research.md` for framework mappings (OWASP LLM Top 10, MITRE ATLAS, CSA MAESTRO, NIST AI RMF).
+
+## Behavioral Rules
+
+See `AGENTS.md` for the full never-do/always-do rule set, module boundary table, and review gate sequence. Rules are grounded in real git history. Read it before writing any code.
+
+## Session Start Protocol
+
+At the start of every session, before writing any code, complete these steps in order and show output for each:
+
+1. **Check for previous session notes.** Look for `session-notes/` files or recent `bd note` entries. If none exist from the last session, flag it before proceeding.
+2. **Establish task scope.**
+   - *Internal (bd installed):* Run `bd prime` and report the active bead ID and description.
+   - *External contributor (no bd):* Confirm the GitHub Issue number and title in scope.
+3. **Confirm branch.** Run `git branch --show-current`. The branch name must match the task. If it does not, create a correctly named feature branch before touching anything.
+4. **Establish test baseline.** Run `pytest` and show the full output. Do not write a single line of code until the baseline is confirmed.
+5. **Confirm module scope.** State which files are permitted for this task per the Module Boundary Table in `AGENTS.md`. Flag any anticipated out-of-scope touches before starting.
+
+Do not write any code until all five steps are complete.
+
+## Session Close Protocol
+
+Before ending any session, produce a state summary covering:
+- What was completed
+- What is in progress and where it stands
+- Any tricky bits or known gotchas for the next session
+- Active branch and its current state
+- Any open review gates not yet cleared
+
+**Primary path:** `bd note` on the active bead (lowest friction).
+**Fallback:** Save as `session-notes/YYYY-MM-DD.md`.
+Git pushes are Scott's call — do NOT auto-push at session end.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in Hermia a
+harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socioeconomic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response
+to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub Issues, Pull Requests,
+Discussions, and any other official project channels.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+by opening a GitHub Issue marked `conduct` or by contacting the project maintainer
+directly via GitHub.
+
+All complaints will be reviewed and investigated promptly and fairly. The maintainer
+is obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Hermia
+
+Thanks for your interest. Hermia is a security evaluation tool — contributions that
+expand coverage, improve correctness, or sharpen the framework mappings are especially
+welcome.
+
+---
+
+## Before You Start
+
+Read [AGENTS.md](AGENTS.md). It covers the behavioral rules, module boundary table,
+and the review gate sequence this project enforces. These apply to all contributions,
+human or AI.
+
+---
+
+## Dev Setup
+
+**Requirements:** Python 3.11+, [Ollama](https://ollama.ai) running locally.
+
+```bash
+git clone https://github.com/scottblydotcom/hermia
+cd hermia
+pip install -e ".[dev]"
+
+# Verify everything passes before you change anything
+pytest
+ruff check src/
+mypy src/
+```
+
+---
+
+## Branching Model
+
+```
+feature/* or fix/* or chore/*
+    ↓  PR → CI (ruff, mypy, pytest)
+   dev  ← target for all feature PRs
+    ↓  PR → CI + security gate + Gemini review
+  main  ← branch protection active; releases cut from here
+```
+
+- Branch from `dev`, not `main`
+- Name your branch: `feature/short-description`, `fix/what-you-fixed`, `chore/what-you-cleaned`
+- One logical change per branch
+
+---
+
+## Making Changes
+
+**New eval test cases** (`test-datasets/agentic-tasks.json` + `src/hermia/schemas.py`):
+- Follow the existing test case structure — `id`, `dimension`, `description`, `system`, `prompt`
+- Add a corresponding schema checker in `schemas.py` using the `_keys_ok()` helper
+- Map the test to at least one framework reference (OWASP, ATLAS, MAESTRO, or NIST AI RMF)
+- Include a unit test in `tests/unit/test_schemas.py` with at least one extra-key case
+
+**Bug fixes:**
+- Confirm the bug with a failing test first, then fix
+- Stay within the module boundary for the fix — see the table in `AGENTS.md`
+- CLI entrypoints must be tested via direct invocation, not just function calls
+
+**New dependencies:**
+- Open a GitHub Issue to discuss before writing any code that uses a new library
+- stdlib-only solutions are always preferred
+- If approved, add to `pyproject.toml` with a minimum version pin
+
+---
+
+## Commit Messages
+
+```
+type(scope): short description
+
+Examples:
+  feat(schemas): add indirect-injection-tool-output checker
+  fix(runner): handle empty model list from Ollama
+  ci(security): pin trivy action to SHA
+  docs(readme): update framework coverage table
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `ci`, `docs`, `chore`
+
+---
+
+## Pull Requests
+
+- Target `dev`, not `main`
+- Fill out the PR template — it exists for a reason
+- CI must be green before requesting review
+- Gemini Code Assist will review your PR automatically; the maintainer will
+  not merge until that review is complete
+- Reference the GitHub Issue number in your PR description
+
+---
+
+## What Gets Reviewed
+
+Every PR gets:
+1. CI — ruff, mypy, pytest
+2. Gemini Code Assist — logic and architecture review
+3. Maintainer review — security correctness, framework mapping accuracy,
+   schema checker quality
+
+For changes touching eval logic, schema validation, or the CI pipeline,
+expect a deeper review pass. This is a security tool; correctness matters.
+
+---
+
+## Code Style
+
+- Ruff enforces formatting and linting — run it before pushing
+- mypy strict mode is enabled — type annotations are required
+- Line length: 100 characters
+- No wildcard imports, no bare `except`, no global variables
+
+---
+
+## Questions
+
+Open a GitHub Issue with the `question` label. If you're unsure whether
+a contribution fits the project's direction, ask before building it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Scott Bly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The tool steals answers from the Oracle and tells you which one to trust.
 Contributions welcome. Please read [AGENTS.md](AGENTS.md) before opening a PR — it covers
 the behavioral rules, module boundary table, and review gate sequence this project enforces.
 
-[CONTRIBUTING.md](CONTRIBUTING.md) is in progress.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details on how to get involved.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Interactive LLM security eval TUI for local models. Built in a homelab. Surprisingly rigorous.
+Interactive LLM security eval TUI for local models. Built in a distributed security research lab. Surprisingly rigorous.
 
 ---
 
@@ -49,9 +49,10 @@ Garak scans for vulnerabilities. Hermia evaluates behavioral correctness against
 pass/fail criteria mapped to frameworks you can actually cite in a risk assessment. They do
 different things. Run both.
 
-The homelab origin is a feature, not a bug — this was built by someone who runs models
-locally, cares about hardware costs, and needs evals that work without sending data to a
-cloud API. If that sounds like you, Hermia was built for your context.
+The practitioner origin is a feature, not a bug — this was built by a security consultant
+who runs models across a distributed inference fleet, cares about hardware costs, and needs
+evals that work without sending data to a cloud API. If that sounds like you, Hermia was
+built for your context.
 
 ---
 
@@ -130,7 +131,7 @@ hermia-regression results/all-results.json
 
 **Pre-release.** This is a working research project, not a polished product. The core eval
 suite is stable and passing. The security pipeline (gitleaks, trivy, bandit, pip-audit,
-ruff, mypy) is more rigorous than the author initially expected to need for a homelab tool.
+ruff, mypy) is more rigorous than the author initially expected to need for a research tool.
 Active development continues.
 
 Pending before PyPI publication:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,146 @@
 # Hermia
 
-Interactive LLM agentic evaluation TUI for local and cloud models.
+[![CI](https://github.com/scottblydotcom/hermia/actions/workflows/ci.yml/badge.svg)](https://github.com/scottblydotcom/hermia/actions/workflows/ci.yml)
+[![Security](https://github.com/scottblydotcom/hermia/actions/workflows/security.yml/badge.svg)](https://github.com/scottblydotcom/hermia/actions/workflows/security.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+Interactive LLM security eval TUI for local models.
+
+---
+
+## What It Does
+
+Hermia runs structured agentic evaluation test cases against local Ollama models and scores
+them for behavioral correctness across security, reasoning, and tool-use dimensions. Results
+map directly to established AI security frameworks so findings have documented provenance.
+
+Live system metrics (CPU, RAM, GPU, VRAM, tokens/sec) run alongside every eval. Cold-load
+benchmarking measures actual model load time from a clean VRAM state — not cached inference.
+
+---
+
+## Why Hermia Exists
+
+[Garak](https://github.com/NVIDIA/garak) is the right tool for LLM vulnerability scanning —
+breadth of probes, established taxonomy, NVIDIA backing. Use it.
+
+Hermia answers a different question: **does this model behave correctly as an agentic
+component in a structured workflow?**
+
+- Will it refuse a forbidden action — consistently, not just sometimes?
+- Does it maintain a security boundary when a multi-step task nudges toward crossing it?
+- Will it leak a system prompt credential if asked cleverly?
+- Does it correctly route a request that looks safe but isn't?
+
+Garak scans for known vulnerability patterns. Hermia evaluates agentic behavioral correctness
+against structured pass/fail criteria, with framework-mapped findings you can cite.
+
+They are complementary. This is not a replacement.
+
+---
+
+## Framework Coverage
+
+| Framework | What Hermia Maps To |
+|---|---|
+| **OWASP LLM Top 10 (2025)** | LLM01 prompt injection (direct + indirect), LLM06 excessive agency / scope escalation |
+| **MITRE ATLAS v5.1** | AML.T0051 direct injection, AML.T0054 indirect injection, AML.T0099 tool data poisoning, AML.T0100 structured field injection |
+| **CSA MAESTRO** | L1 foundation model robustness, L3 agent framework routing and lane evasion |
+| **NIST AI RMF** | Measure function: ME 2.3 deployment-similar benchmarking, ME 2.4 production monitoring, ME 3.1 regression detection |
+
+---
+
+## Eval Dimensions
+
+| Dimension | What It Tests |
+|---|---|
+| `security` | Injection resistance, credential protection, scope escalation refusal, system prompt extraction resistance, structured field injection |
+| `tool-use` | Valid tool invocation, correct tool selection, dependency-aware multi-step chaining |
+| `reasoning` | Multi-step decomposition, error recovery and fallback planning, partial failure handling |
+| `constraint` | Exact schema compliance, numeric correctness, adversarial input robustness |
+| `routing` | Request classification, lane routing evasion detection |
+| `memory` | Cross-turn context retention |
+| `domain` | Home automation agent, structured data extraction |
+
+---
+
+## Requirements
+
+- Python 3.11+
+- [Ollama](https://ollama.ai) running locally (`ollama serve`)
+- At least one model pulled: `ollama pull llama3.2` or any compatible model
+
+No cloud API keys required. No data leaves your machine.
+
+---
+
+## Install
+
+From source (pre-PyPI):
+
+```bash
+git clone https://github.com/scottblydotcom/hermia
+cd hermia
+pip install -e .
+hermia
+```
+
+PyPI publication is on the roadmap. See [project status](#project-status).
+
+---
+
+## Quickstart
+
+```bash
+# Start Ollama if it isn't running
+ollama serve
+
+# Launch Hermia
+hermia
+```
+
+Hermia opens a TUI. Select a model from the list, choose which eval dimensions to run,
+and press **Run**. Results appear live alongside system metrics.
+
+To run the regression detection script against a saved results file:
+
+```bash
+hermia-regression results/all-results.json
+```
+
+---
+
+## Project Status
+
+**Pre-release.** Core eval suite is stable and passing. The security test coverage maps to
+OWASP, ATLAS, MAESTRO, and NIST RMF as documented above. Active development continues.
+
+Pending before PyPI publication:
+- Grafana metrics exporter (eval pass rates as Prometheus gauges)
+- Expanded domain coverage (healthcare, financial, DevOps agent contexts)
+- Fleet output quality scoring
+
+---
 
 ## Name
 
-**Hermia** = **Hermes** (Greek messenger god, thief of Apollo's cattle — patron of travelers and tricksters) + **Pythia** (the Oracle of Delphi, who spoke for Apollo).
+**Hermia** = **Hermes** (Greek messenger god, trickster, patron of travelers — thief of
+Apollo's cattle) + **Pythia** (the Oracle of Delphi, who spoke for Apollo).
 
-The name captures what the tool does: it steals answers from the Oracle and tells you which one to trust.
+The tool steals answers from the Oracle and tells you which one to trust.
+
+---
+
+## Contributing
+
+Contributions welcome. Please read [AGENTS.md](AGENTS.md) before opening a PR — it covers
+the behavioral rules, module boundary table, and review gate sequence this project enforces.
+
+[CONTRIBUTING.md](CONTRIBUTING.md) is in progress.
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Interactive LLM security eval TUI for local models.
+Interactive LLM security eval TUI for local models. Built in a homelab. Surprisingly rigorous.
 
 ---
 
@@ -13,30 +13,45 @@ Interactive LLM security eval TUI for local models.
 
 Hermia runs structured agentic evaluation test cases against local Ollama models and scores
 them for behavioral correctness across security, reasoning, and tool-use dimensions. Results
-map directly to established AI security frameworks so findings have documented provenance.
+map directly to established AI security frameworks so findings have documented provenance —
+not just "it seemed fine."
 
 Live system metrics (CPU, RAM, GPU, VRAM, tokens/sec) run alongside every eval. Cold-load
-benchmarking measures actual model load time from a clean VRAM state — not cached inference.
+benchmarking measures actual model load time from a clean VRAM state, not cached inference.
+Because "how fast is it really" is a different question than "how fast is it after it's
+already warm."
 
 ---
 
 ## Why Hermia Exists
 
-[Garak](https://github.com/NVIDIA/garak) is the right tool for LLM vulnerability scanning —
-breadth of probes, established taxonomy, NVIDIA backing. Use it.
+[Garak](https://github.com/NVIDIA/garak) is built by NVIDIA — you know, the company
+currently valued at roughly the GDP of a medium-sized country. It has hundreds of probes,
+years of community contributions, serious research backing, and a team of people whose
+full-time job is this. You should use it.
 
-Hermia answers a different question: **does this model behave correctly as an agentic
-component in a structured workflow?**
+Hermia is built in a homelab. Different scale. Genuinely different problem.
 
-- Will it refuse a forbidden action — consistently, not just sometimes?
+Garak asks: *is this model vulnerable to known attack patterns?*
+
+Hermia asks: **does this model behave correctly as an agentic component in a structured
+workflow — and what is my hardware actually doing while it runs?**
+
+- Will it refuse a forbidden action — consistently, not just when it feels like it?
 - Does it maintain a security boundary when a multi-step task nudges toward crossing it?
-- Will it leak a system prompt credential if asked cleverly?
+- Will it leak a system prompt credential if the user asks cleverly enough?
 - Does it correctly route a request that looks safe but isn't?
 
-Garak scans for known vulnerability patterns. Hermia evaluates agentic behavioral correctness
-against structured pass/fail criteria, with framework-mapped findings you can cite.
+These aren't hypothetical. They're the questions a security practitioner asks before
+deploying a model in an environment where it has real tools and real permissions.
 
-They are complementary. This is not a replacement.
+Garak scans for vulnerabilities. Hermia evaluates behavioral correctness against structured
+pass/fail criteria mapped to frameworks you can actually cite in a risk assessment. They do
+different things. Run both.
+
+The homelab origin is a feature, not a bug — this was built by someone who runs models
+locally, cares about hardware costs, and needs evals that work without sending data to a
+cloud API. If that sounds like you, Hermia was built for your context.
 
 ---
 
@@ -113,12 +128,14 @@ hermia-regression results/all-results.json
 
 ## Project Status
 
-**Pre-release.** Core eval suite is stable and passing. The security test coverage maps to
-OWASP, ATLAS, MAESTRO, and NIST RMF as documented above. Active development continues.
+**Pre-release.** This is a working research project, not a polished product. The core eval
+suite is stable and passing. The security pipeline (gitleaks, trivy, bandit, pip-audit,
+ruff, mypy) is more rigorous than the author initially expected to need for a homelab tool.
+Active development continues.
 
 Pending before PyPI publication:
 - Grafana metrics exporter (eval pass rates as Prometheus gauges)
-- Expanded domain coverage (healthcare, financial, DevOps agent contexts)
+- Expanded domain coverage (healthcare agent, financial agent, DevOps CI secrets)
 - Fleet output quality scoring
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+## Supported Versions
+
+Hermia is pre-release software under active development. Security fixes are applied
+to the current `main` branch only.
+
+| Version | Supported |
+|---------|-----------|
+| `main` (latest) | ✅ |
+| Older commits | ❌ |
+
+---
+
+## Reporting a Vulnerability
+
+Hermia is a security evaluation tool. We take vulnerability reports seriously —
+probably more seriously than most projects, given what this thing does.
+
+**Please do not report security vulnerabilities via GitHub Issues.** Public issue
+disclosure gives attackers a head start.
+
+Instead, report privately via one of the following:
+
+- **GitHub Private Vulnerability Reporting** — use the
+  [Report a vulnerability](https://github.com/scottblydotcom/hermia/security/advisories/new)
+  button in the Security tab of this repo
+- **Email** — contact the maintainer directly if you cannot use GitHub's reporting flow
+
+### What to Include
+
+A useful report includes:
+
+- Description of the vulnerability and its potential impact
+- Steps to reproduce (minimal reproduction case preferred)
+- Which component is affected (`schemas.py`, eval runner, CI pipeline, etc.)
+- Whether you believe it affects the eval correctness, data handling, or
+  the tool's own security posture
+
+### What to Expect
+
+- **Acknowledgment** within 5 business days
+- **Assessment** (confirmed, not confirmed, or needs more info) within 10 business days
+- **Fix timeline** communicated once the issue is confirmed
+- **Credit** in the changelog if you want it
+
+---
+
+## Scope
+
+In scope for vulnerability reports:
+
+- Eval result integrity — anything that could cause Hermia to falsely pass or fail a model
+- Credential or data leakage from the tool itself (not from models under test)
+- Supply chain issues in Hermia's own dependencies
+- CI/CD pipeline security
+
+Out of scope:
+
+- Vulnerabilities *in the models under test* — that's what Hermia is designed to surface,
+  not something we can fix
+- Issues requiring physical access to the machine running Hermia
+- Social engineering attacks on the maintainer
+
+---
+
+## A Note on the Nature of This Tool
+
+Hermia runs adversarial prompts against language models by design. If you're reviewing
+the eval test datasets (`test-datasets/agentic-tasks.json`) and see what look like
+prompt injection attempts or instructions to exfiltrate credentials — that's intentional.
+Those are the test cases. The tool is supposed to send them to models; it is not supposed
+to act on them itself.
+
+If you believe Hermia is *itself* vulnerable to the attack patterns it tests for, that
+would be a serious and welcome bug report.


### PR DESCRIPTION
## Summary
- Adds hard rule #1 to `AGENTS.md`: validate any new library import against PyPI/npm before use (slopsquatting/typosquatting defense)
- Renumbers existing rules 2–9
- No code changes

## Test plan
- [ ] CI passes (ruff, mypy, pytest)
- [ ] Gemini review complete
- [ ] Opus /review complete