### PR TITLE
test(export): add main() CLI entrypoint tests — hermia-main-test

### DIFF
--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -109,35 +109,60 @@ def push(rows: list[dict[str, object]], dsn: str, dry_run: bool) -> None:
         conn.close()
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Push hermia eval results to Postgres")
-    parser.add_argument(
-        "--dsn",
-        default=os.environ.get("HERMIA_PG_DSN", ""),
-        help="Postgres DSN (or set HERMIA_PG_DSN env var)",
-    )
-    parser.add_argument(
-        "--results-dir",
-        type=Path,
-        default=Path("results"),
-        help="Directory containing eval_*.jsonl files (default: ./results)",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print rows that would be inserted without writing to Postgres",
-    )
-    args = parser.parse_args()
+def main(
+    dsn: str | None = None,
+    results_dir: Path | str | None = None,
+    dry_run: bool | None = None,
+) -> int:
+    """CLI entry point for hermia-push.
 
-    if not args.dry_run and not args.dsn:
+    Returns:
+        0 — success
+        1 — no results found
+        2 — argument/path error
+    """
+    # Resolve env var before argparse so tests can inject results_dir+dry_run
+    # and skip parse_args() entirely while still exercising env-var DSN logic.
+    if dsn is None:
+        dsn = os.environ.get("HERMIA_PG_DSN", "")
+
+    if results_dir is None or dry_run is None:
+        parser = argparse.ArgumentParser(description="Push hermia eval results to Postgres")
+        parser.add_argument(
+            "--dsn",
+            default=dsn,
+            help="Postgres DSN (or set HERMIA_PG_DSN env var)",
+        )
+        parser.add_argument(
+            "--results-dir",
+            type=Path,
+            default=Path("results"),
+            help="Directory containing eval_*.jsonl files (default: ./results)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print rows that would be inserted without writing to Postgres",
+        )
+        args = parser.parse_args()
+        dsn = args.dsn
+        if results_dir is None:
+            results_dir = args.results_dir
+        if dry_run is None:
+            dry_run = args.dry_run
+
+    results_dir = Path(results_dir)
+
+    if not dry_run and not dsn:
         sys.exit("--dsn or HERMIA_PG_DSN is required")
 
-    if not args.results_dir.is_dir():
-        sys.exit(f"Results directory not found: {args.results_dir}")
+    if not results_dir.is_dir():
+        sys.exit(f"Results directory not found: {results_dir}")
 
-    rows = collect_results(args.results_dir)
+    rows = collect_results(results_dir)
     if not rows:
         print("No results found.")
-        return
+        return 1
 
-    push(rows, args.dsn, args.dry_run)
+    push(rows, dsn, dry_run)
+    return 0

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -113,6 +113,7 @@ def main(
     dsn: str | None = None,
     results_dir: Path | str | None = None,
     dry_run: bool | None = None,
+    exit_on_error: bool = True,
 ) -> int:
     """CLI entry point for hermia-push.
 
@@ -154,10 +155,18 @@ def main(
     results_dir = Path(results_dir)
 
     if not dry_run and not dsn:
-        sys.exit("--dsn or HERMIA_PG_DSN is required")
+        msg = "--dsn or HERMIA_PG_DSN is required"
+        if exit_on_error:
+            sys.exit(msg)
+        print(msg, file=sys.stderr)
+        return 2
 
     if not results_dir.is_dir():
-        sys.exit(f"Results directory not found: {results_dir}")
+        msg = f"Results directory not found: {results_dir}"
+        if exit_on_error:
+            sys.exit(msg)
+        print(msg, file=sys.stderr)
+        return 2
 
     rows = collect_results(results_dir)
     if not rows:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -208,15 +208,18 @@ def test_main_dry_run_with_results(tmp_path: Path, capsys) -> None:
 
 
 def test_main_missing_results_dir(tmp_path: Path) -> None:
-    with pytest.raises(SystemExit):
-        main(dsn="postgresql://test", results_dir=tmp_path / "missing", dry_run=False)
+    rc = main(
+        dsn="postgresql://test",
+        results_dir=tmp_path / "missing",
+        dry_run=False,
+        exit_on_error=False,
+    )
+    assert rc == 2
 
 
-def test_main_missing_dsn_exits() -> None:
-    import tempfile
-    with tempfile.TemporaryDirectory() as d:
-        with pytest.raises(SystemExit):
-            main(dsn="", results_dir=Path(d), dry_run=False)
+def test_main_missing_dsn_exits(tmp_path: Path) -> None:
+    rc = main(dsn="", results_dir=tmp_path, dry_run=False, exit_on_error=False)
+    assert rc == 2
 
 
 def test_main_dsn_from_env(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -189,3 +189,54 @@ def test_push_missing_psycopg2_exits() -> None:
     with patch("builtins.__import__", side_effect=fake_import):
         with pytest.raises(SystemExit):
             push([_ROW], dsn="postgresql://test", dry_run=False)
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI paths
+# ---------------------------------------------------------------------------
+
+from hermia.export import main
+
+
+def test_main_dry_run_no_results(tmp_path: Path) -> None:
+    rc = main(dsn="", results_dir=tmp_path, dry_run=True)
+    assert rc == 1
+
+
+def test_main_dry_run_with_results(tmp_path: Path, capsys) -> None:
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    rc = main(dsn="", results_dir=tmp_path, dry_run=True)
+    assert rc == 0
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_main_missing_results_dir(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        main(dsn="postgresql://test", results_dir=tmp_path / "missing", dry_run=False)
+
+
+def test_main_missing_dsn_exits() -> None:
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(SystemExit):
+            main(dsn="", results_dir=Path(d), dry_run=False)
+
+
+def test_main_dsn_from_env(tmp_path: Path, monkeypatch) -> None:
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    monkeypatch.setenv("HERMIA_PG_DSN", "postgresql://envtest")
+    import sys
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        rc = main(results_dir=tmp_path, dry_run=False)
+    assert rc == 0
+    mock_pg.connect.assert_called_once_with("postgresql://envtest")

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hermia.export import collect_results, compute_score, push
+from hermia.export import collect_results, compute_score, main, push
 from hermia.results import load_jsonl
 
 _ROW = {
@@ -194,9 +194,6 @@ def test_push_missing_psycopg2_exits() -> None:
 # ---------------------------------------------------------------------------
 # main() — CLI paths
 # ---------------------------------------------------------------------------
-
-from hermia.export import main
-
 
 def test_main_dry_run_no_results(tmp_path: Path) -> None:
     rc = main(dsn="", results_dir=tmp_path, dry_run=True)


### PR DESCRIPTION
## Summary

- Refactors `export.main()` to accept injectable params (`dsn`, `results_dir`, `dry_run`) following the `regression.py` pattern — avoids `parse_args()` in tests
- Resolves env var (`HERMIA_PG_DSN`) before the argparse gate so `dsn=None` + env var set bypasses `parse_args()` cleanly
- Adds 5 `main()` tests: dry-run no results, dry-run with results, missing results dir, missing DSN, env-var DSN

## Test plan
- [ ] CI green
- [ ] Gemini review
- [ ] 320 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)