### PR TITLE
docs(agents): add branch workflow hard rule and model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ These are grounded in actual git history. Violations have caused real rework.
 
 10. **Never open a PR against `main` from a work branch — always target `dev`.**
     The only PR that should ever target `main` is the dev→main promotion PR.
-    All other work flows: any work branch → PR → `dev` → PR → `main`.
+    All other workflows: any work branch → PR → `dev` → PR → `main`.
     When using `gh pr create`, always pass `--base dev` explicitly; the default
     is the repo's default branch (`main`), which will bypass the dev gate and
     cause `main` to diverge ahead of `dev`, requiring rebase or merge judo to fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,10 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, etc.) → dev → main
 ```
-- All work branches from `dev`. Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
+- All work branches from `dev` (always `git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, something went wrong.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git merge main`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ These are grounded in actual git history. Violations have caused real rework.
    output confirms correct behavior — not just that the workflow ran.
    *(Commit: b9f1ff0)*
 
-10. **Never open a feature or fix PR against `main` — always target `dev`.**
+10. **Never open a feature, fix, or chore PR against `main` — always target `dev`.**
     The only PR that should ever target `main` is the dev→main promotion PR.
-    All other work flows: `feature/* or fix/*` → PR → `dev` → PR → `main`.
+    All other work flows: `feature/*`, `fix/*`, or `chore/*` → PR → `dev` → PR → `main`.
     When using `gh pr create`, always pass `--base dev` explicitly; the default
     is the repo's default branch (`main`), which will bypass the dev gate and
     cause `main` to diverge ahead of `dev`, requiring rebase or merge judo to fix.
@@ -75,10 +75,10 @@ These are grounded in actual git history. Violations have caused real rework.
 
 ### Branch Workflow
 ```
-main ← dev ← feature/* or fix/*
+main ← dev ← feature/*, fix/*, or chore/*
 ```
-- All work branches from `dev`. Always `git checkout -b feature/name` from `dev`.
-- Feature/fix PR: `gh pr create --base dev`
+- All work branches from `dev`. Use the appropriate prefix (`feature/`, `fix/`, or `chore/`) when branching.
+- Feature/fix/chore PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
 - `main` must never get ahead of `dev`. If it does, something went wrong.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → d
 - Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix>branch-name`). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,12 +75,12 @@ These are grounded in actual git history. Violations have caused real rework.
 
 ### Branch Workflow
 ```
-work branches (feature/, fix/, chore/, docs/, refactor/, etc.) → dev → main
+work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → dev → main
 ```
-- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `ci/`, `test/`, etc.) when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,10 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → dev → main
 ```
-- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix from the workflow diagram above when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix>/branch-name`). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ These are grounded in actual git history. Violations have caused real rework.
    output confirms correct behavior — not just that the workflow ran.
    *(Commit: b9f1ff0)*
 
-10. **Never open a feature, fix, or chore PR against `main` — always target `dev`.**
+10. **Never open a PR against `main` from a work branch — always target `dev`.**
     The only PR that should ever target `main` is the dev→main promotion PR.
-    All other work flows: `feature/*`, `fix/*`, or `chore/*` → PR → `dev` → PR → `main`.
+    All other work flows: any work branch → PR → `dev` → PR → `main`.
     When using `gh pr create`, always pass `--base dev` explicitly; the default
     is the repo's default branch (`main`), which will bypass the dev gate and
     cause `main` to diverge ahead of `dev`, requiring rebase or merge judo to fix.
@@ -75,10 +75,10 @@ These are grounded in actual git history. Violations have caused real rework.
 
 ### Branch Workflow
 ```
-feature/*, fix/*, or chore/* → dev → main
+work branches (feature/, fix/, chore/, docs/, refactor/, etc.) → dev → main
 ```
-- All work branches from `dev`. Use the appropriate prefix (`feature/`, `fix/`, or `chore/`) when branching.
-- Feature/fix/chore PR: `gh pr create --base dev`
+- All work branches from `dev`. Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
+- Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
 - `main` must never get ahead of `dev`. If it does, something went wrong.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ These are grounded in actual git history. Violations have caused real rework.
 
 ### Branch Workflow
 ```
-main ← dev ← feature/*, fix/*, or chore/*
+feature/*, fix/*, or chore/* → dev → main
 ```
 - All work branches from `dev`. Use the appropriate prefix (`feature/`, `fix/`, or `chore/`) when branching.
 - Feature/fix/chore PR: `gh pr create --base dev`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → dev → main
 ```
-- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix>branch-name`). Use the appropriate prefix from the workflow diagram above when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix><branch-name>`). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
 - `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → dev → main
 ```
-- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix>/branch-name`). Use the appropriate prefix from the workflow diagram above when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix>branch-name`). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
 - `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,10 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, etc.) → dev → main
 ```
-- All work branches from `dev` (always `git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, etc.) when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git merge main`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → d
 - Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first, then `git checkout -b <prefix><branch-name>`). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin dev && git pull origin main && git push origin dev` (resolve any conflicts before pushing). If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev && git push origin <branch> --force-with-lease`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,10 @@ These are grounded in actual git history. Violations have caused real rework.
 ```
 work branches (feature/, fix/, chore/, docs/, refactor/, ci/, test/, etc.) → dev → main
 ```
-- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix (`feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `ci/`, `test/`, etc.) when branching.
+- Create all work branches from `dev` (always `git checkout dev && git pull origin dev` first). Use the appropriate prefix from the workflow diagram above when branching.
 - Work branch PR: `gh pr create --base dev`
 - Promotion PR (only): `gh pr create --base main --head dev`
-- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`.
+- `main` must never get ahead of `dev`. If it does, sync immediately: `git checkout dev && git pull origin main && git push origin dev`. If you are currently on a work branch, rebase it afterward: `git checkout <branch> && git rebase dev`.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,26 @@ These are grounded in actual git history. Violations have caused real rework.
    output confirms correct behavior — not just that the workflow ran.
    *(Commit: b9f1ff0)*
 
+10. **Never open a feature or fix PR against `main` — always target `dev`.**
+    The only PR that should ever target `main` is the dev→main promotion PR.
+    All other work flows: `feature/* or fix/*` → PR → `dev` → PR → `main`.
+    When using `gh pr create`, always pass `--base dev` explicitly; the default
+    is the repo's default branch (`main`), which will bypass the dev gate and
+    cause `main` to diverge ahead of `dev`, requiring rebase or merge judo to fix.
+    *(Cause of PR #19 conflict, 2026-05-08)*
+
 ---
 
 ## ALWAYS DO (Required Behaviors)
+
+### Branch Workflow
+```
+main ← dev ← feature/* or fix/*
+```
+- All work branches from `dev`. Always `git checkout -b feature/name` from `dev`.
+- Feature/fix PR: `gh pr create --base dev`
+- Promotion PR (only): `gh pr create --base main --head dev`
+- `main` must never get ahead of `dev`. If it does, something went wrong.
 
 ### Before Writing Code
 - Agree on the approach with the user before implementation. Produce a brief


### PR DESCRIPTION
## Summary

- Adds hard rule #10: never open feature/fix PRs against `main` — always `--base dev`
- Adds Branch Workflow section to ALWAYS DO with the explicit `feature/* → dev → main` model and `gh pr create` reminders

## Why

PR #19 had a conflict because a PR was opened against `main` instead of `dev`, causing main to diverge ahead of dev. This required a rebase to fix. The rule captures both the what and the why so it doesn't happen again.

## Test plan

- [ ] AGENTS.md renders correctly on GitHub
- [ ] Gemini review complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)