### PR TITLE
hermia-cix: README scope clarifications + roadmap section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ integration test infrastructure, and a rigorous CI/security pipeline.
 - Property-based tests on all 19 schema checkers via `hypothesis` — total, required-keys-
   present, and required-keys-missing properties; 64 tests; `schemas.py` coverage 76% → 97%
   (hermia-xjj, PR #39)
-- CI pipeline — ruff, mypy, pytest (410 tests, 89% branch coverage) on all branches and PRs
+- CI pipeline — ruff, mypy, pytest (474 tests, 89% branch coverage) on all branches and PRs
 - Security CI pipeline — gitleaks, trivy, bandit, pip-audit on PRs to main + weekly
 - Gemini Code Assist wired for PR review
 - Branch protection active on `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Planned
-- Grafana metrics exporter — eval pass rates as Prometheus gauges
-- Expanded domain coverage — healthcare agent, financial agent, DevOps CI secrets
-- Fleet output quality scoring
-- PyPI publication
+See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 ---
 
-## [0.1.0] — 2026-05-03
+## [0.1.0] — target 2026-05-23
 
-First stable eval suite. Core TUI, security test coverage, and CI pipeline established.
+First stable eval suite. Core TUI, multi-vendor GPU metrics, robustness scoring,
+integration test infrastructure, and a rigorous CI/security pipeline.
 
 ### Added
 - Interactive TUI (`textual`) — model selection, eval dimension selection, live run view
@@ -35,7 +32,23 @@ First stable eval suite. Core TUI, security test coverage, and CI pipeline estab
 - Framework mapping — OWASP LLM Top 10 (2025), MITRE ATLAS v5.1, CSA MAESTRO, NIST AI RMF
 - Schema validation via `_keys_ok()` helper — tolerates reasoning model extra keys
 - Regression detection script (`hermia-regression`) — detects behavioral drift across runs
-- CI pipeline — ruff, mypy, pytest on all branches and PRs
+- NVIDIA GPU metrics — `nvidia-smi` integration; vendor-tagged `detect_gpu()` result
+  (hermia-ku7, PR #33)
+- Apple Silicon GPU metrics — `ioreg` integration for unified-memory VRAM reporting on
+  macOS arm64 (hermia-c3f, PR #34)
+- Robustness module + `--repeat N` flag — multi-run consistency scoring, `is_cold` / warm
+  tracking, `cold_warm_delta_tps`, `patch_results()` aggregate backfill (hermia-0ws, PR #35)
+- TUI test coverage via Textual `Pilot` — SelectionScreen + RunnerScreen happy-path and
+  edge-case tests; `screens.py` coverage 31% → 94% (hermia-tun, PR #36)
+- Fake-Ollama integration test fixture — stdlib HTTP server in `tests/integration/`;
+  covers happy path, API drift, timeout, 500, malformed JSON, tags endpoint
+  (hermia-w59, PR #37)
+- Determinism / stability harness — end-to-end test asserting identical scored fields
+  for identical inputs; timing fields excluded from equality check (hermia-gx8, PR #38)
+- Property-based tests on all 19 schema checkers via `hypothesis` — total, required-keys-
+  present, and required-keys-missing properties; 64 tests; `schemas.py` coverage 76% → 97%
+  (hermia-xjj, PR #39)
+- CI pipeline — ruff, mypy, pytest (410 tests, 89% branch coverage) on all branches and PRs
 - Security CI pipeline — gitleaks, trivy, bandit, pip-audit on PRs to main + weekly
 - Gemini Code Assist wired for PR review
 - Branch protection active on `main`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ benchmarking measures actual model load time from a clean VRAM state, not cached
 Because "how fast is it really" is a different question than "how fast is it after it's
 already warm."
 
+**Current scope:** single-turn evaluation against Ollama-compatible local endpoints.
+Multi-endpoint and cloud API support (OpenAI, LiteLLM, Anthropic, Bedrock) land in v0.2.
+
 ---
 
 ## Why Hermia Exists
@@ -91,6 +94,22 @@ No cloud API keys required. No data leaves your machine.
 
 ---
 
+## Hardware Support
+
+| Platform | GPU | Status |
+|---|---|---|
+| Linux | AMD ROCm (gfx900 / RX series) | ✅ Tested |
+| Linux / Windows* | NVIDIA CUDA (sm_89 / RTX series) | ✅ Tested |
+| macOS | Apple Silicon (M1 / M2 / M3 / M4) | ✅ Tested |
+| Linux | Intel iGPU | ⚠️ Best-effort |
+| Any | CPU-only (no discrete GPU) | ✅ Supported |
+| Windows | Any | ❌ Not yet |
+
+*NVIDIA metrics tested on Linux eval client. Windows Ollama servers are supported as fleet
+targets via `--host`; running Hermia itself on Windows is not yet supported.
+
+---
+
 ## Install
 
 From source (pre-PyPI):
@@ -127,17 +146,29 @@ hermia-regression results/all-results.json
 
 ---
 
+## Roadmap
+
+**v0.2 — Endpoint Bus** (target ~2026-06-15): Hermia evaluates anything that speaks
+OpenAI-compatible — LiteLLM, OpenAI, Anthropic, Google, Bedrock, plus local Ollama. Fleet
+config file for multi-host runs; backend stack tagging by GPU arch and runtime version.
+
+**v0.3 — Eval Bus** (target ~2026-08): Hermia becomes the platform other tools build into.
+Probe adapters for Garak, PyRIT, and HarmBench pull their results into Hermia's
+hardware-correlated, framework-mapped view alongside Hermia's own probes. LLM-as-judge
+scoring; Sink interface for custom output destinations (Prometheus, webhook, S3).
+
+See [docs/roadmap.md](docs/roadmap.md) for the full plan.
+
+---
+
 ## Project Status
 
 **Pre-release.** This is a working research project, not a polished product. The core eval
 suite is stable and passing. The security pipeline (gitleaks, trivy, bandit, pip-audit,
 ruff, mypy) is more rigorous than the author initially expected to need for a research tool.
-Active development continues.
+Active development continues toward the v0.1.0 release (target 2026-05-23).
 
-Pending before PyPI publication:
-- Grafana metrics exporter (eval pass rates as Prometheus gauges)
-- Expanded domain coverage (healthcare agent, financial agent, DevOps CI secrets)
-- Fleet output quality scoring
+PyPI publication is planned after v0.1.0 stabilizes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Because "how fast is it really" is a different question than "how fast is it aft
 already warm."
 
 **Current scope:** single-turn evaluation against Ollama-compatible local endpoints.
-Multi-endpoint and cloud API support (OpenAI, LiteLLM, Anthropic, Bedrock) land in v0.2.
+Multi-endpoint and cloud API support (OpenAI, LiteLLM, Anthropic, Google, Bedrock) land in v0.2.
 
 ---
 
@@ -99,10 +99,10 @@ No cloud API keys required. No data leaves your machine.
 | Platform | GPU | Status |
 |---|---|---|
 | Linux | AMD ROCm (gfx900 / RX series) | ✅ Tested |
-| Linux / Windows* | NVIDIA CUDA (sm_89 / RTX series) | ✅ Tested |
+| Linux | NVIDIA CUDA (sm_89 / RTX series) | ✅ Tested* |
 | macOS | Apple Silicon (M1 / M2 / M3 / M4) | ✅ Tested |
 | Linux | Intel iGPU | ⚠️ Best-effort |
-| Any | CPU-only (no discrete GPU) | ✅ Supported |
+| Linux / macOS | CPU-only (no discrete GPU) | ✅ Supported |
 | Windows | Any | ❌ Not yet |
 
 *NVIDIA metrics tested on Linux eval client. Windows Ollama servers are supported as fleet


### PR DESCRIPTION
## Summary

- **What It Does** — explicit single-turn / local-endpoint scope note pre-empts "where's multi-turn?" and "where's cloud API support?" on day one
- **Hardware Support matrix** — AMD ✅ / NVIDIA ✅ / Apple Silicon ✅ / Intel iGPU ⚠️ / Windows ❌; Windows footnote clarifies fleet-target vs. eval-client distinction
- **Roadmap section** — v0.2 Endpoint Bus + v0.3 Eval Bus one-liners with link to `docs/roadmap.md`
- **Project Status** — replaced stale "Pending" list with v0.1.0 target date + PyPI note
- **CHANGELOG 0.1.0** — date updated to target 2026-05-23; all post-May-03 beads documented (hermia-ku7 through hermia-xjj); test counts updated (474 tests, 89% branch coverage)
- **[Unreleased]** — replaced stale planned list with pointer to `docs/roadmap.md`

## Acceptance checklist

- [x] "What It Does" notes single-turn / Ollama-compatible local endpoints
- [x] Hardware Support matrix added
- [x] Roadmap section names v0.2 (endpoint bus) and v0.3 (eval bus) with one-line descriptions
- [x] CHANGELOG entry for v0.1.0 complete with all merged beads
- [x] No code changes — docs only; 474 tests collect cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)