### PR TITLE
docs: add maintainer email to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Instead, report privately via one of the following:
 - **GitHub Private Vulnerability Reporting** — use the
   [Report a vulnerability](https://github.com/scottblydotcom/hermia/security/advisories/new)
   button in the Security tab of this repo
-- **Email** — contact the maintainer directly if you cannot use GitHub's reporting flow
+- **Email** — contact the maintainer directly at scottbly1@gmail.com if you cannot use GitHub's reporting flow
 
 ### What to Include
 


### PR DESCRIPTION
## Summary
- Adds `scottbly1@gmail.com` to the email reporting option in SECURITY.md
- Gemini flagged this as a missing contact in a prior review

## Test plan
- [ ] Verify line 28 reads correctly in the rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)