### PR TITLE
fix(export): dsn precedence, ArgumentError handling, consistent exit 3

### DIFF
--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -153,7 +153,7 @@ def main(
         try:
             args = parser.parse_args()
         except argparse.ArgumentError as e:
-            print(str(e), file=sys.stderr)
+            print(f"Argument error: {e}", file=sys.stderr)
             return 2
         if not dsn_explicit:
             dsn = args.dsn
@@ -185,11 +185,14 @@ def main(
 
     try:
         push(rows, dsn, dry_run)
-    except (SystemExit, Exception) as e:
-        if isinstance(e, SystemExit) and isinstance(e.code, str):
+    except SystemExit as e:
+        if isinstance(e.code, str):
             print(e.code, file=sys.stderr)
-        elif not isinstance(e, SystemExit):
-            print(f"Error: {e}", file=sys.stderr)
+        if exit_on_error:
+            sys.exit(3)
+        return 3
+    except Exception as e:
+        print(f"Push failed: {e}", file=sys.stderr)
         if exit_on_error:
             sys.exit(3)
         return 3

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -155,6 +155,10 @@ def main(
         except argparse.ArgumentError as e:
             print(f"Argument error: {e}", file=sys.stderr)
             return 2
+        except SystemExit as e:
+            if exit_on_error:
+                raise
+            return 0 if e.code == 0 or e.code is None else 2
         if not dsn_explicit:
             dsn = args.dsn
         if results_dir is None:

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -152,7 +152,8 @@ def main(
         )
         try:
             args = parser.parse_args()
-        except argparse.ArgumentError:
+        except argparse.ArgumentError as e:
+            print(str(e), file=sys.stderr)
             return 2
         if not dsn_explicit:
             dsn = args.dsn
@@ -184,7 +185,11 @@ def main(
 
     try:
         push(rows, dsn, dry_run)
-    except (SystemExit, Exception):
+    except (SystemExit, Exception) as e:
+        if isinstance(e, SystemExit) and isinstance(e.code, str):
+            print(e.code, file=sys.stderr)
+        elif not isinstance(e, SystemExit):
+            print(f"Error: {e}", file=sys.stderr)
         if exit_on_error:
             sys.exit(3)
         return 3

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -125,6 +125,7 @@ def main(
     """
     # Resolve env var before argparse so tests can inject results_dir+dry_run
     # and skip parse_args() entirely while still exercising env-var DSN logic.
+    dsn_explicit = dsn is not None
     if dsn is None:
         dsn = os.environ.get("HERMIA_PG_DSN", "")
 
@@ -149,8 +150,12 @@ def main(
             action="store_true",
             help="Print rows that would be inserted without writing to Postgres",
         )
-        args = parser.parse_args()
-        dsn = args.dsn
+        try:
+            args = parser.parse_args()
+        except argparse.ArgumentError:
+            return 2
+        if not dsn_explicit:
+            dsn = args.dsn
         if results_dir is None:
             results_dir = args.results_dir
         if dry_run is None:
@@ -179,8 +184,8 @@ def main(
 
     try:
         push(rows, dsn, dry_run)
-    except SystemExit:
+    except (SystemExit, Exception):
         if exit_on_error:
-            raise
+            sys.exit(3)
         return 3
     return 0

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -186,6 +186,8 @@ def main(
     try:
         push(rows, dsn, dry_run)
     except SystemExit as e:
+        if e.code == 0 or e.code is None:
+            return 0
         if isinstance(e.code, str):
             print(e.code, file=sys.stderr)
         if exit_on_error:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -291,7 +291,7 @@ def test_main_explicit_dsn_not_overridden_by_argv(tmp_path: Path, monkeypatch) -
     mock_conn.cursor.return_value = mock_cur
     mock_pg.connect.return_value = mock_conn
     with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
-        rc = main(dsn="postgresql://explicit", results_dir=tmp_path, dry_run=False)
+        rc = main(dsn="postgresql://explicit", results_dir=tmp_path, dry_run=None)
     assert rc == 0
     mock_pg.connect.assert_called_once_with("postgresql://explicit")
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -225,15 +225,7 @@ def test_main_missing_dsn_exits(tmp_path: Path) -> None:
 def test_main_push_failure_returns_3(tmp_path: Path) -> None:
     """push() SystemExit must be caught and return 3 when exit_on_error=False."""
     _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
-    import builtins
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "psycopg2":
-            raise ImportError("no module")
-        return real_import(name, *args, **kwargs)
-
-    with patch("builtins.__import__", side_effect=fake_import):
+    with patch("hermia.export.push", side_effect=SystemExit("psycopg2 missing")):
         rc = main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=False)
     assert rc == 3
 
@@ -241,36 +233,16 @@ def test_main_push_failure_returns_3(tmp_path: Path) -> None:
 def test_main_push_failure_exits_3(tmp_path: Path) -> None:
     """push() failure with exit_on_error=True must sys.exit(3), not sys.exit(1)."""
     _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
-    import builtins
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "psycopg2":
-            raise ImportError("no module")
-        return real_import(name, *args, **kwargs)
-
-    with patch("builtins.__import__", side_effect=fake_import):
+    with patch("hermia.export.push", side_effect=SystemExit("psycopg2 missing")):
         with pytest.raises(SystemExit) as exc:
             main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=True)
     assert exc.value.code == 3
 
 
 def test_main_db_exception_returns_3(tmp_path: Path) -> None:
-    """psycopg2.Error from execute_batch must be caught and return 3."""
-    import sys
+    """Exception from push (e.g. psycopg2.Error) must be caught and return 3."""
     _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
-    mock_pg = MagicMock()
-    mock_extras = MagicMock()
-    mock_conn = MagicMock()
-    mock_cur = MagicMock()
-    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-    mock_conn.__exit__ = MagicMock(return_value=False)
-    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
-    mock_cur.__exit__ = MagicMock(return_value=False)
-    mock_conn.cursor.return_value = mock_cur
-    mock_pg.connect.return_value = mock_conn
-    mock_extras.execute_batch.side_effect = Exception("db error")
-    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+    with patch("hermia.export.push", side_effect=Exception("db error")):
         rc = main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=False)
     assert rc == 3
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -238,6 +238,64 @@ def test_main_push_failure_returns_3(tmp_path: Path) -> None:
     assert rc == 3
 
 
+def test_main_push_failure_exits_3(tmp_path: Path) -> None:
+    """push() failure with exit_on_error=True must sys.exit(3), not sys.exit(1)."""
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psycopg2":
+            raise ImportError("no module")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(SystemExit) as exc:
+            main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=True)
+    assert exc.value.code == 3
+
+
+def test_main_db_exception_returns_3(tmp_path: Path) -> None:
+    """psycopg2.Error from execute_batch must be caught and return 3."""
+    import sys
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+    mock_extras.execute_batch.side_effect = Exception("db error")
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        rc = main(dsn="postgresql://test", results_dir=tmp_path, dry_run=False, exit_on_error=False)
+    assert rc == 3
+
+
+def test_main_explicit_dsn_not_overridden_by_argv(tmp_path: Path, monkeypatch) -> None:
+    """Explicit dsn arg must not be overwritten by sys.argv --dsn when argparse runs."""
+    import sys
+    monkeypatch.setattr(sys, "argv", ["hermia-push", "--dsn", "postgresql://from-argv"])
+    _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        rc = main(dsn="postgresql://explicit", results_dir=tmp_path, dry_run=False)
+    assert rc == 0
+    mock_pg.connect.assert_called_once_with("postgresql://explicit")
+
+
 def test_main_dsn_from_env(tmp_path: Path, monkeypatch) -> None:
     _write_jsonl(tmp_path / "eval_20260509_120000.jsonl", [_ROW])
     monkeypatch.setenv("HERMIA_PG_DSN", "postgresql://envtest")


### PR DESCRIPTION
## Summary
Addresses two new issues flagged by Gemini on promotion PR #28:

- **dsn precedence**: explicit `dsn` arg was silently overwritten by `--dsn` in `sys.argv` when argparse ran; tracked via `dsn_explicit` flag — caller wins
- **`argparse.ArgumentError`**: raised by `parse_args()` when `exit_on_error=False` and args are invalid; was unhandled (traceback); now caught and returns 2
- **Consistent exit code 3**: `except SystemExit` widened to `except (SystemExit, Exception)` to also catch `psycopg2.Error` from `execute_batch`; `exit_on_error=True` path now `sys.exit(3)` instead of re-raising (which exited with code 1 from push's string message)

## Test plan
- [ ] `test_main_push_failure_exits_3` — exit_on_error=True exits with code 3 not 1
- [ ] `test_main_db_exception_returns_3` — psycopg2.Error from execute_batch returns 3
- [ ] `test_main_explicit_dsn_not_overridden_by_argv` — explicit dsn survives sys.argv override
- [ ] 341 tests passing, ruff + mypy clean
- [ ] CI + Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)