### PR TITLE
chore: fleet config, github-actions dependabot, gitleaks fleet allowlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: quarterly
+    open-pull-requests-limit: 5

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -92,4 +92,6 @@ paths = [
     "uv.lock",
     # detect-secrets baseline records false-positives as JSON — not real secrets
     ".secrets.baseline",
+    # Fleet config — intentionally contains fleet node IPs (Tailscale) and hostnames
+    "hermia-fleet.yaml",
 ]

--- a/hermia-fleet.yaml
+++ b/hermia-fleet.yaml
@@ -1,0 +1,27 @@
+fleet:
+  - name: openclaw
+    host: http://localhost:11440
+    models:
+      - llama3.2:latest
+      - phi3:3.8b
+      - mistral:7b
+      - qwen2.5:7b
+      - qwen2.5-coder:7b
+      - llama3:8b
+      - gemma2:9b
+      - qwen3:8b
+
+  - name: m3pro
+    host: http://localhost:11450
+
+  - name: m1pro
+    host: http://localhost:11410
+
+  - name: erics-5090
+    host: http://100.71.60.30:11434
+    models:
+      - qwen3:8b-q8_0
+      - qwen3:32b
+      - qwen2.5:32b-instruct-q6_K
+      - qwen3-coder:30b-a3b-q8_0
+      - qwen2.5:72b


### PR DESCRIPTION
## Summary

- `hermia-fleet.yaml`: adds `erics-5090` (RTX 5090, Tailscale 100.71.60.30) with curated model allowlist — enables the CUDA vs Metal fleet demo for the talk
- `.github/dependabot.yml`: adds `github-actions` ecosystem on quarterly schedule so action SHA pins stay current
- `.gitleaks.toml`: allowlists `hermia-fleet.yaml` — the file is intentionally full of fleet node IPs; blocking it defeats its purpose

## Test plan
- [ ] CI passes (ruff, mypy, pytest, gitleaks, trivy, bandit)
- [ ] Gemini review clean
- [ ] Confirm `erics-5090` reachable at 100.71.60.30:11434 before demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)