### PR TITLE
fix: correct pypa/gh-action-pypi-publish SHA for v1.12.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,4 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc3e469d42c11b08f7a2ded924853a785f3  # v1.12.4
+        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011  # v1.12.4


### PR DESCRIPTION
Previous SHA (`76f52bc3...`) doesn't exist in the `pypa/gh-action-pypi-publish` repo — resolved via GitHub API to the correct hash for v1.12.4.

After merging: delete and recreate the `v0.1.1` tag to retrigger publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)