### PR TITLE
hermia-klc: NVIDIA compute capability warning for older GPUs

### DIFF
--- a/analysis/hermia-nvidia-compat-warn-spec.md
+++ b/analysis/hermia-nvidia-compat-warn-spec.md
@@ -1,0 +1,86 @@
+# hermia-nvidia-compat-warn — NVIDIA compute capability warning
+
+## What this bead does
+
+When Hermia detects an NVIDIA GPU with compute capability < 6.0 (Maxwell / Kepler and
+older), it shows a visible warning on the SelectionScreen. Without this, a user on an
+older card sees no indication that Ollama may silently fail to use the GPU — the first
+sign is 500 errors during inference.
+
+Discovered empirically: GTX 980 (sm 5.2) causes Ollama 0.22.1 to crash on model load
+under CUDA 12.2. The runner process terminates without a user-visible error in Hermia.
+
+## Threshold
+
+`compute_cap < 6.0` — Pascal (GTX 10xx, sm 6.x) is the oldest generation with reliable
+Ollama/llama.cpp CUDA support. Maxwell (sm 5.x) and Kepler (sm 3.x) are in the warning
+zone. Threshold is a named constant `_NVIDIA_MIN_SUPPORTED_COMPUTE = 6.0` in `metrics.py`
+for easy future adjustment.
+
+## Changes
+
+### `src/hermia/metrics.py`
+
+- `_detect_nvidia()` adds `compute_cap` to its query:
+  ```
+  nvidia-smi --query-gpu=name,memory.total,compute_cap --format=csv,noheader,nounits
+  ```
+  Returns `(found, name, vram_total_gb, compute_cap: float)` — `0.0` on failure.
+
+- `detect_gpu()` includes `compute_cap: float` in the returned dict for all vendors
+  (0.0 for non-NVIDIA). Existing callers are unaffected — new key added, nothing removed.
+
+- Module-level constant: `_NVIDIA_MIN_SUPPORTED_COMPUTE: float = 6.0`
+
+### `src/hermia/screens.py`
+
+`SelectionScreen` — the GPU label at line 149 gains an optional warning suffix:
+
+```
+GPU: NVIDIA GeForce GTX 980  (4.0 GB VRAM)  ⚠ sm 5.2 — Ollama may fall back to CPU (requires sm 6.0+)
+```
+
+Logic:
+```python
+warn = ""
+if vendor == "nvidia":
+    cc = gpu.get("compute_cap", 0.0)
+    if 0.0 < cc < _NVIDIA_MIN_SUPPORTED_COMPUTE:
+        warn = f"  ⚠ sm {cc} — Ollama may fall back to CPU (requires sm 6.0+)"
+gpu_label = f"GPU: {gpu['card']}  ({gpu['vram_total_gb']:.1f} GB {mem_label}){warn}"
+```
+
+`_NVIDIA_MIN_SUPPORTED_COMPUTE` is imported from `metrics`.
+
+## Permitted scope
+
+- `src/hermia/metrics.py`
+- `src/hermia/screens.py`
+- `tests/unit/test_metrics.py`
+- `tests/unit/test_screens.py`
+
+## Acceptance criteria
+
+1. `_detect_nvidia()` queries `compute_cap` via `nvidia-smi`; returns it as a float (e.g. `5.2`)
+2. `detect_gpu()` returns dict includes `compute_cap: float` for all vendors
+3. `_NVIDIA_MIN_SUPPORTED_COMPUTE = 6.0` defined as a module constant
+4. SelectionScreen GPU label shows warning suffix when `vendor == "nvidia"` and `0.0 < compute_cap < 6.0`
+5. No warning shown for sm 6.0+ cards (RTX/GTX 10xx and newer)
+6. No warning shown for non-NVIDIA vendors
+7. No warning shown if `compute_cap == 0.0` (nvidia-smi failed to return it — fail silent)
+8. Unit tests:
+   - `test_detect_nvidia_returns_compute_cap` — mocked nvidia-smi returning `"GTX 980, 4096, 5.2"` → `compute_cap == 5.2`
+   - `test_detect_nvidia_compute_cap_missing` — mocked nvidia-smi returning only 2 fields → `compute_cap == 0.0` (no crash)
+   - `test_detect_gpu_nvidia_includes_compute_cap` — `detect_gpu()` dict has `compute_cap` key
+   - `test_selection_screen_nvidia_old_gpu_warning` — Pilot test: gpu_info with sm 5.2 → label contains "⚠"
+   - `test_selection_screen_nvidia_new_gpu_no_warning` — gpu_info with sm 8.9 → label does not contain "⚠"
+   - `test_selection_screen_non_nvidia_no_warning` — amd vendor → no "⚠"
+
+## Estimate
+
+0.5 days
+
+## Why
+
+Silent failure mode for a class of hardware that real users own. The warning is cheap;
+the confusion it prevents is not.

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -16,6 +16,7 @@ _NVIDIA_VRAM_TOTAL_GB: float = 0.0
 _APPLE_SILICON: bool = False
 _APPLE_VRAM_TOTAL_GB: float = 0.0
 _INTEL_IGPU: bool = False
+_NVIDIA_MIN_SUPPORTED_COMPUTE: float = 6.0
 
 
 def _find_amdgpu_dev() -> str | None:
@@ -47,26 +48,34 @@ def _find_amdgpu_dev() -> str | None:
     return candidates[0][1]
 
 
-def _detect_nvidia() -> tuple[bool, str, float]:
-    """Probe nvidia-smi to detect an NVIDIA GPU. Returns (found, name, vram_total_gb)."""
+def _detect_nvidia() -> tuple[bool, str, float, float]:
+    """Probe nvidia-smi. Returns (found, name, vram_total_gb, compute_cap)."""  # noqa: E501
     try:
         result = subprocess.run(  # noqa: S603
-            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],  # noqa: S607
+            [  # noqa: S607
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,compute_cap",
+                "--format=csv,noheader,nounits",
+            ],
             capture_output=True,
             text=True,
             timeout=5,
         )
         if result.returncode != 0 or not result.stdout.strip():
-            return False, "", 0.0
+            return False, "", 0.0, 0.0
         line = result.stdout.strip().splitlines()[0]
         parts = [p.strip() for p in line.split(",")]
         if len(parts) < 2:
-            return False, "", 0.0
+            return False, "", 0.0, 0.0
         name = parts[0]
         vram_total_gb = float(parts[1]) / 1024  # MiB → GiB
-        return True, name, vram_total_gb
+        try:
+            compute_cap = float(parts[2]) if len(parts) >= 3 else 0.0
+        except (ValueError, IndexError):
+            compute_cap = 0.0
+        return True, name, vram_total_gb, compute_cap
     except (subprocess.SubprocessError, ValueError, IndexError, OSError):
-        return False, "", 0.0
+        return False, "", 0.0, 0.0
 
 
 def _detect_apple_silicon() -> tuple[bool, str, float]:
@@ -237,7 +246,7 @@ def detect_gpu() -> dict[str, Any]:
     global _AMD_DEV, _NVIDIA_FOUND, _NVIDIA_VRAM_TOTAL_GB  # noqa: PLW0603
     global _APPLE_SILICON, _APPLE_VRAM_TOTAL_GB, _INTEL_IGPU  # noqa: PLW0603
 
-    found, name, vram_total_gb = _detect_nvidia()
+    found, name, vram_total_gb, compute_cap = _detect_nvidia()
     if found:
         _NVIDIA_VRAM_TOTAL_GB = vram_total_gb
         _APPLE_SILICON = False
@@ -250,6 +259,7 @@ def detect_gpu() -> dict[str, Any]:
             "card": name,
             "dev_path": "",
             "vram_total_gb": vram_total_gb,
+            "compute_cap": compute_cap,
         }
 
     _NVIDIA_FOUND = False
@@ -266,6 +276,7 @@ def detect_gpu() -> dict[str, Any]:
             "card": apple_name,
             "dev_path": "",
             "vram_total_gb": apple_vram,
+            "compute_cap": 0.0,
         }
 
     _APPLE_SILICON = False
@@ -284,6 +295,7 @@ def detect_gpu() -> dict[str, Any]:
             "card": card,
             "dev_path": _AMD_DEV,
             "vram_total_gb": vram_total_gb,
+            "compute_cap": 0.0,
         }
 
     found_intel, intel_name = _detect_intel_igpu()
@@ -295,10 +307,14 @@ def detect_gpu() -> dict[str, Any]:
             "card": intel_name,
             "dev_path": "",
             "vram_total_gb": 0.0,
+            "compute_cap": 0.0,
         }
 
     _INTEL_IGPU = False
-    return {"found": False, "vendor": "none", "card": "", "dev_path": "", "vram_total_gb": 0.0}
+    return {
+        "found": False, "vendor": "none", "card": "",
+        "dev_path": "", "vram_total_gb": 0.0, "compute_cap": 0.0,
+    }
 
 
 def _gpu_stats_nvidia() -> tuple[float, float, float]:

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -16,7 +16,7 @@ _NVIDIA_VRAM_TOTAL_GB: float = 0.0
 _APPLE_SILICON: bool = False
 _APPLE_VRAM_TOTAL_GB: float = 0.0
 _INTEL_IGPU: bool = False
-_NVIDIA_MIN_SUPPORTED_COMPUTE: float = 6.0
+NVIDIA_MIN_SUPPORTED_COMPUTE: float = 6.0
 
 
 def _find_amdgpu_dev() -> str | None:

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -17,7 +17,7 @@ from textual.screen import Screen
 from textual.widgets import Button, Checkbox, Footer, Header, Label, ProgressBar, Static
 
 from hermia import robustness
-from hermia.metrics import _NVIDIA_MIN_SUPPORTED_COMPUTE, MetricsSampler
+from hermia.metrics import NVIDIA_MIN_SUPPORTED_COMPUTE, MetricsSampler
 from hermia.preflight import run_preflight
 from hermia.results import append_result, open_run, patch_results
 from hermia.runner import (
@@ -149,8 +149,9 @@ class SelectionScreen(Screen):  # type: ignore[type-arg]
             warn = ""
             if vendor == "nvidia":
                 cc = gpu.get("compute_cap", 0.0)
-                if 0.0 < cc < _NVIDIA_MIN_SUPPORTED_COMPUTE:
-                    warn = f"  ⚠ sm {cc} — Ollama may fall back to CPU (requires sm 6.0+)"
+                if 0.0 < cc < NVIDIA_MIN_SUPPORTED_COMPUTE:
+                    min_cc = NVIDIA_MIN_SUPPORTED_COMPUTE
+                    warn = f"  ⚠ sm {cc} — Ollama may fall back to CPU (requires sm {min_cc}+)"
             gpu_label = f"GPU: {gpu['card']}  ({gpu['vram_total_gb']:.1f} GB {mem_label}){warn}"
         else:
             gpu_label = "GPU: not detected — VRAM metrics unavailable"

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -17,7 +17,7 @@ from textual.screen import Screen
 from textual.widgets import Button, Checkbox, Footer, Header, Label, ProgressBar, Static
 
 from hermia import robustness
-from hermia.metrics import MetricsSampler
+from hermia.metrics import _NVIDIA_MIN_SUPPORTED_COMPUTE, MetricsSampler
 from hermia.preflight import run_preflight
 from hermia.results import append_result, open_run, patch_results
 from hermia.runner import (
@@ -146,7 +146,12 @@ class SelectionScreen(Screen):  # type: ignore[type-arg]
         if gpu["found"]:
             vendor = gpu.get("vendor", "")
             mem_label = "unified memory" if vendor == "apple" else "VRAM"
-            gpu_label = f"GPU: {gpu['card']}  ({gpu['vram_total_gb']:.1f} GB {mem_label})"
+            warn = ""
+            if vendor == "nvidia":
+                cc = gpu.get("compute_cap", 0.0)
+                if 0.0 < cc < _NVIDIA_MIN_SUPPORTED_COMPUTE:
+                    warn = f"  ⚠ sm {cc} — Ollama may fall back to CPU (requires sm 6.0+)"
+            gpu_label = f"GPU: {gpu['card']}  ({gpu['vram_total_gb']:.1f} GB {mem_label}){warn}"
         else:
             gpu_label = "GPU: not detected — VRAM metrics unavailable"
         yield Label(gpu_label, id="gpu-info")

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -151,11 +151,11 @@ def test_detect_gpu_picks_highest_vram_when_multiple_amdgpu():
 # ---------------------------------------------------------------------------
 
 def _nvidia_detect_result(
-    name: str = "NVIDIA GeForce RTX 5090", vram_mib: int = 32768
+    name: str = "NVIDIA GeForce RTX 5090", vram_mib: int = 32768, compute_cap: float = 8.9
 ) -> MagicMock:
     r = MagicMock()
     r.returncode = 0
-    r.stdout = f"{name}, {vram_mib}\n"
+    r.stdout = f"{name}, {vram_mib}, {compute_cap}\n"
     return r
 
 
@@ -278,6 +278,65 @@ def test_get_gpu_stats_nvidia_nonzero_returncode_returns_zeros():
 
     assert gpu_pct == 0.0
     assert vram_total == 24.0
+
+
+# ---------------------------------------------------------------------------
+# _detect_nvidia compute_cap tests
+# ---------------------------------------------------------------------------
+
+def test_detect_nvidia_returns_compute_cap():
+    """_detect_nvidia() parses compute_cap as the third CSV field."""
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = "GTX 980, 4096, 5.2\n"
+    with patch("subprocess.run", return_value=r):
+        found, name, vram, compute_cap = metrics_mod._detect_nvidia()
+    assert found is True
+    assert name == "GTX 980"
+    assert compute_cap == 5.2
+
+
+def test_detect_nvidia_compute_cap_missing():
+    """_detect_nvidia() returns 0.0 for compute_cap when the field is absent."""
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = "GTX 980, 4096\n"
+    with patch("subprocess.run", return_value=r):
+        found, name, vram, compute_cap = metrics_mod._detect_nvidia()
+    assert found is True
+    assert compute_cap == 0.0
+
+
+def test_detect_gpu_nvidia_includes_compute_cap():
+    """detect_gpu() includes compute_cap in the returned dict for NVIDIA."""
+    result = _nvidia_detect_result("NVIDIA GeForce GTX 980", 4096, compute_cap=5.2)
+    with patch("subprocess.run", return_value=result):
+        info = detect_gpu()
+    assert info["vendor"] == "nvidia"
+    assert info["compute_cap"] == 5.2
+
+
+def test_detect_gpu_non_nvidia_compute_cap_zero():
+    """detect_gpu() returns compute_cap=0.0 for non-NVIDIA (AMD fallback) paths."""
+    uevent_paths = ["/sys/class/drm/card1/device/uevent"]
+    dev = "/sys/class/drm/card1/device"
+    uevent_data = {
+        "/sys/class/drm/card1/device/uevent": "DRIVER=amdgpu\n",
+        f"{dev}/mem_info_vram_total": str(8 * 1024**3),
+    }
+
+    def fake_open(path, *a, **kw):
+        return mock_open(read_data=uevent_data.get(path, ""))()
+
+    with (
+        patch("subprocess.run", side_effect=FileNotFoundError),
+        patch("hermia.metrics.glob.glob", return_value=uevent_paths),
+        patch("builtins.open", side_effect=fake_open),
+    ):
+        info = detect_gpu()
+
+    assert info["vendor"] == "amd"
+    assert info["compute_cap"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_screens_pilot.py
+++ b/tests/unit/test_screens_pilot.py
@@ -20,6 +20,7 @@ GPU_FOUND = {
     "vendor": "nvidia",
     "vram_total_gb": 24.0,
     "vram_used_gb": 0.5,
+    "compute_cap": 8.9,
 }
 
 GPU_NOT_FOUND = {"found": False}
@@ -510,4 +511,46 @@ def test_runner_screen_fleet_subtitle(monkeypatch) -> None:
                 await pilot.pause()
                 assert "FLEET" in pilot.app.sub_title
                 assert "m3pro" in pilot.app.sub_title
+    asyncio.run(_inner())
+
+
+# ── NVIDIA compute capability warning (hermia-klc) ───────────────────────────
+
+def test_selection_screen_old_nvidia_shows_warning() -> None:
+    gpu_info = {
+        "found": True, "vendor": "nvidia", "card": "GTX 980",
+        "vram_total_gb": 4.0, "compute_cap": 5.2,
+    }
+    async def _inner() -> None:
+        async with _make_test_app(gpu_info=gpu_info).run_test() as pilot:
+            await pilot.pause()
+            label = pilot.app.screen.query_one("#gpu-info", Label)
+            assert "⚠" in str(label.render())
+            assert "sm 5.2" in str(label.render())
+    asyncio.run(_inner())
+
+
+def test_selection_screen_new_nvidia_no_warning() -> None:
+    gpu_info = {
+        "found": True, "vendor": "nvidia", "card": "RTX 4090",
+        "vram_total_gb": 24.0, "compute_cap": 8.9,
+    }
+    async def _inner() -> None:
+        async with _make_test_app(gpu_info=gpu_info).run_test() as pilot:
+            await pilot.pause()
+            label = pilot.app.screen.query_one("#gpu-info", Label)
+            assert "⚠" not in str(label.render())
+    asyncio.run(_inner())
+
+
+def test_selection_screen_non_nvidia_no_warning() -> None:
+    gpu_info = {
+        "found": True, "vendor": "amd", "card": "RX 7800 XT",
+        "vram_total_gb": 16.0, "compute_cap": 0.0,
+    }
+    async def _inner() -> None:
+        async with _make_test_app(gpu_info=gpu_info).run_test() as pilot:
+            await pilot.pause()
+            label = pilot.app.screen.query_one("#gpu-info", Label)
+            assert "⚠" not in str(label.render())
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary

- Adds a visible `⚠ sm X.Y — Ollama may fall back to CPU (requires sm 6.0+)` warning on the SelectionScreen GPU label when Hermia detects NVIDIA compute capability < 6.0 (Maxwell / Kepler)
- `_detect_nvidia()` now fetches `compute_cap` from nvidia-smi alongside name and VRAM; returns `0.0` gracefully if absent
- `detect_gpu()` includes `compute_cap: float` in the returned dict for all vendors (0.0 for non-NVIDIA)
- `_NVIDIA_MIN_SUPPORTED_COMPUTE = 6.0` module constant for easy future adjustment
- Warning is silent for sm 6.0+ cards, non-NVIDIA vendors, and when compute_cap is unavailable

Discovered during real-world smoke test: GTX 980 (sm 5.2) on the gateway caused Ollama 0.22.1 to crash on model load under CUDA 12.2 driver — zero user-visible indication in Hermia.

## Test plan

- [ ] 7 new tests (4 metrics unit, 3 SelectionScreen Pilot): old NVIDIA shows warning, new NVIDIA silent, AMD silent
- [ ] All 525 tests pass, 90% branch coverage, ruff + mypy clean
- [ ] Visually verify warning text on a real sm 5.2 machine once gateway Ollama is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)