### PR TITLE
chore: add PyPI publish metadata and workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,36 @@ on:
       - "v*.*.*"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check src/ tests/
+
+      - name: Type check (mypy)
+        run: mypy src/
+
+      - name: Test (pytest)
+        run: pytest tests/
+
   build-and-publish:
+    needs: test
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
 
     steps:
@@ -20,7 +46,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install build
-        run: pip install build
+        run: pip install build==1.5.0
 
       - name: Build
         run: python -m build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc3e469d42c11b08f7a2ded924853a785f3  # v1.12.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,5 +27,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc3e469d42c11b08f7a2ded924853a785f3  # v1.12.4
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/scottblydotcom/hermia"
-Repository = "https://github.com/scottblydotcom/hermia"
 Documentation = "https://github.com/scottblydotcom/hermia/blob/main/docs/usage.md"
 "Bug Tracker" = "https://github.com/scottblydotcom/hermia/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description = "Interactive LLM agentic evaluation TUI for local and cloud models
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
+authors = [
+    { name = "Scott Bly", email = "scottbly1@gmail.com" },
+]
 keywords = ["llm", "security", "evaluation", "ollama", "red-team", "inference", "tui"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -16,7 +19,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -34,6 +38,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/scottblydotcom/hermia"
 Repository = "https://github.com/scottblydotcom/hermia"
+Documentation = "https://github.com/scottblydotcom/hermia/blob/main/docs/usage.md"
 "Bug Tracker" = "https://github.com/scottblydotcom/hermia/issues"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,35 @@ build-backend = "hatchling.build"
 name = "hermia"
 version = "0.1.1"
 description = "Interactive LLM agentic evaluation TUI for local and cloud models"
+readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
+keywords = ["llm", "security", "evaluation", "ollama", "red-team", "inference", "tui"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Security",
+    "Topic :: Software Development :: Testing",
+]
 dependencies = [
     "textual>=0.80.0",
     "requests>=2.32.0",
     "psutil>=6.0.0",
     "pyyaml>=6.0.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/scottblydotcom/hermia"
+Repository = "https://github.com/scottblydotcom/hermia"
+"Bug Tracker" = "https://github.com/scottblydotcom/hermia/issues"
 
 [project.optional-dependencies]
 grafana = [


### PR DESCRIPTION
## Summary

- Adds `readme`, `keywords`, `classifiers`, `authors`, and `[project.urls]` to `pyproject.toml` so the package page on PyPI renders correctly
- Adds `.github/workflows/publish.yml` — triggers on any `v*.*.*` tag push; runs full lint/type/test gate before building and publishing via OIDC trusted publisher (no API token required)

## To publish after merge

```bash
git tag v0.1.1
git push origin v0.1.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)