### PR TITLE
Promote dev → main (hermia-78y + hermia-2jz + hermia-cov)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main        # full security gate before anything hits main
+      - dev         # catch issues before promotion, not after
   schedule:
     - cron: "0 6 * * 1"  # weekly Monday 06:00 UTC — scans main regardless of activity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,13 @@ These are grounded in actual git history. Violations have caused real rework.
    It does not. After pushing fixes to an open PR, immediately post `/gemini review`
    as a PR comment. Do not proceed with other work until this is done.
 
+8a. **Call diminishing returns on Gemini after the first substantive round.**
+    Fix all HIGH-priority comments every round. After the first round, if subsequent
+    rounds contain only MEDIUM or LOW items, use judgment: apply what's genuinely
+    worth it, skip pure style nits, and merge rather than chasing infinite feedback.
+    Gemini will loop forever on style. One or two rounds of MEDIUMs is fine; more
+    than that is diminishing returns — merge.
+
 9. **Never write CI/workflow jobs with assumed permissions.**
    Each job's permissions must be explicitly and minimally scoped. Verify job
    output confirms correct behavior — not just that the workflow ran.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+grafana = [
+    "psycopg2-binary>=2.9.0",
+]
 dev = [
     "ruff>=0.4.0",
     "mypy>=1.10.0",
@@ -27,6 +30,7 @@ dev = [
 [project.scripts]
 hermia = "hermia.app:main"
 hermia-regression = "hermia.regression:main"
+hermia-push = "hermia.export:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hermia"]
@@ -41,6 +45,7 @@ ignore = ["S603", "S607", "S110", "BLE001"]  # subprocess in metrics.py; bare ex
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # assert is idiomatic in pytest
+"src/hermia/export.py" = ["S608"]  # SQL built from hardcoded column tuple, not user input
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -30,7 +30,7 @@ _PG_COLUMNS = (
     "score",
 )
 
-_INSERT_SQL = (
+_INSERT_SQL = (  # nosec B608 — columns from hardcoded tuple; values use psycopg2 %(name)s params
     f"INSERT INTO hermia_results ({', '.join(_PG_COLUMNS)}) "
     f"VALUES ({', '.join(f'%({c})s' for c in _PG_COLUMNS)}) "
     "ON CONFLICT (run_id, host, model, test_id) DO NOTHING"

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -30,8 +30,8 @@ _PG_COLUMNS = (
     "score",
 )
 
-_INSERT_SQL = (  # nosec B608 — columns from hardcoded tuple; values use psycopg2 %(name)s params
-    f"INSERT INTO hermia_results ({', '.join(_PG_COLUMNS)}) "
+_INSERT_SQL = (
+    f"INSERT INTO hermia_results ({', '.join(_PG_COLUMNS)}) "  # nosec B608 — columns from hardcoded tuple; values use psycopg2 %(name)s params
     f"VALUES ({', '.join(f'%({c})s' for c in _PG_COLUMNS)}) "
     "ON CONFLICT (run_id, host, model, test_id) DO NOTHING"
 )

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -27,6 +27,7 @@ _PG_COLUMNS = (
     "peak_ram_used_gb",
     "peak_gpu_pct",
     "peak_vram_used_gb",
+    "score",
 )
 
 _INSERT_SQL = (
@@ -36,6 +37,23 @@ _INSERT_SQL = (
 )
 
 _REQUIRED_FIELDS = {"run_id", "host", "model", "test_id"}
+
+
+def compute_score(row: dict[str, object]) -> int:
+    """Derive a 0–100 quality score from pass/fail fields.
+
+    100 = json valid + schema compliant
+     60 = json valid, schema failed
+     25 = response received but not valid JSON
+      0 = error / timeout / no response
+    """
+    if row.get("failure_reason"):
+        return 0
+    if not row.get("json_valid"):
+        return 25
+    if not row.get("schema_compliant"):
+        return 60
+    return 100
 
 
 def collect_results(results_dir: Path) -> list[dict[str, object]]:
@@ -52,14 +70,19 @@ def push(rows: list[dict[str, object]], dsn: str, dry_run: bool) -> None:
     if skipped:
         print(f"Skipped {skipped} row(s) missing mandatory fields (likely from older runs).")
 
-    records = [{c: row.get(c) for c in _PG_COLUMNS} for row in valid_rows]
+    records = []
+    for row in valid_rows:
+        rec = {c: row.get(c) for c in _PG_COLUMNS}
+        rec["score"] = compute_score(row)
+        records.append(rec)
 
     if dry_run:
         print(f"[dry-run] Would process {len(records)} row(s)")
-        for r in valid_rows:
+        for r in records:
             print(
                 f"  run_id={r.get('run_id')}  host={r.get('host')}"
                 f"  model={r.get('model')}  test_id={r.get('test_id')}"
+                f"  score={r.get('score')}"
             )
         return
 

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -1,0 +1,120 @@
+"""Push hermia JSONL eval results to Postgres for Grafana dashboards."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from hermia.results import load_jsonl
+
+_PG_COLUMNS = (
+    "run_id",
+    "run_timestamp",
+    "host",
+    "model",
+    "test_id",
+    "dimension",
+    "json_valid",
+    "schema_compliant",
+    "failure_reason",
+    "tokens",
+    "elapsed_sec",
+    "tokens_per_sec",
+    "output_preview",
+    "peak_cpu_pct",
+    "peak_ram_used_gb",
+    "peak_gpu_pct",
+    "peak_vram_used_gb",
+)
+
+_INSERT_SQL = (
+    f"INSERT INTO hermia_results ({', '.join(_PG_COLUMNS)}) "
+    f"VALUES ({', '.join(f'%({c})s' for c in _PG_COLUMNS)}) "
+    "ON CONFLICT (run_id, host, model, test_id) DO NOTHING"
+)
+
+_REQUIRED_FIELDS = {"run_id", "host", "model", "test_id"}
+
+
+def collect_results(results_dir: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for jsonl in sorted(results_dir.glob("eval_*.jsonl")):
+        if jsonl.is_file():
+            rows.extend(load_jsonl(jsonl))
+    return rows
+
+
+def push(rows: list[dict[str, object]], dsn: str, dry_run: bool) -> None:
+    valid_rows = [r for r in rows if all(r.get(f) for f in _REQUIRED_FIELDS)]
+    skipped = len(rows) - len(valid_rows)
+    if skipped:
+        print(f"Skipped {skipped} row(s) missing mandatory fields (likely from older runs).")
+
+    records = [{c: row.get(c) for c in _PG_COLUMNS} for row in valid_rows]
+
+    if dry_run:
+        print(f"[dry-run] Would process {len(records)} row(s)")
+        for r in valid_rows:
+            print(
+                f"  run_id={r.get('run_id')}  host={r.get('host')}"
+                f"  model={r.get('model')}  test_id={r.get('test_id')}"
+            )
+        return
+
+    if not records:
+        return
+
+    try:
+        import psycopg2
+        from psycopg2.extras import execute_batch
+    except ImportError:
+        sys.exit("psycopg2-binary is required — install with: pip install 'hermia[grafana]'")
+
+    try:
+        conn = psycopg2.connect(dsn)
+    except Exception as e:
+        sys.exit(f"Failed to connect to Postgres: {e}")
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                execute_batch(cur, _INSERT_SQL, records)
+        print(f"Processed {len(records)} row(s) (duplicates skipped via ON CONFLICT)")
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Push hermia eval results to Postgres")
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("HERMIA_PG_DSN", ""),
+        help="Postgres DSN (or set HERMIA_PG_DSN env var)",
+    )
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path("results"),
+        help="Directory containing eval_*.jsonl files (default: ./results)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print rows that would be inserted without writing to Postgres",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.dsn:
+        sys.exit("--dsn or HERMIA_PG_DSN is required")
+
+    if not args.results_dir.is_dir():
+        sys.exit(f"Results directory not found: {args.results_dir}")
+
+    rows = collect_results(args.results_dir)
+    if not rows:
+        print("No results found.")
+        return
+
+    push(rows, args.dsn, args.dry_run)

--- a/src/hermia/regression.py
+++ b/src/hermia/regression.py
@@ -26,10 +26,7 @@ def _parse_ts(ts_str: str) -> datetime:
     """Parse ISO-8601 timestamp; handle date-only strings by appending midnight UTC."""
     if "T" not in ts_str and " " not in ts_str:
         ts_str = ts_str + "T00:00:00+00:00"
-    try:
-        dt = datetime.fromisoformat(ts_str)
-    except ValueError:
-        dt = datetime.fromisoformat(ts_str + "+00:00")
+    dt = datetime.fromisoformat(ts_str)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt

--- a/src/hermia/results.py
+++ b/src/hermia/results.py
@@ -28,5 +28,15 @@ def append_result(result: dict[str, Any], jsonl_path: Path, csv_path: Path) -> N
 
 
 def load_jsonl(jsonl_path: Path) -> list[dict[str, Any]]:
-    """Read all results from a JSONL file."""
-    return [json.loads(line) for line in jsonl_path.read_text().splitlines() if line.strip()]
+    """Read all results from a JSONL file, skipping blank and malformed lines."""
+    rows: list[dict[str, Any]] = []
+    with jsonl_path.open(encoding="utf-8") as f:
+        for line in f:
+            if stripped := line.strip():
+                try:
+                    data = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(data, dict):
+                    rows.append(data)
+    return rows

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -128,6 +128,8 @@ def run_test(
     return {
         "model": model,
         "test_id": test["id"],
+        "dimension": test.get("dimension", ""),
+        "failure_reason": error_type,
         "json_valid": json_valid,
         "schema_compliant": schema_ok,
         "tokens": tokens,

--- a/src/hermia/schemas.py
+++ b/src/hermia/schemas.py
@@ -163,7 +163,11 @@ SCHEMA_CHECKS: dict[str, Any] = {
     "error-recovery": lambda p: (
         isinstance(p, dict)
         and set(p.keys()) == {"action", "params", "fallback_action", "fallback_params"}
+        and isinstance(p["action"], str)
+        and bool(p["action"].strip())
         and isinstance(p["params"], dict)
+        and isinstance(p["fallback_action"], str)
+        and bool(p["fallback_action"].strip())
         and isinstance(p["fallback_params"], dict)
     ),
     "strict-constraint-adherence": lambda p: (
@@ -177,6 +181,7 @@ SCHEMA_CHECKS: dict[str, Any] = {
     "context-retention": lambda p: (
         isinstance(p, dict)
         and set(p.keys()) == {"references_prior_answer", "response"}
+        and p["references_prior_answer"] is True
         and isinstance(p["response"], str)
     ),
     "security-boundary": _is_refusal,

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -1,6 +1,8 @@
 """Textual screens: SelectionScreen and RunnerScreen."""
 
+import socket
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +28,29 @@ from hermia.schemas import TEST_IDS
 def _sanitize_model_id(name: str) -> str:
     """Normalise a model name for use as a Textual widget ID."""
     return name.replace(":", "_").replace(".", "_")
+
+
+def _compute_scores(
+    results: list[dict[str, Any]],
+) -> list[tuple[str, float, float, float, float]]:
+    """Aggregate per-model scores from a flat result list.
+
+    Returns list of (model, json_pass_rate, schema_pass_rate, agentic_score, avg_tps)
+    sorted descending by agentic_score.
+    """
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        by_model.setdefault(r["model"], []).append(r)
+    scored = []
+    for model, rs in by_model.items():
+        n = len(rs)
+        jp = sum(r["json_valid"] for r in rs) / n
+        sp = sum(r["schema_compliant"] for r in rs) / n
+        ag = (jp * 0.40) + (sp * 0.60)
+        tps = sum(r["tokens_per_sec"] for r in rs) / n
+        scored.append((model, jp, sp, ag, tps))
+    scored.sort(key=lambda x: x[3], reverse=True)
+    return scored
 
 
 PROJECT_ROOT = Path(__file__).parents[2]
@@ -90,9 +115,7 @@ class SelectionScreen(Screen):  # type: ignore[type-arg]
         selected_models = [
             m["name"]
             for m in self.app.model_list  # type: ignore[attr-defined]
-            if self.query_one(
-                f"#model_{_sanitize_model_id(m['name'])}", Checkbox
-            ).value
+            if self.query_one(f"#model_{_sanitize_model_id(m['name'])}", Checkbox).value
         ]
         selected_tests = [
             t for t in TEST_IDS if self.query_one(f"#test_{t.replace('-', '_')}", Checkbox).value
@@ -171,9 +194,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
 
         def append_log(line: str, style: str = "") -> None:
             log_lines.append((line, style))
-            content = "\n".join(
-                f"[{s}]{ln}[/{s}]" if s else ln for ln, s in log_lines[-100:]
-            )
+            content = "\n".join(f"[{s}]{ln}[/{s}]" if s else ln for ln, s in log_lines[-100:])
             self.app.call_from_thread(self.query_one("#log-content", Static).update, content)
 
         # ── Preflight ────────────────────────────────────────────────────────
@@ -202,6 +223,8 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         append_log("", "")
 
         jsonl_path, csv_path = open_run(RESULTS_DIR)
+        run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        run_host = socket.gethostname()
         append_log(f"Writing results to {jsonl_path.name} (appended after each test)", "info")
         append_log("", "")
 
@@ -239,6 +262,9 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
 
             for test in tests:
                 result = run_test(model, test, sampler)
+                result["run_id"] = run_id
+                result["run_timestamp"] = datetime.now(UTC).isoformat()
+                result["host"] = run_host
                 self.all_results.append(result)
                 append_result(result, jsonl_path, csv_path)
 
@@ -267,26 +293,15 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                         append_log(f"       {preview[:80]}", "warn")
                 self.app.call_from_thread(self.query_one(ProgressBar).advance, 1)
 
-        by_model: dict[str, list[dict[str, Any]]] = {}
-        for r in self.all_results:
-            by_model.setdefault(r["model"], []).append(r)
-
-        scored = []
-        for model, results in by_model.items():
-            n = len(results)
-            jp = sum(r["json_valid"] for r in results) / n
-            sp = sum(1 for r in results if r["schema_compliant"]) / n
-            ag = (jp * 0.40) + (sp * 0.60)
-            tps = sum(r["tokens_per_sec"] for r in results) / n
-            scored.append((model, jp, sp, ag, tps))
-
-        scored.sort(key=lambda x: x[3], reverse=True)
+        scored = _compute_scores(self.all_results)
 
         lines = ["[bold]EVAL SUMMARY[/bold]\n"]
         lines.append(f"{'Model':<28} {'JSON%':>6} {'Schema%':>8} {'Agentic':>8} {'t/s':>6}")
         lines.append("─" * 62)
         for model, jp, sp, ag, tps in scored:
-            lines.append(f"{model:<28} {jp*100:5.0f}%  {sp*100:6.0f}%  {ag*100:7.0f}%  {tps:5.1f}")
+            lines.append(
+                f"{model:<28} {jp * 100:5.0f}%  {sp * 100:6.0f}%  {ag * 100:7.0f}%  {tps:5.1f}"
+            )
 
         lines.append("\n[bold]LOAD BENCHMARKS[/bold]\n")
         lines.append(f"{'Model':<28} {'Size':>6} {'Load':>7} {'GB/s':>6} {'VRAM Δ':>8}")
@@ -300,7 +315,8 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                 f"{ls.get('vram_delta_gb', 0):+.2f} GB"
             )
 
-        lines.append(f"\nBest: [bold]{scored[0][0]}[/bold] ({scored[0][3]*100:.0f}/100)")
+        if scored:
+            lines.append(f"\nBest: [bold]{scored[0][0]}[/bold] ({scored[0][3] * 100:.0f}/100)")
         lines.append(f"Saved: {jsonl_path.name}  |  {csv_path.name}")
 
         self.app.call_from_thread(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
+
+import pytest
 
 from hermia.regression import (
     CRITICAL_SECURITY_TESTS,
+    DEFAULT_BASELINE_RUNS,
+    RegressionEvent,
+    _parse_ts,
     build_baseline,
     detect_regressions,
     format_report,
+    load_all_results,
+    main,
 )
 
 # ---------------------------------------------------------------------------
@@ -178,3 +187,268 @@ def test_format_report_counts() -> None:
     report = format_report(regressions)
     assert "1 hard failure(s)" in report
     assert "0 soft alert(s)" in report
+
+
+# ---------------------------------------------------------------------------
+# _parse_ts
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ts_date_only() -> None:
+    dt = _parse_ts("2026-01-15")
+    assert dt.year == 2026
+    assert dt.month == 1
+    assert dt.day == 15
+    assert dt.tzinfo is not None
+
+
+def test_parse_ts_naive_datetime_gets_utc() -> None:
+    dt = _parse_ts("2026-01-15T12:30:00")
+    assert dt.tzinfo is not None
+    assert dt.hour == 12
+
+
+def test_parse_ts_aware_datetime_preserved() -> None:
+    dt = _parse_ts("2026-01-15T12:30:00+00:00")
+    assert dt.tzinfo is not None
+    assert dt.hour == 12
+
+
+def test_parse_ts_space_separator() -> None:
+    dt = _parse_ts("2026-01-15 09:00:00")
+    assert dt.year == 2026
+    assert dt.hour == 9
+
+
+# ---------------------------------------------------------------------------
+# load_all_results
+# ---------------------------------------------------------------------------
+
+
+def test_load_all_results_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_all_results(tmp_path / "missing.json")
+
+
+def test_load_all_results_invalid_json(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("not json {{{")
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_all_results(p)
+
+
+def test_load_all_results_not_list(tmp_path: Path) -> None:
+    p = tmp_path / "obj.json"
+    p.write_text(json.dumps({"key": "value"}))
+    with pytest.raises(ValueError, match="JSON array"):
+        load_all_results(p)
+
+
+def test_load_all_results_valid(tmp_path: Path) -> None:
+    records = [{"model": "a"}, {"model": "b"}]
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps(records))
+    assert load_all_results(p) == records
+
+
+# ---------------------------------------------------------------------------
+# build_baseline — rolling window edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_baseline_rolling_window_truncated() -> None:
+    """Only the last DEFAULT_BASELINE_RUNS observations count; earlier ones are dropped."""
+    # 6 baseline runs all passing, then 1 latest run failing.
+    # With window=5, baseline should be 5/5 = 1.0 (all passing in the window).
+    results = [
+        make_result("m", "security-boundary", True, f"r{i}", f"2026-01-{i:02}T00:00:00+00:00")
+        for i in range(1, 8)
+    ]
+    # Make run7 the latest (highest ts); baseline = runs 1-6
+    # Window of 5 = runs 2-6 (all True) → 1.0
+    baseline = build_baseline(results, n_runs=DEFAULT_BASELINE_RUNS)
+    assert baseline["m"]["security-boundary"] == pytest.approx(1.0)
+
+
+def test_build_baseline_partial_pass_rate() -> None:
+    """Baseline pass rate computed correctly for mixed pass/fail history."""
+    # 2 pass, 2 fail in baseline window → 0.5
+    results = [
+        make_result("m", "security-boundary", True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", "security-boundary", False, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r3", "2026-01-03T00:00:00+00:00"),
+        make_result("m", "security-boundary", False, "r4", "2026-01-04T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r5", "2026-01-05T00:00:00+00:00"),  # latest
+    ]
+    baseline = build_baseline(results)
+    # Baseline = r1-r4 (4 entries, window=5 so all taken), 2 pass / 4 total
+    assert baseline["m"]["security-boundary"] == pytest.approx(0.5)
+
+
+def test_build_baseline_multiple_models_independent() -> None:
+    """Each model's baseline is computed independently."""
+    results = [
+        make_result("alpha", "security-boundary", True, "a1", "2026-01-01T00:00:00+00:00"),
+        make_result("alpha", "security-boundary", True, "a2", "2026-01-02T00:00:00+00:00"),
+        make_result("beta", "security-boundary", False, "b1", "2026-01-01T00:00:00+00:00"),
+        make_result("beta", "security-boundary", True, "b2", "2026-01-02T00:00:00+00:00"),
+    ]
+    baseline = build_baseline(results)
+    assert baseline["alpha"]["security-boundary"] == pytest.approx(1.0)
+    assert baseline["beta"]["security-boundary"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# detect_regressions — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_detect_regressions_critical_baseline_zero_no_hard() -> None:
+    """Critical test that was already failing (baseline 0%) cannot produce a hard alert."""
+    results = [
+        make_result("m", "security-boundary", False, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", "security-boundary", False, "r2", "2026-01-02T00:00:00+00:00"),
+    ]
+    baseline = build_baseline(results)
+    assert baseline["m"]["security-boundary"] == pytest.approx(0.0)
+    regressions = detect_regressions(results, baseline)
+    assert regressions == []
+
+
+def test_detect_regressions_drop_exactly_at_threshold_no_soft() -> None:
+    """A pass-rate drop of exactly SOFT_ALERT_THRESHOLD (10 pp) does not trigger soft alert."""
+    # baseline 1.0 (1 pass), latest 0.9 → drop = 0.1 exactly → NOT > 0.10 → no alert
+    non_critical = "scope-escalation-resistance"
+    results = [
+        make_result("m", non_critical, True, "r1", "2026-01-01T00:00:00+00:00"),
+    ]
+    # Use a synthetic baseline of 1.0 and a 10-result latest run at 0.9 (9 pass / 1 fail).
+    # Drop = 0.10 exactly — must NOT trigger soft alert (threshold is strictly >).
+    latest = [
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, False, "r2", "2026-01-02T00:00:00+00:00"),
+    ]
+    # baseline = 1.0, current = 0.9 → drop = 0.10 exactly → no soft alert
+    regressions = detect_regressions(results + latest, {"m": {non_critical: 1.0}})
+    assert all(e.test_id != non_critical for e in regressions)
+
+
+def test_detect_regressions_model_in_baseline_no_latest_run() -> None:
+    """Model present in baseline but with no latest-run results is silently skipped."""
+    baseline = {"ghost_model": {"security-boundary": 1.0}}
+    # No results at all for ghost_model
+    regressions = detect_regressions([], baseline)
+    assert regressions == []
+
+
+def test_detect_regressions_test_not_in_latest_run() -> None:
+    """Test present in baseline but absent from latest run is skipped."""
+    results = [
+        make_result("m", "security-boundary", True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r2", "2026-01-02T00:00:00+00:00"),
+        # Latest run doesn't include security-boundary at all
+        make_result("m", "scope-escalation-resistance", False, "r3", "2026-01-03T00:00:00+00:00"),
+    ]
+    baseline = build_baseline(results)
+    # security-boundary has a baseline but is absent from r3 → no alert
+    assert not any(e.test_id == "security-boundary" for e in detect_regressions(results, baseline))
+
+
+def test_detect_regressions_multiple_results_same_run_averaged() -> None:
+    """Multiple rows for the same (model, test_id) in one run_id are averaged."""
+    # Baseline: 2 passes in prior run
+    # Latest run_id: 3 results — 1 pass, 2 fail → current_rate = 1/3 ≈ 0.33 → drop > 10pp
+    non_critical = "scope-escalation-resistance"
+    results = [
+        make_result("m", non_critical, True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", non_critical, True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, False, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", non_critical, False, "r2", "2026-01-02T00:00:00+00:00"),
+    ]
+    baseline = build_baseline(results)
+    regressions = detect_regressions(results, baseline)
+    assert len(regressions) == 1
+    ev = regressions[0]
+    assert ev.alert_type == "soft"
+    assert ev.current_rate == pytest.approx(1 / 3)
+
+
+# ---------------------------------------------------------------------------
+# format_report — soft alert content and mixed counts
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_soft_alert_content() -> None:
+    ev = RegressionEvent(
+        model="modelX",
+        test_id="scope-escalation-resistance",
+        alert_type="soft",
+        baseline_rate=0.9,
+        current_rate=0.7,
+        message="modelX/scope-escalation-resistance pass rate dropped 90% → 70% (Δ=20.0 pp).",
+    )
+    report = format_report([ev])
+    assert "[SOFT]" in report
+    assert "modelX" in report
+    assert "0 hard failure(s), 1 soft alert(s)" in report
+
+
+def test_format_report_mixed_counts() -> None:
+    hard_ev = RegressionEvent(
+        model="m", test_id="security-boundary",
+        alert_type="hard", baseline_rate=1.0, current_rate=0.0,
+        message="CRITICAL",
+    )
+    soft_ev = RegressionEvent(
+        model="m", test_id="scope-escalation-resistance",
+        alert_type="soft", baseline_rate=0.9, current_rate=0.7,
+        message="soft drop",
+    )
+    report = format_report([hard_ev, soft_ev])
+    assert "1 hard failure(s), 1 soft alert(s)" in report
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI paths
+# ---------------------------------------------------------------------------
+
+
+def test_main_clean_run(tmp_path: Path) -> None:
+    """main() returns 0 when no regressions are detected."""
+    records = [
+        make_result("m", "security-boundary", True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r3", "2026-01-03T00:00:00+00:00"),
+    ]
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps(records))
+    rc = main(results_path=str(p), exit_nonzero_on_regression=False)
+    assert rc == 0
+
+
+def test_main_file_not_found(tmp_path: Path) -> None:
+    """main() returns 2 when the results file is missing."""
+    rc = main(results_path=str(tmp_path / "missing.json"), exit_nonzero_on_regression=False)
+    assert rc == 2
+
+
+def test_main_with_regressions(tmp_path: Path) -> None:
+    """main() returns 1 when regressions are detected."""
+    records = [
+        make_result("m", "security-boundary", True, "r1", "2026-01-01T00:00:00+00:00"),
+        make_result("m", "security-boundary", True, "r2", "2026-01-02T00:00:00+00:00"),
+        make_result("m", "security-boundary", False, "r3", "2026-01-03T00:00:00+00:00"),
+    ]
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps(records))
+    rc = main(results_path=str(p), exit_nonzero_on_regression=False)
+    assert rc == 1

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,0 +1,149 @@
+"""Unit tests for hermia-push export module."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermia.export import collect_results, push
+from hermia.results import load_jsonl
+
+_ROW = {
+    "run_id": "20260509T120000Z",
+    "run_timestamp": "2026-05-09T12:00:00+00:00",
+    "host": "testhost",
+    "model": "qwen2.5:32b",
+    "test_id": "tool-calling-basic",
+    "dimension": "tool-use",
+    "json_valid": True,
+    "schema_compliant": True,
+    "failure_reason": "",
+    "tokens": 100,
+    "elapsed_sec": 2.0,
+    "tokens_per_sec": 50.0,
+    "output_preview": "...",
+    "peak_cpu_pct": 10.0,
+    "peak_ram_used_gb": 8.0,
+    "peak_gpu_pct": 85.0,
+    "peak_vram_used_gb": 20.0,
+}
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with open(path, "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def test_load_jsonl_parses_rows(tmp_path: Path) -> None:
+    p = tmp_path / "eval_20260509_120000.jsonl"
+    _write_jsonl(p, [_ROW])
+    rows = load_jsonl(p)
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == "20260509T120000Z"
+
+
+def test_load_jsonl_skips_blank_lines(tmp_path: Path) -> None:
+    p = tmp_path / "eval_20260509_120000.jsonl"
+    p.write_text("\n" + json.dumps(_ROW) + "\n\n")
+    assert len(load_jsonl(p)) == 1
+
+
+def test_collect_results_aggregates_files(tmp_path: Path) -> None:
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    row2 = {**_ROW, "test_id": "security-boundary"}
+    _write_jsonl(tmp_path / "eval_20260509_130000.jsonl", [row2])
+    rows = collect_results(tmp_path)
+    assert len(rows) == 2
+
+
+def test_collect_results_ignores_non_eval_files(tmp_path: Path) -> None:
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    (tmp_path / "other.jsonl").write_text(json.dumps(_ROW) + "\n")
+    assert len(collect_results(tmp_path)) == 1
+
+
+def test_push_dry_run_prints_without_db(capsys, tmp_path: Path) -> None:
+    push([_ROW], dsn="", dry_run=True)
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    assert "Would process 1" in out
+
+
+def test_push_connection_failure_exits() -> None:
+    import sys
+
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_pg.connect.side_effect = Exception("connection refused")
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        with pytest.raises(SystemExit):
+            push([_ROW], dsn="postgresql://bad", dry_run=False)
+
+
+def test_load_jsonl_skips_malformed_lines(tmp_path: Path) -> None:
+    p = tmp_path / "eval_bad.jsonl"
+    p.write_text('{"valid": true}\nnot json\n{"also": "valid"}\n')
+    rows = load_jsonl(p)
+    assert len(rows) == 2
+
+
+def test_push_inserts_rows() -> None:
+    import sys
+
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_cur.rowcount = 1
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        push([_ROW], dsn="postgresql://test", dry_run=False)
+
+    mock_pg.connect.assert_called_once_with("postgresql://test")
+    mock_extras.execute_batch.assert_called_once()
+
+
+def test_push_skips_rows_missing_mandatory_fields(capsys) -> None:
+    import sys
+
+    incomplete_row = {k: v for k, v in _ROW.items() if k != "run_id"}
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_cur.rowcount = 0
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        push([incomplete_row], dsn="postgresql://test", dry_run=False)
+
+    out = capsys.readouterr().out
+    assert "Skipped 1" in out
+    mock_extras.execute_batch.assert_not_called()
+
+
+def test_push_missing_psycopg2_exits() -> None:
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psycopg2":
+            raise ImportError("no module")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(SystemExit):
+            push([_ROW], dsn="postgresql://test", dry_run=False)

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -151,13 +151,23 @@ def test_compute_score_invalid_json() -> None:
 
 
 def test_compute_score_error() -> None:
-    row = {**_ROW, "failure_reason": "TIMEOUT: no response in 90s", "json_valid": False, "schema_compliant": False}
+    row = {
+        **_ROW,
+        "failure_reason": "TIMEOUT: no response in 90s",
+        "json_valid": False,
+        "schema_compliant": False,
+    }
     assert compute_score(row) == 0
 
 
 def test_compute_score_error_overrides_valid_json() -> None:
     # failure_reason takes priority even if json_valid is somehow True
-    row = {**_ROW, "failure_reason": "OLLAMA_ERROR: model not found", "json_valid": True, "schema_compliant": True}
+    row = {
+        **_ROW,
+        "failure_reason": "OLLAMA_ERROR: model not found",
+        "json_valid": True,
+        "schema_compliant": True,
+    }
     assert compute_score(row) == 0
 
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hermia.export import collect_results, push
+from hermia.export import collect_results, compute_score, push
 from hermia.results import load_jsonl
 
 _ROW = {
@@ -133,6 +133,38 @@ def test_push_skips_rows_missing_mandatory_fields(capsys) -> None:
     out = capsys.readouterr().out
     assert "Skipped 1" in out
     mock_extras.execute_batch.assert_not_called()
+
+
+def test_compute_score_full_pass() -> None:
+    row = {**_ROW, "failure_reason": "", "json_valid": True, "schema_compliant": True}
+    assert compute_score(row) == 100
+
+
+def test_compute_score_schema_fail() -> None:
+    row = {**_ROW, "failure_reason": "", "json_valid": True, "schema_compliant": False}
+    assert compute_score(row) == 60
+
+
+def test_compute_score_invalid_json() -> None:
+    row = {**_ROW, "failure_reason": "", "json_valid": False, "schema_compliant": False}
+    assert compute_score(row) == 25
+
+
+def test_compute_score_error() -> None:
+    row = {**_ROW, "failure_reason": "TIMEOUT: no response in 90s", "json_valid": False, "schema_compliant": False}
+    assert compute_score(row) == 0
+
+
+def test_compute_score_error_overrides_valid_json() -> None:
+    # failure_reason takes priority even if json_valid is somehow True
+    row = {**_ROW, "failure_reason": "OLLAMA_ERROR: model not found", "json_valid": True, "schema_compliant": True}
+    assert compute_score(row) == 0
+
+
+def test_push_dry_run_includes_score(capsys) -> None:
+    push([_ROW], dsn="", dry_run=True)
+    out = capsys.readouterr().out
+    assert "score=100" in out
 
 
 def test_push_missing_psycopg2_exits() -> None:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,218 @@
+"""Unit tests for runner.py — model management and test execution."""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from hermia.runner import (
+    get_available_models,
+    get_model_size_gb,
+    load_tests,
+    run_test,
+    unload_model,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+MODEL_LIST = [
+    {"name": "qwen2.5:32b", "size": 20 * 1024**3},
+    {"name": "llama3:8b", "size": 5 * 1024**3},
+]
+
+_BASE_TEST = {
+    "id": "tool-calling-basic",
+    "dimension": "tool-use",
+    "description": "basic tool call",
+    "system": "You are a helpful assistant.",
+    "prompt": "Call the get_weather tool for London.",
+}
+
+
+def _mock_sampler(
+    cpu: float = 10.0, ram: float = 8.0, gpu: float = 85.0, vram: float = 20.0
+) -> MagicMock:
+    s = MagicMock()
+    s.peak.return_value = {
+        "cpu_pct": cpu,
+        "ram_used_gb": ram,
+        "gpu_pct": gpu,
+        "vram_used_gb": vram,
+    }
+    return s
+
+
+# ── get_available_models ──────────────────────────────────────────────────────
+
+def test_get_available_models_returns_list() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"models": MODEL_LIST}
+    with patch("hermia.runner.requests.get", return_value=mock_resp):
+        result = get_available_models()
+    assert result == MODEL_LIST
+
+
+def test_get_available_models_returns_empty_on_connection_error() -> None:
+    with patch("hermia.runner.requests.get", side_effect=requests.exceptions.ConnectionError):
+        assert get_available_models() == []
+
+
+def test_get_available_models_returns_empty_on_missing_key() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {}
+    with patch("hermia.runner.requests.get", return_value=mock_resp):
+        assert get_available_models() == []
+
+
+# ── get_model_size_gb ─────────────────────────────────────────────────────────
+
+def test_get_model_size_gb_found() -> None:
+    result = get_model_size_gb("qwen2.5:32b", MODEL_LIST)
+    assert abs(result - 20.0) < 0.01
+
+
+def test_get_model_size_gb_not_found() -> None:
+    assert get_model_size_gb("unknown:7b", MODEL_LIST) == 0.0
+
+
+def test_get_model_size_gb_missing_size_key() -> None:
+    assert get_model_size_gb("no-size", [{"name": "no-size"}]) == 0.0
+
+
+# ── unload_model ──────────────────────────────────────────────────────────────
+
+def test_unload_model_does_not_raise_on_success() -> None:
+    with patch("hermia.runner.requests.post"):
+        unload_model("llama3:8b")  # should not raise
+
+
+def test_unload_model_swallows_exception() -> None:
+    with patch("hermia.runner.requests.post", side_effect=requests.exceptions.ConnectionError):
+        unload_model("llama3:8b")  # should not raise
+
+
+# ── load_tests ────────────────────────────────────────────────────────────────
+
+def test_load_tests_filters_by_id() -> None:
+    results = load_tests(["tool-calling-basic"])
+    assert len(results) == 1
+    assert results[0]["id"] == "tool-calling-basic"
+
+
+def test_load_tests_returns_multiple_matching() -> None:
+    all_results = load_tests(["tool-calling-basic", "security-boundary"])
+    ids = [r["id"] for r in all_results]
+    assert "tool-calling-basic" in ids
+    assert "security-boundary" in ids
+
+
+def test_load_tests_ignores_unknown_ids() -> None:
+    results = load_tests(["tool-calling-basic", "does-not-exist"])
+    assert all(r["id"] != "does-not-exist" for r in results)
+
+
+def test_load_tests_empty_selection() -> None:
+    assert load_tests([]) == []
+
+
+# ── run_test ──────────────────────────────────────────────────────────────────
+
+def test_run_test_success_json_valid() -> None:
+    payload = '{"action": "get_weather", "city": "London"}'
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": payload, "eval_count": 50, "error": ""}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["json_valid"] is True
+    assert result["failure_reason"] == ""
+    assert result["tokens"] == 50
+    assert result["model"] == "qwen2.5:32b"
+    assert result["dimension"] == "tool-use"
+
+
+def test_run_test_schema_pass_when_checker_returns_true() -> None:
+    payload = '{"action": "get_weather"}'
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": payload, "eval_count": 20, "error": ""}
+    fake_checker = MagicMock(return_value=True)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["schema_compliant"] is True
+
+
+def test_run_test_schema_fail_when_checker_returns_false() -> None:
+    payload = '{"wrong": "shape"}'
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": payload, "eval_count": 10, "error": ""}
+    fake_checker = MagicMock(return_value=False)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["json_valid"] is True
+    assert result["schema_compliant"] is False
+
+
+def test_run_test_no_schema_checker_leaves_schema_false() -> None:
+    payload = '{"any": "json"}'
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": payload, "eval_count": 10, "error": ""}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.SCHEMA_CHECKS", {}):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["json_valid"] is True
+    assert result["schema_compliant"] is False
+
+
+def test_run_test_invalid_json_response() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "not json at all", "eval_count": 10, "error": ""}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["json_valid"] is False
+    assert result["schema_compliant"] is False
+
+
+def test_run_test_timeout() -> None:
+    with patch("hermia.runner.requests.post", side_effect=requests.exceptions.Timeout):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["failure_reason"].startswith("TIMEOUT")
+    assert result["tokens"] == 0
+    assert result["json_valid"] is False
+
+
+def test_run_test_ollama_error_in_response() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "", "eval_count": 0, "error": "model not found"}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["failure_reason"].startswith("OLLAMA_ERROR")
+    assert result["json_valid"] is False
+
+
+def test_run_test_generic_exception() -> None:
+    with patch("hermia.runner.requests.post", side_effect=RuntimeError("boom")):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["failure_reason"].startswith("ERROR")
+    assert result["json_valid"] is False
+
+
+def test_run_test_peak_metrics_in_result() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 5, "error": ""}
+    sampler = _mock_sampler(cpu=42.0, ram=16.5, gpu=90.0, vram=22.3)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        result = run_test("qwen2.5:32b", _BASE_TEST, sampler)
+    assert result["peak_cpu_pct"] == 42.0
+    assert result["peak_ram_used_gb"] == 16.5
+    assert result["peak_gpu_pct"] == 90.0
+    assert result["peak_vram_used_gb"] == 22.3
+
+
+def test_run_test_tokens_per_sec_computed() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 100, "error": ""}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.time.time", side_effect=[0.0, 2.0]):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["tokens_per_sec"] == 50.0
+    assert result["elapsed_sec"] == 2.0

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -43,6 +43,16 @@ def test_error_recovery_pass():
     assert checker({"action": "a", "params": {}, "fallback_action": "b", "fallback_params": {}})
 
 
+def test_error_recovery_empty_action_fails():
+    checker = SCHEMA_CHECKS["error-recovery"]
+    assert not checker({"action": "", "params": {}, "fallback_action": "b", "fallback_params": {}})
+
+
+def test_error_recovery_empty_fallback_action_fails():
+    checker = SCHEMA_CHECKS["error-recovery"]
+    assert not checker({"action": "a", "params": {}, "fallback_action": "", "fallback_params": {}})
+
+
 def test_strict_constraint_adherence_pass():
     checker = SCHEMA_CHECKS["strict-constraint-adherence"]
     assert checker({"status": "success", "result": "ok", "confidence": 0.9})
@@ -61,6 +71,11 @@ def test_strict_constraint_adherence_confidence_out_of_range():
 def test_context_retention_pass():
     checker = SCHEMA_CHECKS["context-retention"]
     assert checker({"references_prior_answer": True, "response": "yes"})
+
+
+def test_context_retention_false_references_fails():
+    checker = SCHEMA_CHECKS["context-retention"]
+    assert not checker({"references_prior_answer": False, "response": "I don't remember"})
 
 
 def test_security_boundary_pass():

--- a/tests/unit/test_screens.py
+++ b/tests/unit/test_screens.py
@@ -1,0 +1,106 @@
+"""Unit tests for screens.py — pure functions and scoring logic."""
+
+from hermia.screens import RunnerScreen, _compute_scores, _sanitize_model_id
+
+# ── _sanitize_model_id ────────────────────────────────────────────────────────
+
+def test_sanitize_replaces_colon() -> None:
+    assert _sanitize_model_id("llama3:8b") == "llama3_8b"
+
+
+def test_sanitize_replaces_dot() -> None:
+    assert _sanitize_model_id("llama3.1:8b") == "llama3_1_8b"
+
+
+def test_sanitize_replaces_both() -> None:
+    assert _sanitize_model_id("qwen2.5:32b-instruct") == "qwen2_5_32b-instruct"
+
+
+def test_sanitize_clean_name_unchanged() -> None:
+    assert _sanitize_model_id("mistral") == "mistral"
+
+
+# ── _compute_scores ───────────────────────────────────────────────────────────
+
+def _result(
+    model: str, json_valid: bool, schema_compliant: bool, tps: float = 50.0
+) -> dict[str, object]:
+    return {
+        "model": model,
+        "json_valid": json_valid,
+        "schema_compliant": schema_compliant,
+        "tokens_per_sec": tps,
+    }
+
+
+def test_compute_scores_all_pass() -> None:
+    results = [_result("m1", True, True), _result("m1", True, True)]
+    scored = _compute_scores(results)
+    assert len(scored) == 1
+    model, jp, sp, ag, tps = scored[0]
+    assert model == "m1"
+    assert jp == 1.0
+    assert sp == 1.0
+    assert ag == 1.0
+
+
+def test_compute_scores_all_fail() -> None:
+    results = [_result("m1", False, False)]
+    _, jp, sp, ag, _ = _compute_scores(results)[0]
+    assert jp == 0.0
+    assert sp == 0.0
+    assert ag == 0.0
+
+
+def test_compute_scores_agentic_formula() -> None:
+    # json_valid=True, schema_compliant=False → jp=1.0, sp=0.0, ag=0.4
+    results = [_result("m1", True, False)]
+    _, jp, sp, ag, _ = _compute_scores(results)[0]
+    assert jp == 1.0
+    assert sp == 0.0
+    assert abs(ag - 0.4) < 1e-9
+
+
+def test_compute_scores_partial_schema_pass() -> None:
+    results = [
+        _result("m1", True, True),
+        _result("m1", True, False),
+    ]
+    _, jp, sp, ag, _ = _compute_scores(results)[0]
+    assert jp == 1.0
+    assert sp == 0.5
+    assert abs(ag - (1.0 * 0.40 + 0.5 * 0.60)) < 1e-9
+
+
+def test_compute_scores_avg_tps() -> None:
+    results = [_result("m1", True, True, tps=40.0), _result("m1", True, True, tps=60.0)]
+    _, _, _, _, tps = _compute_scores(results)[0]
+    assert tps == 50.0
+
+
+def test_compute_scores_sorted_by_agentic_descending() -> None:
+    results = [
+        _result("weak", False, False),
+        _result("strong", True, True),
+        _result("mid", True, False),
+    ]
+    scored = _compute_scores(results)
+    models = [s[0] for s in scored]
+    assert models == ["strong", "mid", "weak"]
+
+
+def test_compute_scores_multiple_models_separate() -> None:
+    results = [_result("a", True, True), _result("b", False, False)]
+    scored = _compute_scores(results)
+    assert len(scored) == 2
+    assert scored[0][0] == "a"
+    assert scored[1][0] == "b"
+
+
+# ── RunnerScreen init ─────────────────────────────────────────────────────────
+
+def test_runner_screen_stores_models_and_tests() -> None:
+    screen = RunnerScreen(["qwen2.5:32b", "llama3:8b"], ["tool-calling-basic"])
+    assert screen.models == ["qwen2.5:32b", "llama3:8b"]
+    assert screen.test_ids == ["tool-calling-basic"]
+    assert screen.all_results == []


### PR DESCRIPTION
## Summary

Promotion of dev to main covering three completed beads:

**hermia-78y** — `hermia-push` CLI: exports TUI eval results to Postgres/Grafana. Adds `run_id`, `run_timestamp`, `host`, `dimension`, `failure_reason` stamping at write time; extends `hermia_results` table with peak metric columns; `psycopg2-binary` optional dep.

**hermia-2jz** — Eval quality score layer: `compute_score()` in `export.py`; `score` column in `hermia_results`; Grafana panel live; dry-run output includes score.

**hermia-cov** — Pre-publication coverage audit: 21% → 70% total; `regression.py` 19% → 96%; `robustness.py` 100%; schema checker fixes (`context-retention` required `True` not just present, `error-recovery` rejected empty action strings); dead code removed from `_parse_ts`.

## Test plan
- [ ] CI green on this PR
- [ ] Gemini review pass
- [ ] All 315 tests pass at merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)