### PR TITLE
fix: restore internal-ssh-alias gitleaks rule after history purge

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -38,7 +38,7 @@ tags        = ["internal-ip", "docker"]
 [[rules]]
 id          = "internal-ssh-alias"
 description = "Original internal SSH host aliases — catch if accidentally re-introduced"
-regex       = '''\b(m3pro|m1pro|openclaw|m3pro-work|m1pro-personal|openclaw-linux)\b'''
+regex       = '''\b(m3pro-work|m3pro|m1pro-personal|m1pro|openclaw-linux|openclaw)\b'''
 tags        = ["internal-hostname", "ssh"]
 
 [[rules]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,8 +37,8 @@ tags        = ["internal-ip", "docker"]
 
 [[rules]]
 id          = "internal-ssh-alias"
-description = "Known internal SSH host aliases"
-regex       = '''\b(node1|node2|node3|node1-work|node2-personal|node3-linux)\b'''
+description = "Original internal SSH host aliases — catch if accidentally re-introduced"
+regex       = '''\b(m3pro|m1pro|openclaw)\b'''
 tags        = ["internal-hostname", "ssh"]
 
 [[rules]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -38,7 +38,7 @@ tags        = ["internal-ip", "docker"]
 [[rules]]
 id          = "internal-ssh-alias"
 description = "Original internal SSH host aliases — catch if accidentally re-introduced"
-regex       = '''\b(m3pro|m1pro|openclaw)\b'''
+regex       = '''\b(m3pro|m1pro|openclaw|m3pro-work|m1pro-personal|openclaw-linux)\b'''
 tags        = ["internal-hostname", "ssh"]
 
 [[rules]]


### PR DESCRIPTION
## Summary

- \`filter-repo --replace-text\` rewrote the gitleaks rule's own regex during the history purge, changing the original internal alias names (\`m3pro\`, \`m1pro\`, \`openclaw\`) to their sanitized placeholders (\`node1\`, \`node2\`, \`node3\`)
- This caused the rule to catch the placeholder names instead of the originals — any PR touching test fixtures or docs would fail CI
- Restored the regex to match the original aliases so the rule fires if they are accidentally re-introduced

## Test plan
- [ ] Pre-commit hooks pass (already confirmed locally)
- [ ] CI gitleaks job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)