### PR TITLE
hermia-ku7: NVIDIA GPU support via nvidia-smi

### DIFF
--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -54,10 +54,12 @@ def _detect_nvidia() -> tuple[bool, str, float]:
             return False, "", 0.0
         line = result.stdout.strip().splitlines()[0]
         parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 2:
+            return False, "", 0.0
         name = parts[0]
         vram_total_gb = float(parts[1]) / 1024  # MiB → GiB
         return True, name, vram_total_gb
-    except Exception:
+    except (subprocess.SubprocessError, ValueError, IndexError, OSError):
         return False, "", 0.0
 
 
@@ -114,17 +116,22 @@ def _gpu_stats_nvidia() -> tuple[float, float, float]:
             ],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=2,
         )
         if result.returncode != 0 or not result.stdout.strip():
             return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
         line = result.stdout.strip().splitlines()[0]
         parts = [p.strip() for p in line.split(",")]
-        gpu_pct = float(parts[0])
-        vram_used = float(parts[1]) / 1024  # MiB → GiB
-        vram_total = float(parts[2]) / 1024  # MiB → GiB
+        if len(parts) < 3:
+            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+        try:
+            gpu_pct = float(parts[0])
+            vram_used = float(parts[1]) / 1024  # MiB → GiB
+            vram_total = float(parts[2]) / 1024  # MiB → GiB
+        except ValueError:
+            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
         return gpu_pct, vram_used, vram_total
-    except Exception:
+    except (subprocess.SubprocessError, ValueError, IndexError, OSError):
         return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
 
 

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -1,4 +1,4 @@
-"""System and GPU metrics sampling (CPU, RAM, AMD GPU via rocm-smi or sysfs)."""
+"""System and GPU metrics sampling (CPU, RAM, GPU via nvidia-smi or AMD sysfs/rocm-smi)."""
 
 import glob
 import json
@@ -7,8 +7,9 @@ import threading
 import time
 from typing import Any
 
-# Resolved once per run via detect_gpu(); updated by detect_gpu() on each run start.
 _AMD_DEV: str | None = None
+_NVIDIA_FOUND: bool = False
+_NVIDIA_VRAM_TOTAL_GB: float = 0.0
 
 
 def _find_amdgpu_dev() -> str | None:
@@ -40,24 +41,91 @@ def _find_amdgpu_dev() -> str | None:
     return candidates[0][1]
 
 
-def detect_gpu() -> dict[str, Any]:
-    """Detect AMD GPU hardware at run start. Updates the module-level cache.
+def _detect_nvidia() -> tuple[bool, str, float]:
+    """Probe nvidia-smi to detect an NVIDIA GPU. Returns (found, name, vram_total_gb)."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return False, "", 0.0
+        line = result.stdout.strip().splitlines()[0]
+        parts = [p.strip() for p in line.split(",")]
+        name = parts[0]
+        vram_total_gb = float(parts[1]) / 1024  # MiB → GiB
+        return True, name, vram_total_gb
+    except Exception:
+        return False, "", 0.0
 
-    Returns a dict with keys: found (bool), card (str), dev_path (str),
-    vram_total_gb (float). Call this once at the start of each eval run so
-    hardware changes (e.g. new GPU installed) are caught without restarting.
+
+def detect_gpu() -> dict[str, Any]:
+    """Detect GPU hardware at run start. Updates module-level cache.
+
+    Tries NVIDIA first (via nvidia-smi), then AMD (via sysfs). Returns a dict
+    with keys: found (bool), vendor (str), card (str), dev_path (str),
+    vram_total_gb (float). vendor is one of: nvidia, amd, none.
     """
-    global _AMD_DEV
+    global _AMD_DEV, _NVIDIA_FOUND, _NVIDIA_VRAM_TOTAL_GB
+
+    found, name, vram_total_gb = _detect_nvidia()
+    if found:
+        _NVIDIA_FOUND = True
+        _NVIDIA_VRAM_TOTAL_GB = vram_total_gb
+        _AMD_DEV = None
+        return {
+            "found": True,
+            "vendor": "nvidia",
+            "card": name,
+            "dev_path": "",
+            "vram_total_gb": vram_total_gb,
+        }
+
+    _NVIDIA_FOUND = False
     _AMD_DEV = _find_amdgpu_dev()
     if _AMD_DEV is None:
-        return {"found": False, "card": "", "dev_path": "", "vram_total_gb": 0.0}
+        return {"found": False, "vendor": "none", "card": "", "dev_path": "", "vram_total_gb": 0.0}
+
     card = _AMD_DEV.split("/sys/class/drm/")[-1].split("/")[0]
     try:
         with open(f"{_AMD_DEV}/mem_info_vram_total") as f:
             vram_total_gb = int(f.read().strip()) / (1024**3)
     except OSError:
         vram_total_gb = 0.0
-    return {"found": True, "card": card, "dev_path": _AMD_DEV, "vram_total_gb": vram_total_gb}
+    return {
+        "found": True,
+        "vendor": "amd",
+        "card": card,
+        "dev_path": _AMD_DEV,
+        "vram_total_gb": vram_total_gb,
+    }
+
+
+def _gpu_stats_nvidia() -> tuple[float, float, float]:
+    """Read GPU utilization and VRAM via nvidia-smi."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            [  # noqa: S607
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu,memory.used,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+        line = result.stdout.strip().splitlines()[0]
+        parts = [p.strip() for p in line.split(",")]
+        gpu_pct = float(parts[0])
+        vram_used = float(parts[1]) / 1024  # MiB → GiB
+        vram_total = float(parts[2]) / 1024  # MiB → GiB
+        return gpu_pct, vram_used, vram_total
+    except Exception:
+        return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
 
 
 def _gpu_stats_sysfs() -> tuple[float, float, float]:
@@ -82,9 +150,12 @@ def _gpu_stats_sysfs() -> tuple[float, float, float]:
 def get_gpu_stats() -> tuple[float, float, float]:
     """Return (gpu_pct, vram_used_gb, vram_total_gb).
 
-    Tries rocm-smi first; falls back to amdgpu sysfs so Vulkan workloads
-    (which rocm-smi reports as zero) are still measured correctly.
+    Routes to nvidia-smi when an NVIDIA GPU was detected, otherwise tries
+    rocm-smi then falls back to amdgpu sysfs.
     """
+    if _NVIDIA_FOUND:
+        return _gpu_stats_nvidia()
+
     try:
         result = subprocess.run(  # noqa: S603
             ["rocm-smi", "--showuse", "--showmemuse", "--showmeminfo", "vram", "--json"],  # noqa: S607

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -72,9 +72,9 @@ def detect_gpu() -> dict[str, Any]:
 
     found, name, vram_total_gb = _detect_nvidia()
     if found:
-        _NVIDIA_FOUND = True
         _NVIDIA_VRAM_TOTAL_GB = vram_total_gb
         _AMD_DEV = None
+        _NVIDIA_FOUND = True
         return {
             "found": True,
             "vendor": "nvidia",

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,4 +1,4 @@
-"""Unit tests for MetricsSampler."""
+"""Unit tests for MetricsSampler and GPU detection."""
 
 import time
 from unittest.mock import MagicMock, mock_open, patch
@@ -69,6 +69,10 @@ def _make_uevent_open(dev_path: str, driver: str = "amdgpu", vram_bytes: int = 8
     return fake_open
 
 
+# ---------------------------------------------------------------------------
+# AMD detection tests — patch subprocess.run so nvidia-smi detection is skipped
+# ---------------------------------------------------------------------------
+
 def test_detect_gpu_finds_amdgpu_card():
     """detect_gpu() picks the amdgpu card and ignores non-amdgpu cards."""
     uevent_paths = [
@@ -86,27 +90,31 @@ def test_detect_gpu_finds_amdgpu_card():
         return mock_open(read_data=uevent_data.get(path, ""))()
 
     with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
         patch("hermia.metrics.glob.glob", return_value=uevent_paths),
         patch("builtins.open", side_effect=fake_open),
     ):
         info = detect_gpu()
 
     assert info["found"] is True
+    assert info["vendor"] == "amd"
     assert info["card"] == "card2"
     assert abs(info["vram_total_gb"] - 8.0) < 0.01
     assert metrics_mod._AMD_DEV == dev
 
 
 def test_detect_gpu_no_amdgpu():
-    """detect_gpu() returns found=False when no amdgpu card is present."""
+    """detect_gpu() returns found=False when no GPU is present."""
     uevent_paths = ["/sys/class/drm/card0/device/uevent"]
     with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
         patch("hermia.metrics.glob.glob", return_value=uevent_paths),
         patch("builtins.open", mock_open(read_data="DRIVER=i915\n")),
     ):
         info = detect_gpu()
 
     assert info["found"] is False
+    assert info["vendor"] == "none"
     assert metrics_mod._AMD_DEV is None
 
 
@@ -127,6 +135,7 @@ def test_detect_gpu_picks_highest_vram_when_multiple_amdgpu():
         return mock_open(read_data=uevent_data.get(path, "0"))()
 
     with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
         patch("hermia.metrics.glob.glob", return_value=uevent_paths),
         patch("builtins.open", side_effect=fake_open),
     ):
@@ -135,6 +144,138 @@ def test_detect_gpu_picks_highest_vram_when_multiple_amdgpu():
     assert info["card"] == "card2"
     assert abs(info["vram_total_gb"] - 16.0) < 0.01
 
+
+# ---------------------------------------------------------------------------
+# NVIDIA detection tests
+# ---------------------------------------------------------------------------
+
+def _nvidia_detect_result(name: str = "NVIDIA GeForce RTX 5090", vram_mib: int = 32768) -> MagicMock:
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = f"{name}, {vram_mib}\n"
+    return r
+
+
+def test_detect_gpu_nvidia_found():
+    """detect_gpu() returns vendor=nvidia when nvidia-smi succeeds."""
+    with patch("subprocess.run", return_value=_nvidia_detect_result("NVIDIA GeForce RTX 5090", 32768)):
+        info = detect_gpu()
+
+    assert info["found"] is True
+    assert info["vendor"] == "nvidia"
+    assert info["card"] == "NVIDIA GeForce RTX 5090"
+    assert abs(info["vram_total_gb"] - 32.0) < 0.1
+    assert metrics_mod._NVIDIA_FOUND is True
+    assert metrics_mod._AMD_DEV is None
+
+
+def test_detect_gpu_nvidia_3090():
+    """detect_gpu() correctly parses RTX 3090 (24 GB)."""
+    with patch("subprocess.run", return_value=_nvidia_detect_result("NVIDIA GeForce RTX 3090", 24576)):
+        info = detect_gpu()
+
+    assert info["vendor"] == "nvidia"
+    assert abs(info["vram_total_gb"] - 24.0) < 0.1
+
+
+def test_detect_gpu_nvidia_missing():
+    """detect_gpu() falls through to AMD when nvidia-smi is not on PATH."""
+    uevent_paths = ["/sys/class/drm/card1/device/uevent"]
+    dev = "/sys/class/drm/card1/device"
+    uevent_data = {
+        "/sys/class/drm/card1/device/uevent": "DRIVER=amdgpu\n",
+        f"{dev}/mem_info_vram_total": str(8 * 1024**3),
+    }
+
+    def fake_open(path, *a, **kw):
+        return mock_open(read_data=uevent_data.get(path, ""))()
+
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.glob.glob", return_value=uevent_paths),
+        patch("builtins.open", side_effect=fake_open),
+    ):
+        info = detect_gpu()
+
+    assert info["vendor"] == "amd"
+    assert metrics_mod._NVIDIA_FOUND is False
+
+
+def test_detect_gpu_nvidia_error_returncode():
+    """detect_gpu() treats non-zero nvidia-smi exit as no NVIDIA GPU."""
+    bad_result = MagicMock()
+    bad_result.returncode = 1
+    bad_result.stdout = ""
+
+    with (
+        patch("subprocess.run", return_value=bad_result),
+        patch("hermia.metrics.glob.glob", return_value=[]),
+    ):
+        info = detect_gpu()
+
+    assert info["found"] is False
+    assert info["vendor"] == "none"
+    assert metrics_mod._NVIDIA_FOUND is False
+
+
+# ---------------------------------------------------------------------------
+# get_gpu_stats NVIDIA routing tests
+# ---------------------------------------------------------------------------
+
+def _nvidia_stats_result(util_pct: float = 82.0, used_mib: float = 12288.0, total_mib: float = 32768.0) -> MagicMock:
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = f"{util_pct}, {used_mib}, {total_mib}\n"
+    return r
+
+
+def test_get_gpu_stats_uses_nvidia_when_found():
+    """get_gpu_stats() routes to nvidia-smi when _NVIDIA_FOUND is True."""
+    with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", True),
+        patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 32.0),
+        patch("subprocess.run", return_value=_nvidia_stats_result(82.0, 12288.0, 32768.0)),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 82.0
+    assert abs(vram_used - 12.0) < 0.01
+    assert abs(vram_total - 32.0) < 0.01
+
+
+def test_get_gpu_stats_nvidia_subprocess_error_returns_zeros():
+    """nvidia-smi failure during stats returns zeros with cached vram_total."""
+    with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", True),
+        patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 24.0),
+        patch("subprocess.run", side_effect=OSError),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 0.0
+    assert vram_used == 0.0
+    assert vram_total == 24.0
+
+
+def test_get_gpu_stats_nvidia_nonzero_returncode_returns_zeros():
+    """Non-zero nvidia-smi exit during stats returns zeros with cached vram_total."""
+    bad = MagicMock()
+    bad.returncode = 1
+    bad.stdout = ""
+    with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", True),
+        patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 24.0),
+        patch("subprocess.run", return_value=bad),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 0.0
+    assert vram_total == 24.0
+
+
+# ---------------------------------------------------------------------------
+# Existing AMD get_gpu_stats tests
+# ---------------------------------------------------------------------------
 
 def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_returns_zeros():
     """rocm-smi returning all zeros should trigger sysfs fallback."""
@@ -156,6 +297,7 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_returns_zeros():
         return mock_open(read_data=open_values.get(path, "0"))()
 
     with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch("subprocess.run", return_value=mock_result),
         patch("hermia.metrics.glob.glob", return_value=[f"{dev}/uevent"]),
         patch("builtins.open", side_effect=fake_open),
@@ -181,6 +323,7 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_missing():
         return mock_open(read_data=open_values.get(path, "0"))()
 
     with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch("subprocess.run", side_effect=FileNotFoundError),
         patch("hermia.metrics.glob.glob", return_value=[f"{dev}/uevent"]),
         patch("builtins.open", side_effect=fake_open),

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -149,7 +149,9 @@ def test_detect_gpu_picks_highest_vram_when_multiple_amdgpu():
 # NVIDIA detection tests
 # ---------------------------------------------------------------------------
 
-def _nvidia_detect_result(name: str = "NVIDIA GeForce RTX 5090", vram_mib: int = 32768) -> MagicMock:
+def _nvidia_detect_result(
+    name: str = "NVIDIA GeForce RTX 5090", vram_mib: int = 32768
+) -> MagicMock:
     r = MagicMock()
     r.returncode = 0
     r.stdout = f"{name}, {vram_mib}\n"
@@ -158,7 +160,8 @@ def _nvidia_detect_result(name: str = "NVIDIA GeForce RTX 5090", vram_mib: int =
 
 def test_detect_gpu_nvidia_found():
     """detect_gpu() returns vendor=nvidia when nvidia-smi succeeds."""
-    with patch("subprocess.run", return_value=_nvidia_detect_result("NVIDIA GeForce RTX 5090", 32768)):
+    result = _nvidia_detect_result("NVIDIA GeForce RTX 5090", 32768)
+    with patch("subprocess.run", return_value=result):
         info = detect_gpu()
 
     assert info["found"] is True
@@ -171,7 +174,8 @@ def test_detect_gpu_nvidia_found():
 
 def test_detect_gpu_nvidia_3090():
     """detect_gpu() correctly parses RTX 3090 (24 GB)."""
-    with patch("subprocess.run", return_value=_nvidia_detect_result("NVIDIA GeForce RTX 3090", 24576)):
+    result = _nvidia_detect_result("NVIDIA GeForce RTX 3090", 24576)
+    with patch("subprocess.run", return_value=result):
         info = detect_gpu()
 
     assert info["vendor"] == "nvidia"
@@ -222,7 +226,9 @@ def test_detect_gpu_nvidia_error_returncode():
 # get_gpu_stats NVIDIA routing tests
 # ---------------------------------------------------------------------------
 
-def _nvidia_stats_result(util_pct: float = 82.0, used_mib: float = 12288.0, total_mib: float = 32768.0) -> MagicMock:
+def _nvidia_stats_result(
+    util_pct: float = 82.0, used_mib: float = 12288.0, total_mib: float = 32768.0
+) -> MagicMock:
     r = MagicMock()
     r.returncode = 0
     r.stdout = f"{util_pct}, {used_mib}, {total_mib}\n"


### PR DESCRIPTION
## Summary
- `detect_gpu()` probes `nvidia-smi` first; falls back to AMD sysfs path unchanged
- Adds `vendor` field to return dict (`nvidia` | `amd` | `none`)
- `get_gpu_stats()` routes to new `_gpu_stats_nvidia()` when NVIDIA is cached
- No new pip dependencies — `nvidia-smi` is on PATH wherever CUDA is installed
- 7 new unit tests cover NVIDIA-detected, NVIDIA-missing, and NVIDIA-error paths
- AMD tests updated to patch `subprocess.run` (now that `detect_gpu` calls it for nvidia probe)

## Test plan
- [ ] 355 tests passing locally
- [ ] mypy clean
- [ ] Manual smoke test on Eric's 5090 and Marcus's 3090 before merge (per bead AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)