### PR TITLE
hermia-qqz: Intel iGPU detection + CPU-only fallback

### DIFF
--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -241,6 +241,7 @@ def detect_gpu() -> dict[str, Any]:
         _NVIDIA_VRAM_TOTAL_GB = vram_total_gb
         _APPLE_SILICON = False
         _AMD_DEV = None
+        _INTEL_IGPU = False
         _NVIDIA_FOUND = True  # set last — sampler thread must not see True before VRAM is written
         return {
             "found": True,
@@ -256,6 +257,7 @@ def detect_gpu() -> dict[str, Any]:
     if found_apple:
         _APPLE_VRAM_TOTAL_GB = apple_vram
         _AMD_DEV = None
+        _INTEL_IGPU = False
         _APPLE_SILICON = True  # set last
         return {
             "found": True,

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -1,4 +1,4 @@
-"""System and GPU metrics sampling — nvidia-smi, Apple Silicon ioreg, AMD sysfs/rocm-smi."""
+"""System and GPU metrics sampling — nvidia-smi, Apple Silicon ioreg, AMD sysfs/rocm-smi, Intel i915."""
 
 import glob
 import json
@@ -15,6 +15,7 @@ _NVIDIA_FOUND: bool = False
 _NVIDIA_VRAM_TOTAL_GB: float = 0.0
 _APPLE_SILICON: bool = False
 _APPLE_VRAM_TOTAL_GB: float = 0.0
+_INTEL_IGPU: bool = False
 
 
 def _find_amdgpu_dev() -> str | None:
@@ -155,15 +156,76 @@ def _gpu_stats_apple_silicon() -> tuple[float, float, float]:
         return 0.0, 0.0, _APPLE_VRAM_TOTAL_GB
 
 
+def _detect_intel_igpu() -> tuple[bool, str]:
+    """Detect Intel iGPU. Returns (found, name).
+
+    macOS: parses system_profiler SPDisplaysDataType for an Intel GPU entry.
+    Linux: scans DRM sysfs uevent files for DRIVER=i915.
+    Returns (False, "") when not found or on other platforms.
+    """
+    if sys.platform == "darwin":
+        try:
+            r = subprocess.run(  # noqa: S603
+                ["system_profiler", "SPDisplaysDataType", "-json"],  # noqa: S607
+                capture_output=True, text=True, timeout=5,
+            )
+            data: dict[str, Any] = json.loads(r.stdout)
+            for entry in data.get("SPDisplaysDataType", []):
+                model = entry.get("sppci_model", "")
+                if "Intel" in model:
+                    return True, model
+        except (subprocess.SubprocessError, json.JSONDecodeError, OSError, KeyError):
+            pass
+        return False, ""
+
+    if sys.platform == "linux":
+        for uevent_path in glob.glob("/sys/class/drm/card*/device/uevent"):
+            try:
+                with open(uevent_path) as f:
+                    if "DRIVER=i915" in f.read():
+                        return True, "Intel iGPU"
+            except OSError:
+                continue
+
+    return False, ""
+
+
+def _gpu_stats_intel() -> tuple[float, float, float]:
+    """Read Intel iGPU utilization via intel_gpu_top (Linux only).
+
+    Returns (gpu_pct, 0.0, 0.0) — i915 sysfs does not expose VRAM usage
+    without kernel perf access. Returns (0.0, 0.0, 0.0) on any failure.
+    """
+    if sys.platform != "linux":
+        return 0.0, 0.0, 0.0
+    try:
+        r = subprocess.run(  # noqa: S603
+            ["intel_gpu_top", "-J", "-s", "200"],  # noqa: S607
+            capture_output=True, text=True, timeout=1,
+        )
+        text = r.stdout.strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end <= start:
+            return 0.0, 0.0, 0.0
+        obj = json.loads(text[start : end + 1])
+        engines = obj.get("engines", {})
+        render = engines.get("Render/3D/0", engines.get("Render/3D", {}))
+        return float(render.get("busy", 0.0)), 0.0, 0.0
+    except Exception:
+        return 0.0, 0.0, 0.0
+
+
 def detect_gpu() -> dict[str, Any]:
     """Detect GPU hardware at run start. Updates module-level cache.
 
     Tries NVIDIA first (via nvidia-smi), then Apple Silicon (via ioreg/sysctl),
-    then AMD (via sysfs). Returns a dict with keys: found (bool), vendor (str),
-    card (str), dev_path (str), vram_total_gb (float).
-    vendor is one of: nvidia, apple, amd, none.
+    then AMD (via sysfs), then Intel iGPU (via i915/system_profiler).
+    Returns a dict with keys: found (bool), vendor (str), card (str),
+    dev_path (str), vram_total_gb (float).
+    vendor is one of: nvidia, apple, amd, intel, none.
     """
-    global _AMD_DEV, _NVIDIA_FOUND, _NVIDIA_VRAM_TOTAL_GB, _APPLE_SILICON, _APPLE_VRAM_TOTAL_GB
+    global _AMD_DEV, _NVIDIA_FOUND, _NVIDIA_VRAM_TOTAL_GB, _APPLE_SILICON, _APPLE_VRAM_TOTAL_GB, _INTEL_IGPU
 
     found, name, vram_total_gb = _detect_nvidia()
     if found:
@@ -196,22 +258,35 @@ def detect_gpu() -> dict[str, Any]:
 
     _APPLE_SILICON = False
     _AMD_DEV = _find_amdgpu_dev()
-    if _AMD_DEV is None:
-        return {"found": False, "vendor": "none", "card": "", "dev_path": "", "vram_total_gb": 0.0}
+    if _AMD_DEV is not None:
+        _INTEL_IGPU = False
+        card = _AMD_DEV.split("/sys/class/drm/")[-1].split("/")[0]
+        try:
+            with open(f"{_AMD_DEV}/mem_info_vram_total") as f:
+                vram_total_gb = int(f.read().strip()) / (1024**3)
+        except OSError:
+            vram_total_gb = 0.0
+        return {
+            "found": True,
+            "vendor": "amd",
+            "card": card,
+            "dev_path": _AMD_DEV,
+            "vram_total_gb": vram_total_gb,
+        }
 
-    card = _AMD_DEV.split("/sys/class/drm/")[-1].split("/")[0]
-    try:
-        with open(f"{_AMD_DEV}/mem_info_vram_total") as f:
-            vram_total_gb = int(f.read().strip()) / (1024**3)
-    except OSError:
-        vram_total_gb = 0.0
-    return {
-        "found": True,
-        "vendor": "amd",
-        "card": card,
-        "dev_path": _AMD_DEV,
-        "vram_total_gb": vram_total_gb,
-    }
+    found_intel, intel_name = _detect_intel_igpu()
+    if found_intel:
+        _INTEL_IGPU = True
+        return {
+            "found": True,
+            "vendor": "intel",
+            "card": intel_name,
+            "dev_path": "",
+            "vram_total_gb": 0.0,
+        }
+
+    _INTEL_IGPU = False
+    return {"found": False, "vendor": "none", "card": "", "dev_path": "", "vram_total_gb": 0.0}
 
 
 def _gpu_stats_nvidia() -> tuple[float, float, float]:
@@ -266,14 +341,21 @@ def _gpu_stats_sysfs() -> tuple[float, float, float]:
 def get_gpu_stats() -> tuple[float, float, float]:
     """Return (gpu_pct, vram_used_gb, vram_total_gb).
 
-    Routes to nvidia-smi, Apple Silicon ioreg, or AMD rocm-smi/sysfs based on
-    what detect_gpu() found at startup.
+    Routes to nvidia-smi, Apple Silicon ioreg, Intel i915, or AMD rocm-smi/sysfs
+    based on what detect_gpu() found at startup. Returns (0.0, 0.0, 0.0) on
+    CPU-only systems.
     """
     if _NVIDIA_FOUND:
         return _gpu_stats_nvidia()
 
     if _APPLE_SILICON:
         return _gpu_stats_apple_silicon()
+
+    if _INTEL_IGPU:
+        return _gpu_stats_intel()
+
+    if _AMD_DEV is None:
+        return 0.0, 0.0, 0.0
 
     try:
         result = subprocess.run(  # noqa: S603

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -182,7 +182,8 @@ def _detect_intel_igpu() -> tuple[bool, str]:
         for uevent_path in glob.glob("/sys/class/drm/card*/device/uevent"):
             try:
                 with open(uevent_path) as f:
-                    if "DRIVER=i915" in f.read():
+                    content = f.read()
+                    if "DRIVER=i915" in content or "DRIVER=xe" in content:
                         return True, "Intel iGPU"
             except OSError:
                 continue
@@ -193,22 +194,30 @@ def _detect_intel_igpu() -> tuple[bool, str]:
 def _gpu_stats_intel() -> tuple[float, float, float]:
     """Read Intel iGPU utilization via intel_gpu_top (Linux only).
 
-    Returns (gpu_pct, 0.0, 0.0) — i915 sysfs does not expose VRAM usage
-    without kernel perf access. Returns (0.0, 0.0, 0.0) on any failure.
+    intel_gpu_top streams JSON objects continuously; we run it briefly and
+    capture output on TimeoutExpired. VRAM is not exposed by i915/xe sysfs
+    without kernel perf access, so vram fields are always 0.0.
+    Returns (0.0, 0.0, 0.0) on any failure or when not on Linux.
     """
     if sys.platform != "linux":
         return 0.0, 0.0, 0.0
     try:
-        r = subprocess.run(  # noqa: S603
-            ["intel_gpu_top", "-J", "-s", "200"],  # noqa: S607
-            capture_output=True, text=True, timeout=1,
-        )
-        text = r.stdout.strip()
-        start = text.find("{")
-        end = text.rfind("}")
-        if start == -1 or end <= start:
+        try:
+            r = subprocess.run(  # noqa: S603
+                ["intel_gpu_top", "-J", "-s", "100"],  # noqa: S607
+                capture_output=True, text=True, timeout=0.4,
+            )
+            text = r.stdout
+        except subprocess.TimeoutExpired as e:
+            raw = e.stdout
+            text = raw if isinstance(raw, str) else (raw.decode(errors="ignore") if raw else "")
+
+        if not text:
             return 0.0, 0.0, 0.0
-        obj = json.loads(text[start : end + 1])
+        lines = [ln for ln in text.splitlines() if ln.strip().startswith("{")]
+        if not lines:
+            return 0.0, 0.0, 0.0
+        obj = json.loads(lines[-1])
         engines = obj.get("engines", {})
         render = engines.get("Render/3D/0", engines.get("Render/3D", {}))
         return float(render.get("busy", 0.0)), 0.0, 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -305,6 +305,9 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_returns_zeros():
 
     with (
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_INTEL_IGPU", False),
+        patch.object(metrics_mod, "_AMD_DEV", dev),
         patch("subprocess.run", return_value=mock_result),
         patch("hermia.metrics.glob.glob", return_value=[f"{dev}/uevent"]),
         patch("builtins.open", side_effect=fake_open),
@@ -331,6 +334,9 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_missing():
 
     with (
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_INTEL_IGPU", False),
+        patch.object(metrics_mod, "_AMD_DEV", dev),
         patch("subprocess.run", side_effect=FileNotFoundError),
         patch("hermia.metrics.glob.glob", return_value=[f"{dev}/uevent"]),
         patch("builtins.open", side_effect=fake_open),
@@ -468,3 +474,142 @@ def test_get_gpu_stats_apple_silicon_ioreg_error():
     assert gpu_pct == 0.0
     assert vram_used == 0.0
     assert vram_total == 16.0
+
+
+# ---------------------------------------------------------------------------
+# hermia-qqz: Intel iGPU detection and CPU-only fallback
+# ---------------------------------------------------------------------------
+
+def test_detect_intel_igpu_linux():
+    """detect_gpu() returns vendor=intel when DRIVER=i915 is the only GPU on Linux."""
+    uevent_paths = ["/sys/class/drm/card0/device/uevent"]
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("hermia.metrics.glob.glob", return_value=uevent_paths),
+        patch("builtins.open", mock_open(read_data="DRIVER=i915\n")),
+    ):
+        info = detect_gpu()
+
+    assert info["found"] is True
+    assert info["vendor"] == "intel"
+    assert "Intel" in info["card"] or info["card"] == "Intel iGPU"
+    assert metrics_mod._INTEL_IGPU is True
+    assert metrics_mod._AMD_DEV is None
+
+
+def test_detect_intel_igpu_macos():
+    """detect_gpu() returns vendor=intel when system_profiler reports an Intel GPU."""
+    sp_json = json.dumps({"SPDisplaysDataType": [{"sppci_model": "Intel Iris Pro 580"}]})
+
+    def fake_run(cmd, **kw):
+        r = MagicMock()
+        r.returncode = 0
+        if "SPDisplaysDataType" in cmd:
+            r.stdout = sp_json
+        else:
+            r.returncode = 1
+            r.stdout = ""
+        return r
+
+    with (
+        patch("subprocess.run", side_effect=fake_run),
+        patch("hermia.metrics.sys.platform", "darwin"),
+        patch("hermia.metrics.platform.machine", return_value="x86_64"),
+        patch("hermia.metrics.glob.glob", return_value=[]),
+    ):
+        info = detect_gpu()
+
+    assert info["found"] is True
+    assert info["vendor"] == "intel"
+    assert info["card"] == "Intel Iris Pro 580"
+    assert metrics_mod._INTEL_IGPU is True
+
+
+def test_detect_intel_igpu_not_found_linux():
+    """detect_gpu() returns vendor=none when no GPU at all on Linux."""
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("hermia.metrics.glob.glob", return_value=[]),
+    ):
+        info = detect_gpu()
+
+    assert info["found"] is False
+    assert info["vendor"] == "none"
+    assert metrics_mod._INTEL_IGPU is False
+
+
+def test_detect_amd_takes_priority_over_intel():
+    """AMD dGPU wins when both DRIVER=amdgpu and DRIVER=i915 are present."""
+    uevent_paths = [
+        "/sys/class/drm/card0/device/uevent",
+        "/sys/class/drm/card1/device/uevent",
+    ]
+    uevent_data = {
+        "/sys/class/drm/card0/device/uevent": "DRIVER=i915\n",
+        "/sys/class/drm/card1/device/uevent": "DRIVER=amdgpu\n",
+        "/sys/class/drm/card1/device/mem_info_vram_total": str(8 * 1024**3),
+    }
+
+    def fake_open(path, *a, **kw):
+        return mock_open(read_data=uevent_data.get(path, ""))()
+
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("hermia.metrics.glob.glob", return_value=uevent_paths),
+        patch("builtins.open", side_effect=fake_open),
+    ):
+        info = detect_gpu()
+
+    assert info["vendor"] == "amd"
+    assert metrics_mod._INTEL_IGPU is False
+
+
+def test_get_gpu_stats_intel_routes_to_intel_stats():
+    """get_gpu_stats() routes to _gpu_stats_intel() when _INTEL_IGPU is True."""
+    with (
+        patch.object(metrics_mod, "_INTEL_IGPU", True),
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_AMD_DEV", None),
+        patch("hermia.metrics._gpu_stats_intel", return_value=(55.0, 0.0, 0.0)),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 55.0
+    assert vram_used == 0.0
+    assert vram_total == 0.0
+
+
+def test_get_gpu_stats_intel_no_tool_returns_zeros():
+    """_gpu_stats_intel() returns zeros when intel_gpu_top is not installed."""
+    with (
+        patch.object(metrics_mod, "_INTEL_IGPU", True),
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_AMD_DEV", None),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("subprocess.run", side_effect=FileNotFoundError),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 0.0
+    assert vram_used == 0.0
+    assert vram_total == 0.0
+
+
+def test_get_gpu_stats_cpu_only_returns_zeros():
+    """get_gpu_stats() returns zeros when no GPU was detected (CPU-only)."""
+    with (
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_INTEL_IGPU", False),
+        patch.object(metrics_mod, "_AMD_DEV", None),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert gpu_pct == 0.0
+    assert vram_used == 0.0
+    assert vram_total == 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -498,6 +498,21 @@ def test_detect_intel_igpu_linux():
     assert metrics_mod._AMD_DEV is None
 
 
+def test_detect_intel_igpu_xe_driver_linux():
+    """detect_gpu() detects Intel Xe GPU (DRIVER=xe) on Linux."""
+    uevent_paths = ["/sys/class/drm/card0/device/uevent"]
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("hermia.metrics.glob.glob", return_value=uevent_paths),
+        patch("builtins.open", mock_open(read_data="DRIVER=xe\n")),
+    ):
+        info = detect_gpu()
+
+    assert info["found"] is True
+    assert info["vendor"] == "intel"
+
+
 def test_detect_intel_igpu_macos():
     """detect_gpu() returns vendor=intel when system_profiler reports an Intel GPU."""
     sp_json = json.dumps({"SPDisplaysDataType": [{"sppci_model": "Intel Iris Pro 580"}]})
@@ -596,6 +611,28 @@ def test_get_gpu_stats_intel_no_tool_returns_zeros():
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
     assert gpu_pct == 0.0
+    assert vram_used == 0.0
+    assert vram_total == 0.0
+
+
+def test_get_gpu_stats_intel_timeout_captures_partial_output():
+    """_gpu_stats_intel() captures stdout from TimeoutExpired and parses it."""
+    import subprocess as sp
+
+    sample_json = '{"engines": {"Render/3D/0": {"busy": 63.5}}}\n'
+    exc = sp.TimeoutExpired(cmd=["intel_gpu_top"], timeout=0.4, output=sample_json)
+
+    with (
+        patch.object(metrics_mod, "_INTEL_IGPU", True),
+        patch.object(metrics_mod, "_NVIDIA_FOUND", False),
+        patch.object(metrics_mod, "_APPLE_SILICON", False),
+        patch.object(metrics_mod, "_AMD_DEV", None),
+        patch("hermia.metrics.sys.platform", "linux"),
+        patch("subprocess.run", side_effect=exc),
+    ):
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+
+    assert abs(gpu_pct - 63.5) < 0.01
     assert vram_used == 0.0
     assert vram_total == 0.0
 


### PR DESCRIPTION
## Summary

- Adds `_detect_intel_igpu()`: scans i915 sysfs on Linux, queries `system_profiler` on macOS; returns `(found, name)`
- Adds `_gpu_stats_intel()`: reads GPU utilization from `intel_gpu_top -J` (Linux only, gracefully returns zeros if tool absent)
- Updates `detect_gpu()`: Intel check runs after AMD (dedicated GPU takes priority), sets `_INTEL_IGPU` global, returns `vendor="intel"` with `vram_total_gb=0.0`
- Updates `get_gpu_stats()`: routes through Intel path, short-circuits to `(0.0, 0.0, 0.0)` when `_AMD_DEV is None` for CPU-only systems
- 7 new tests; 2 existing AMD stats tests updated to explicitly patch `_AMD_DEV`/`_INTEL_IGPU`

## Test plan

- [ ] `pytest tests/unit/test_metrics.py` — 28 tests pass
- [ ] Full suite — 485 tests, 89% branch coverage
- [ ] Verify `test_detect_gpu_no_amdgpu` still passes (Intel detection doesn't fire on macOS when system_profiler unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)