### PR TITLE
hermia-bo1: Ollama security posture checks (CVE-2026-7482 / CVE-2026-5757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ The tool steals answers from the Oracle and tells you which one to trust.
 
 ---
 
+## Security
+
+Hermia communicates with Ollama via `/api/tags`, `/api/generate`, and `/api/ps`.
+It never uploads model files and is not affected by model-upload CVEs
+(CVE-2026-7482, CVE-2026-5757).
+
+**Protect your Ollama instance:**
+
+- Run Ollama bound to `127.0.0.1` (the default) — never expose port 11434 publicly
+- Keep Ollama upgraded; 0.17.1+ patches CVE-2026-7482 (CVSS 9.1, heap memory
+  disclosure via crafted GGUF upload, nicknamed "Bleeding Llama")
+- CVE-2026-5757 (same attack class, no upstream patch as of May 2026) — restrict
+  `/api/create` access at the network or firewall layer
+- Fleet deployments: use `hermia-fleet.yaml` `auth` blocks or a Tailscale overlay
+  to prevent unauthenticated access to remote Ollama endpoints
+
+Hermia surfaces known Ollama version vulnerabilities at run time in the preflight
+log as `SEC ⚠` warnings.
+
+---
+
 ## Contributing
 
 Contributions welcome. Please read [AGENTS.md](AGENTS.md) before opening a PR — it covers

--- a/analysis/hermia-bo1-spec.md
+++ b/analysis/hermia-bo1-spec.md
@@ -1,0 +1,191 @@
+# hermia-bo1 — Ollama security posture checks (v1)
+
+## What this bead does
+
+Hermia is a security evaluation tool. It should surface known Ollama security
+issues at run time, not silently evaluate against a vulnerable server. This is
+the first iteration of an ongoing security-check subsystem (hermia-co9 tracks
+the backlog).
+
+## v1 scope — two checks
+
+### Check 1: CVE-2026-7482 version gate (CVSS 9.1, "Bleeding Llama")
+- Fixed in Ollama 0.17.1
+- Attack: unauthenticated POST to `/api/create` with crafted GGUF → heap OOB
+  read → exfiltrates env vars, API keys, system prompts, peer session data via
+  `/api/push`
+- Action: query `/api/version`, warn if version < 0.17.1
+- Warning text: `SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable
+  to heap memory disclosure — upgrade to 0.17.1+`
+
+### Check 2: CVE-2026-5757 advisory (no patch)
+- No fixed version — architectural issue in GGUF model loader
+- Same attack class as 7482 (crafted GGUF → heap leak) but no upstream fix
+- Action: always emit advisory if Ollama is reachable and running in local mode
+  (fleet mode may have auth; local mode is the exposed case)
+- Warning text: `SEC ⚠ CVE-2026-5757 (no patch): Ollama model upload endpoint
+  is unpatched — restrict /api/create to localhost or trusted networks`
+
+Both warnings are surfaced in the TUI run log alongside existing preflight
+output. In fleet mode, Check 2 is omitted (assume operator controls access).
+
+## Changes
+
+### `src/hermia/preflight.py`
+
+Add constant:
+```python
+OLLAMA_MIN_SECURE_VERSION = "0.17.1"
+```
+
+Add function:
+```python
+def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
+    """Query /api/version and return security warning strings. Never raises."""
+    ...
+```
+
+Returns a list of zero or more warning strings (empty = no issues found).
+
+Version check logic:
+```python
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse 'X.Y.Z' → (X, Y, Z). Returns (0,) on parse failure."""
+    try:
+        return tuple(int(x) for x in v.split(".")[:3])
+    except (ValueError, AttributeError):
+        return (0,)
+
+def _min_secure() -> tuple[int, ...]:
+    return _parse_version(OLLAMA_MIN_SECURE_VERSION)
+```
+
+Implementation:
+```python
+def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
+    import requests
+    warnings: list[str] = []
+    try:
+        resp = requests.get(f"{host}/api/version", timeout=3)
+        if resp.ok:
+            ver = resp.json().get("version", "")
+            if ver and _parse_version(ver) < _min_secure():
+                warnings.append(
+                    f"SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable "
+                    f"to heap memory disclosure — upgrade to {OLLAMA_MIN_SECURE_VERSION}+"
+                )
+    except Exception:  # noqa: BLE001
+        pass  # offline or non-Ollama endpoint — skip silently
+
+    if not fleet_mode:
+        warnings.append(
+            "SEC ⚠ CVE-2026-5757 (no patch): Ollama model upload endpoint is "
+            "unpatched — restrict /api/create to localhost or trusted networks"
+        )
+    return warnings
+```
+
+Add `security_warnings: list[str]` field to `PreflightReport`:
+```python
+@dataclass
+class PreflightReport:
+    ...
+    security_warnings: list[str] = field(default_factory=list)
+
+    @property
+    def warnings(self) -> list[str]:
+        # existing model/disk warnings unchanged
+        ...
+```
+
+Note: `security_warnings` is a separate field, NOT merged into `warnings`.
+`screens.py` handles them separately so they can be styled distinctly.
+
+Update `run_preflight()`:
+```python
+def run_preflight(...) -> PreflightReport:
+    ...
+    host = _normalize_host(os.environ.get("HERMIA_HOST", "http://localhost:11434"))
+    sec = check_ollama_security(host, fleet_mode=fleet_mode)
+    return PreflightReport(
+        ...,
+        security_warnings=sec,
+    )
+```
+
+Import `os` at top of `preflight.py`. Add a small helper:
+```python
+def _normalize_host(host: str) -> str:
+    host = host.rstrip("/")
+    return host if "://" in host else f"http://{host}"
+```
+(Do NOT import from `runner.py` — avoid circular dependency.)
+
+### `src/hermia/screens.py`
+
+After the existing `for w in pf.warnings:` block (~line 283), add:
+```python
+for sw in pf.security_warnings:
+    append_log(f"  {sw}", "warn")
+```
+
+### `README.md`
+
+Add a `## Security` section after the existing feature list, before the
+Getting Started link. Content:
+
+```markdown
+## Security
+
+Hermia communicates with Ollama over HTTP/HTTPS and never uploads model files.
+It is not affected by model-upload CVEs (CVE-2026-7482, CVE-2026-5757).
+
+**Protect your Ollama instance:**
+- Run Ollama bound to `127.0.0.1` (default) or behind a firewall — never
+  expose port 11434 publicly
+- Keep Ollama upgraded; 0.17.1+ patches CVE-2026-7482 (CVSS 9.1, heap memory
+  disclosure via crafted model upload)
+- CVE-2026-5757 (heap OOB read, no upstream patch as of May 2026) — restrict
+  `/api/create` access at the network layer
+- Fleet deployments: use `hermia-fleet.yaml` auth blocks or a Tailscale overlay
+  to prevent unauthenticated access to remote Ollama endpoints
+
+Hermia surfaces known version-level vulnerabilities at run time in the preflight
+log as `SEC ⚠` warnings.
+```
+
+## Permitted scope
+
+- `src/hermia/preflight.py`
+- `src/hermia/screens.py`
+- `README.md`
+- `tests/unit/test_preflight.py`
+
+## Acceptance criteria
+
+1. `check_ollama_security()` returns CVE-2026-7482 warning when version < 0.17.1
+2. No CVE-2026-7482 warning when version >= 0.17.1
+3. CVE-2026-5757 advisory always appears in local mode; absent in fleet mode
+4. Version parse failure (non-Ollama endpoint, offline) → silently returns []
+   (or just the CVE-2026-5757 advisory in local mode — no crash, no CVE-7482 warning)
+5. `PreflightReport.security_warnings` populated from `run_preflight()`
+6. TUI displays `SEC ⚠` lines in warn style
+7. README Security section present
+8. Unit tests:
+   - `test_ollama_security_vulnerable_version` — mock `/api/version` → "0.16.0" → CVE-7482 warning present
+   - `test_ollama_security_patched_version` — mock → "0.17.1" → no CVE-7482 warning
+   - `test_ollama_security_newer_version` — mock → "0.22.1" → no CVE-7482 warning
+   - `test_ollama_security_version_unreachable` — requests raises → returns list with only CVE-5757 advisory (local mode)
+   - `test_ollama_security_fleet_mode_no_5757` — fleet_mode=True → CVE-5757 advisory absent
+   - `test_preflight_report_security_warnings_populated` — `run_preflight()` calls `check_ollama_security()`
+
+## Estimate
+
+0.5 days
+
+## Why
+
+Hermia is a security evaluation tool. Running it against a CVE-vulnerable Ollama
+and not saying anything would be a credibility problem. The `SEC ⚠` prefix
+establishes a convention for the hermia-co9 backlog (bind address check, model
+provenance, auth enforcement) to follow.

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -38,10 +38,21 @@ def _normalize_host(host: str) -> str:
 
 
 def _parse_version(v: str) -> tuple[int, ...] | None:
-    """Parse 'X.Y.Z[-suffix]' → (X, Y, Z). Returns None on failure."""
+    """Parse 'vX.Y.Z[-pre][+build]' → (X, Y, Z, release_flag). Returns None on failure.
+
+    release_flag is 1 for release versions and 0 for pre-releases, so that
+    0.17.1-rc1 < 0.17.1 in tuple comparison (pre-release of the fix is still vulnerable).
+    Handles leading 'v' prefix and SemVer build metadata (+build.123).
+    """
     try:
-        base = v.split("-")[0] if v else ""
-        return tuple(int(x) for x in base.split(".")[:3])
+        v = v.lstrip("v") if v else ""
+        has_prerelease = "-" in v
+        base = v.split("-")[0].split("+")[0]
+        parts = [int(x) for x in base.split(".")[:3]]
+        while len(parts) < 3:
+            parts.append(0)
+        parts.append(0 if has_prerelease else 1)
+        return tuple(parts)
     except (ValueError, AttributeError):
         return None
 

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -66,10 +66,9 @@ _MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = (
 
 def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
     """Query /api/version and return SEC warning strings. Never raises."""
-    import requests  # local import — optional network check, avoid startup overhead
-
     warnings: list[str] = []
     try:
+        import requests  # local import — optional network check, avoid startup overhead
         resp = requests.get(f"{host}/api/version", timeout=3)
         if resp.ok:
             ver = resp.json().get("version", "")

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -58,7 +58,9 @@ def _parse_version(v: str) -> tuple[int, ...] | None:
 
 
 _parsed_min = _parse_version(OLLAMA_MIN_SECURE_VERSION)
-_MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = _parsed_min if _parsed_min is not None else (0, 17, 1)
+_MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = (
+    _parsed_min if _parsed_min is not None else (0, 17, 1, 1)
+)
 
 
 def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -12,6 +12,7 @@ from hermia.metrics import get_gpu_stats
 VRAM_OVERHEAD_GB = 0.75  # headroom reserved for Ollama runtime
 RAM_LOAD_MULTIPLIER = 1.5  # approximate RAM needed for CPU-only inference
 MIN_DISK_FREE_GB = 0.5
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 OLLAMA_MIN_SECURE_VERSION = "0.17.1"  # fixes CVE-2026-7482 (CVSS 9.1, "Bleeding Llama")
 
 # Models confirmed incompatible with Ollama's Vulkan backend on gfx900 (Vega 64).
@@ -46,7 +47,7 @@ def _parse_version(v: str) -> tuple[int, ...] | None:
     """
     try:
         v = v.lstrip("v") if v else ""
-        has_prerelease = "-" in v
+        has_prerelease = "-" in v.split("+")[0]
         base = v.split("-")[0].split("+")[0]
         parts = [int(x) for x in base.split(".")[:3]]
         while len(parts) < 3:
@@ -193,7 +194,7 @@ def run_preflight(
             reason=reason,
         ))
 
-    host = _normalize_host(os.environ.get("HERMIA_HOST", "http://localhost:11434"))
+    host = _normalize_host(os.environ.get("HERMIA_HOST", DEFAULT_OLLAMA_HOST))
     sec = check_ollama_security(host, fleet_mode=fleet_mode)
 
     return PreflightReport(

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -37,16 +37,17 @@ def _normalize_host(host: str) -> str:
     return host if "://" in host else f"http://{host}"
 
 
-def _parse_version(v: str) -> tuple[int, ...]:
-    """Parse 'X.Y.Z[-suffix]' → (X, Y, Z). Returns (0,) on failure."""
+def _parse_version(v: str) -> tuple[int, ...] | None:
+    """Parse 'X.Y.Z[-suffix]' → (X, Y, Z). Returns None on failure."""
     try:
         base = v.split("-")[0] if v else ""
         return tuple(int(x) for x in base.split(".")[:3])
     except (ValueError, AttributeError):
-        return (0,)
+        return None
 
 
-_MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = _parse_version(OLLAMA_MIN_SECURE_VERSION)
+_parsed_min = _parse_version(OLLAMA_MIN_SECURE_VERSION)
+_MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = _parsed_min if _parsed_min is not None else (0, 17, 1)
 
 
 def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
@@ -58,7 +59,8 @@ def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
         resp = requests.get(f"{host}/api/version", timeout=3)
         if resp.ok:
             ver = resp.json().get("version", "")
-            if ver and _parse_version(ver) < _MIN_SECURE_VERSION_TUPLE:
+            v_tuple = _parse_version(ver)
+            if v_tuple is not None and v_tuple < _MIN_SECURE_VERSION_TUPLE:
                 warnings.append(
                     f"SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable "
                     f"to heap memory disclosure — upgrade to {OLLAMA_MIN_SECURE_VERSION}+"

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -1,16 +1,19 @@
-"""Pre-run sanity checks: VRAM, system RAM, and disk space."""
+"""Pre-run sanity checks: VRAM, system RAM, disk space, and Ollama security posture."""
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import psutil
+import requests
 
 from hermia.metrics import get_gpu_stats
 
 VRAM_OVERHEAD_GB = 0.75  # headroom reserved for Ollama runtime
 RAM_LOAD_MULTIPLIER = 1.5  # approximate RAM needed for CPU-only inference
 MIN_DISK_FREE_GB = 0.5
+OLLAMA_MIN_SECURE_VERSION = "0.17.1"  # fixes CVE-2026-7482 (CVSS 9.1, "Bleeding Llama")
 
 # Models confirmed incompatible with Ollama's Vulkan backend on gfx900 (Vega 64).
 # gemma2:9b falls back to CPU silently, produces garbled output, and fails all tests.
@@ -30,6 +33,42 @@ class ModelCheck:
     reason: str = ""
 
 
+def _normalize_host(host: str) -> str:
+    host = host.rstrip("/")
+    return host if "://" in host else f"http://{host}"
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse 'X.Y.Z' → (X, Y, Z). Returns (0,) on failure."""
+    try:
+        return tuple(int(x) for x in v.split(".")[:3])
+    except (ValueError, AttributeError):
+        return (0,)
+
+
+def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
+    """Query /api/version and return SEC warning strings. Never raises."""
+    warnings: list[str] = []
+    try:
+        resp = requests.get(f"{host}/api/version", timeout=3)
+        if resp.ok:
+            ver = resp.json().get("version", "")
+            if ver and _parse_version(ver) < _parse_version(OLLAMA_MIN_SECURE_VERSION):
+                warnings.append(
+                    f"SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable "
+                    f"to heap memory disclosure — upgrade to {OLLAMA_MIN_SECURE_VERSION}+"
+                )
+    except Exception:  # noqa: BLE001
+        pass
+
+    if not fleet_mode:
+        warnings.append(
+            "SEC ⚠ CVE-2026-5757 (no patch): Ollama model upload endpoint is "
+            "unpatched — restrict /api/create to localhost or trusted networks"
+        )
+    return warnings
+
+
 @dataclass
 class PreflightReport:
     vram_total_gb: float
@@ -40,6 +79,7 @@ class PreflightReport:
     disk_free_gb: float
     disk_ok: bool
     models: list[ModelCheck] = field(default_factory=list)
+    security_warnings: list[str] = field(default_factory=list)
 
     @property
     def runnable_models(self) -> list[str]:
@@ -133,6 +173,9 @@ def run_preflight(
             reason=reason,
         ))
 
+    host = _normalize_host(os.environ.get("HERMIA_HOST", "http://localhost:11434"))
+    sec = check_ollama_security(host, fleet_mode=fleet_mode)
+
     return PreflightReport(
         vram_total_gb=vram_total,
         vram_used_gb=vram_used,
@@ -142,4 +185,5 @@ def run_preflight(
         disk_free_gb=disk_free_gb,
         disk_ok=disk_free_gb >= MIN_DISK_FREE_GB,
         models=checks,
+        security_warnings=sec,
     )

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import psutil
-import requests
 
 from hermia.metrics import get_gpu_stats
 
@@ -39,21 +38,27 @@ def _normalize_host(host: str) -> str:
 
 
 def _parse_version(v: str) -> tuple[int, ...]:
-    """Parse 'X.Y.Z' → (X, Y, Z). Returns (0,) on failure."""
+    """Parse 'X.Y.Z[-suffix]' → (X, Y, Z). Returns (0,) on failure."""
     try:
-        return tuple(int(x) for x in v.split(".")[:3])
+        base = v.split("-")[0] if v else ""
+        return tuple(int(x) for x in base.split(".")[:3])
     except (ValueError, AttributeError):
         return (0,)
 
 
+_MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = _parse_version(OLLAMA_MIN_SECURE_VERSION)
+
+
 def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
     """Query /api/version and return SEC warning strings. Never raises."""
+    import requests  # local import — optional network check, avoid startup overhead
+
     warnings: list[str] = []
     try:
         resp = requests.get(f"{host}/api/version", timeout=3)
         if resp.ok:
             ver = resp.json().get("version", "")
-            if ver and _parse_version(ver) < _parse_version(OLLAMA_MIN_SECURE_VERSION):
+            if ver and _parse_version(ver) < _MIN_SECURE_VERSION_TUPLE:
                 warnings.append(
                     f"SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable "
                     f"to heap memory disclosure — upgrade to {OLLAMA_MIN_SECURE_VERSION}+"

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -283,6 +283,8 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         for w in pf.warnings:
             style = "fail" if w.startswith("SKIP") or w.startswith("Low disk") else "warn"
             append_log(f"  {w}", style)
+        for sw in pf.security_warnings:
+            append_log(f"  {sw}", "warn")
 
         runnable = pf.runnable_models
         if not runnable:

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -18,7 +18,7 @@ from textual.widgets import Button, Checkbox, Footer, Header, Label, ProgressBar
 
 from hermia import robustness
 from hermia.metrics import NVIDIA_MIN_SUPPORTED_COMPUTE, MetricsSampler
-from hermia.preflight import run_preflight
+from hermia.preflight import DEFAULT_OLLAMA_HOST, run_preflight
 from hermia.results import append_result, open_run, patch_results
 from hermia.runner import (
     get_model_size_gb,
@@ -45,7 +45,7 @@ def _resolve_fleet_host(host_url: str) -> tuple[str, str | None]:
 def _get_subtitle(fleet_mode: bool) -> str:
     if not fleet_mode:
         return "LOCAL"
-    host_url = os.environ.get("HERMIA_HOST", "http://localhost:11434")
+    host_url = os.environ.get("HERMIA_HOST", DEFAULT_OLLAMA_HOST)
     _, hostname = _resolve_fleet_host(host_url)
     return f"FLEET  {host_url}" + (f"  → {hostname}" if hostname else "")
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -103,7 +103,7 @@ def _mock_version(version: str):
     resp = MagicMock()
     resp.ok = True
     resp.json.return_value = {"version": version}
-    return patch("hermia.preflight.requests.get", return_value=resp)
+    return patch("requests.get", return_value=resp)
 
 
 def test_ollama_security_vulnerable_version():
@@ -126,7 +126,7 @@ def test_ollama_security_newer_version():
 
 
 def test_ollama_security_version_unreachable():
-    with patch("hermia.preflight.requests.get", side_effect=Exception("connection refused")):
+    with patch("requests.get", side_effect=Exception("connection refused")):
         warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
     assert not any("CVE-2026-7482" in w for w in warns)
     assert any("CVE-2026-5757" in w for w in warns)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -113,6 +113,24 @@ def test_ollama_security_vulnerable_version():
     assert any("0.16.0" in w for w in warns)
 
 
+def test_ollama_security_prerelease_of_fix_is_vulnerable():
+    with _mock_version("0.17.1-rc1"):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert any("CVE-2026-7482" in w for w in warns)
+
+
+def test_ollama_security_v_prefix_handled():
+    with _mock_version("v0.22.1"):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert not any("CVE-2026-7482" in w for w in warns)
+
+
+def test_ollama_security_build_metadata_handled():
+    with _mock_version("0.22.1+build.123"):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert not any("CVE-2026-7482" in w for w in warns)
+
+
 def test_ollama_security_patched_version():
     with _mock_version(OLLAMA_MIN_SECURE_VERSION):
         warns = check_ollama_security("http://localhost:11434", fleet_mode=False)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,9 +1,9 @@
 """Unit tests for preflight sanity checks."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from hermia.preflight import run_preflight
+from hermia.preflight import OLLAMA_MIN_SECURE_VERSION, check_ollama_security, run_preflight
 
 MODEL_LIST = [
     {"name": "llama3:8b", "size": int(4.7 * 1024**3)},
@@ -93,3 +93,58 @@ def test_all_models_runnable_no_warnings(tmp_path: Path):
     with _mock_gpu(total=8.0, used=0.0), _mock_ram(available_gb=12.0), _mock_disk():
         report = run_preflight(["llama3:8b", "phi3:3.8b"], MODEL_LIST, tmp_path)
     assert not report.skipped_models
+
+
+# ---------------------------------------------------------------------------
+# Ollama security checks
+# ---------------------------------------------------------------------------
+
+def _mock_version(version: str):
+    resp = MagicMock()
+    resp.ok = True
+    resp.json.return_value = {"version": version}
+    return patch("hermia.preflight.requests.get", return_value=resp)
+
+
+def test_ollama_security_vulnerable_version():
+    with _mock_version("0.16.0"):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert any("CVE-2026-7482" in w for w in warns)
+    assert any("0.16.0" in w for w in warns)
+
+
+def test_ollama_security_patched_version():
+    with _mock_version(OLLAMA_MIN_SECURE_VERSION):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert not any("CVE-2026-7482" in w for w in warns)
+
+
+def test_ollama_security_newer_version():
+    with _mock_version("0.22.1"):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert not any("CVE-2026-7482" in w for w in warns)
+
+
+def test_ollama_security_version_unreachable():
+    with patch("hermia.preflight.requests.get", side_effect=Exception("connection refused")):
+        warns = check_ollama_security("http://localhost:11434", fleet_mode=False)
+    assert not any("CVE-2026-7482" in w for w in warns)
+    assert any("CVE-2026-5757" in w for w in warns)
+
+
+def test_ollama_security_fleet_mode_no_5757():
+    with _mock_version("0.22.1"):
+        warns = check_ollama_security("http://remotehost:11434", fleet_mode=True)
+    assert not any("CVE-2026-5757" in w for w in warns)
+
+
+def test_preflight_report_security_warnings_populated(tmp_path: Path):
+    with (
+        _mock_gpu(),
+        _mock_ram(),
+        _mock_disk(),
+        _mock_version("0.16.0"),
+    ):
+        report = run_preflight(["llama3:8b"], MODEL_LIST, tmp_path, fleet_mode=False)
+    assert any("CVE-2026-7482" in w for w in report.security_warnings)
+    assert any("CVE-2026-5757" in w for w in report.security_warnings)


### PR DESCRIPTION
## Summary

- Adds `SEC ⚠` preflight warnings for known Ollama vulnerabilities surfaced at run time in the TUI log
- **CVE-2026-7482** (CVSS 9.1, "Bleeding Llama"): warns if Ollama version < 0.17.1; fixed in that release; unauthenticated heap memory disclosure via crafted GGUF upload
- **CVE-2026-5757** (no upstream patch): advisory always shown in local mode, suppressed in fleet mode where operator controls access
- README `## Security` section: exposure guidance, version recommendation, fleet auth reference
- Establishes `SEC ⚠` prefix convention for the hermia-co9 backlog (bind address check, model provenance, auth enforcement)

Hermia itself is not the attack vector for either CVE — it never calls `/api/create` or `/api/push`. The warnings inform users about the security posture of the Ollama instance they're evaluating against.

## Test plan

- [ ] 6 new unit tests in `test_preflight.py`: vulnerable version, patched, newer, unreachable, fleet mode suppression, `run_preflight()` integration
- [ ] 531 tests total, 90% branch coverage
- [ ] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)