### PR TITLE
fix(export): align exit codes and honor exit_on_error — Gemini PR#28

### DIFF
--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -121,6 +121,7 @@ def main(
         0 — success
         1 — no results found
         2 — argument/path error
+        3 — push failure (missing psycopg2 or connection error)
     """
     # Resolve env var before argparse so tests can inject results_dir+dry_run
     # and skip parse_args() entirely while still exercising env-var DSN logic.
@@ -128,7 +129,10 @@ def main(
         dsn = os.environ.get("HERMIA_PG_DSN", "")
 
     if results_dir is None or dry_run is None:
-        parser = argparse.ArgumentParser(description="Push hermia eval results to Postgres")
+        parser = argparse.ArgumentParser(
+            description="Push hermia eval results to Postgres",
+            exit_on_error=exit_on_error,
+        )
         parser.add_argument(
             "--dsn",
             default=dsn,
@@ -156,16 +160,16 @@ def main(
 
     if not dry_run and not dsn:
         msg = "--dsn or HERMIA_PG_DSN is required"
-        if exit_on_error:
-            sys.exit(msg)
         print(msg, file=sys.stderr)
+        if exit_on_error:
+            sys.exit(2)
         return 2
 
     if not results_dir.is_dir():
         msg = f"Results directory not found: {results_dir}"
-        if exit_on_error:
-            sys.exit(msg)
         print(msg, file=sys.stderr)
+        if exit_on_error:
+            sys.exit(2)
         return 2
 
     rows = collect_results(results_dir)
@@ -173,5 +177,10 @@ def main(
         print("No results found.")
         return 1
 
-    push(rows, dsn, dry_run)
+    try:
+        push(rows, dsn, dry_run)
+    except SystemExit:
+        if exit_on_error:
+            raise
+        return 3
     return 0

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -222,6 +222,22 @@ def test_main_missing_dsn_exits(tmp_path: Path) -> None:
     assert rc == 2
 
 
+def test_main_push_failure_returns_3(tmp_path: Path) -> None:
+    """push() SystemExit must be caught and return 3 when exit_on_error=False."""
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psycopg2":
+            raise ImportError("no module")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        rc = main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=False)
+    assert rc == 3
+
+
 def test_main_dsn_from_env(tmp_path: Path, monkeypatch) -> None:
     _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
     monkeypatch.setenv("HERMIA_PG_DSN", "postgresql://envtest")


### PR DESCRIPTION
## Summary
Addresses all Gemini feedback from promotion PR #28:

- **Exit code alignment**: `sys.exit(msg)` was exiting with code 1 for argument/path errors; now prints to `sys.stderr` and exits with code 2, matching the documented API
- **argparse `exit_on_error`**: `ArgumentParser` now receives the flag so invalid CLI args don't bypass it (Python 3.9+)
- **`push()` bypass**: `push()` contains internal `sys.exit()` calls (missing psycopg2, connection failure) that ignored `exit_on_error`; now caught in `main()`, re-raised if `exit_on_error=True`, returns 3 otherwise — new documented return code added to docstring

## Test plan
- [ ] New test: `test_main_push_failure_returns_3` — psycopg2 import failure with `exit_on_error=False` returns 3
- [ ] 338 tests passing
- [ ] ruff + mypy clean
- [ ] CI + Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)