### PR TITLE
hermia-1bf + hermia-843: SQL and JSONL injection round-trip tests

### DIFF
--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -419,3 +419,49 @@ def test_push_framework_columns_default_to_empty_for_old_rows() -> None:
     assert rec["framework_mitre"] == []
     assert rec["framework_maestro"] == []
     assert rec["framework_nist"] == []
+
+
+# ---------------------------------------------------------------------------
+# hermia-1bf: SQL injection round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_sql_injection_values_pass_through_verbatim() -> None:
+    """Hostile model/test_id strings must appear verbatim in the parameter dict,
+    never interpolated into the SQL string."""
+    import sys
+
+    hostile_model = "'; DROP TABLE hermia_results;--"
+    hostile_test_id = "<script>alert(1)</script>"
+
+    row = {
+        **_ROW,
+        "model": hostile_model,
+        "test_id": hostile_test_id,
+    }
+
+    captured_records: list = []
+
+    mock_pg = MagicMock()
+    mock_extras = MagicMock()
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cur
+    mock_pg.connect.return_value = mock_conn
+
+    def capture_batch(cur, sql, records):
+        captured_records.extend(records)
+
+    mock_extras.execute_batch.side_effect = capture_batch
+
+    with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
+        push([row], dsn="postgresql://test", dry_run=False)
+
+    assert len(captured_records) == 1
+    rec = captured_records[0]
+    assert rec["model"] == hostile_model
+    assert rec["test_id"] == hostile_test_id

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -427,8 +427,8 @@ def test_push_framework_columns_default_to_empty_for_old_rows() -> None:
 
 
 def test_sql_injection_values_pass_through_verbatim() -> None:
-    """Hostile model/test_id strings must appear verbatim in the parameter dict,
-    never interpolated into the SQL string."""
+    """Hostile model/test_id strings must appear verbatim in the parameter dict
+    and must never be interpolated into the SQL template itself."""
     import sys
 
     hostile_model = "'; DROP TABLE hermia_results;--"
@@ -440,7 +440,7 @@ def test_sql_injection_values_pass_through_verbatim() -> None:
         "test_id": hostile_test_id,
     }
 
-    captured_records: list = []
+    captured_calls: list = []
 
     mock_pg = MagicMock()
     mock_extras = MagicMock()
@@ -454,14 +454,17 @@ def test_sql_injection_values_pass_through_verbatim() -> None:
     mock_pg.connect.return_value = mock_conn
 
     def capture_batch(cur, sql, records):
-        captured_records.extend(records)
+        assert hostile_model not in sql
+        assert hostile_test_id not in sql
+        captured_calls.append((sql, records))
 
     mock_extras.execute_batch.side_effect = capture_batch
 
     with patch.dict(sys.modules, {"psycopg2": mock_pg, "psycopg2.extras": mock_extras}):
         push([row], dsn="postgresql://test", dry_run=False)
 
-    assert len(captured_records) == 1
-    rec = captured_records[0]
-    assert rec["model"] == hostile_model
-    assert rec["test_id"] == hostile_test_id
+    assert len(captured_calls) == 1
+    sql, records = captured_calls[0]
+    assert sql == _INSERT_SQL
+    assert records[0]["model"] == hostile_model
+    assert records[0]["test_id"] == hostile_test_id

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -129,3 +129,19 @@ def test_patch_results_atomic_via_tmp(tmp_path: Path) -> None:
     append_result(_run_row(1), jsonl, csv_path)
     patch_results(jsonl, [_run_row(1, {"consistency_pct": 0.9})])
     assert not (jsonl.with_suffix(".jsonl.tmp")).exists()
+
+
+# ---------------------------------------------------------------------------
+# hermia-843: JSONL injection round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_injection_in_output_preview_does_not_split_record(tmp_path: Path) -> None:
+    """An embedded newline + JSON object in output_preview must not become a
+    second JSONL record when the file is read back."""
+    jsonl, csv_path = open_run(tmp_path)
+    row = {**RESULT_A, "output_preview": 'hello\n{"malicious": true}'}
+    append_result(row, jsonl, csv_path)
+    rows = load_jsonl(jsonl)
+    assert len(rows) == 1
+    assert rows[0]["output_preview"] == 'hello\n{"malicious": true}'


### PR DESCRIPTION
## Summary

Two audit-facing security test beads, combined into one PR.

**hermia-1bf — SQL injection round-trip** (`tests/unit/test_export.py`)
- Hostile `model = "'; DROP TABLE hermia_results;--"` and `test_id = "<script>alert(1)</script>"` flow through `push()` → `execute_batch`
- Asserts values appear verbatim in the `records` parameter dict — never interpolated into the SQL string
- Confirms psycopg2 parameterization is the actual defense

**hermia-843 — JSONL injection round-trip** (`tests/unit/test_results.py`)
- `output_preview` containing `\n{"malicious": true}` written via `append_result`, read back via `load_jsonl`
- Asserts exactly 1 row returned — the embedded newline + JSON did not split into a second record
- Confirms `json.dumps` serialization escapes the newline correctly

## Acceptance checklist

- [x] SQL injection: hostile model/test_id values pass through verbatim in parameter dict
- [x] JSONL injection: embedded `\n{"malicious": true}` does not produce a second record
- [x] 476 tests, 90% branch coverage (up from 474 / 89%)
- [x] Tests only — no src changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)