### PR TITLE
docs: PyPI launch cleanup — install instructions + workflow fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
+        # SHA pinning not supported: pypa/gh-action-pypi-publish is a Docker container action;
+        # GHCR does not publish images tagged by commit SHA. release/v1 is the pypa-maintained stable ref.
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,4 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011  # v1.12.4
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -127,8 +127,13 @@ targets via `--host`; running Hermia itself on Windows is not yet supported.
 ## Install
 
 ```bash
-pipx install hermia  # recommended for CLI tools
-# or: pip install hermia
+pipx install hermia
+```
+
+Or with pip:
+
+```bash
+pip install hermia
 ```
 
 Or from source:
@@ -184,7 +189,7 @@ analysis pipeline are all shipping. The security pipeline (gitleaks, trivy, band
 pip-audit, ruff, mypy) is more rigorous than a research tool strictly needs to be. That
 was intentional.
 
-Available on [PyPI](https://pypi.org/project/hermia/): `pip install hermia`
+Available on [PyPI](https://pypi.org/project/hermia/): `pipx install hermia`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ targets via `--host`; running Hermia itself on Windows is not yet supported.
 
 ## Install
 
-From source (pre-PyPI):
+```bash
+pip install hermia
+hermia
+```
+
+Or from source:
 
 ```bash
 git clone https://github.com/scottblydotcom/hermia
@@ -134,8 +139,6 @@ cd hermia
 pip install -e .
 hermia
 ```
-
-PyPI publication is on the roadmap. See [project status](#project-status).
 
 ---
 
@@ -181,7 +184,7 @@ analysis pipeline are all shipping. The security pipeline (gitleaks, trivy, band
 pip-audit, ruff, mypy) is more rigorous than a research tool strictly needs to be. That
 was intentional.
 
-PyPI publication is planned after v0.1.0 stabilizes in the wild.
+Available on PyPI: `pip install hermia`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ targets via `--host`; running Hermia itself on Windows is not yet supported.
 
 ```bash
 pip install hermia
-hermia
 ```
 
 Or from source:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ targets via `--host`; running Hermia itself on Windows is not yet supported.
 
 ## Install
 
+Recommended (via pipx):
+
 ```bash
 pipx install hermia
 ```

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ targets via `--host`; running Hermia itself on Windows is not yet supported.
 ## Install
 
 ```bash
-pip install hermia
+pipx install hermia  # recommended for CLI tools
+# or: pip install hermia
 ```
 
 Or from source:
@@ -178,12 +179,12 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 ## Project Status
 
-**v0.1.0** — stable and tested. The core eval suite, fleet mode, audit trail, and findings
+**v0.1.1** — stable and tested. The core eval suite, fleet mode, audit trail, and findings
 analysis pipeline are all shipping. The security pipeline (gitleaks, trivy, bandit,
 pip-audit, ruff, mypy) is more rigorous than a research tool strictly needs to be. That
 was intentional.
 
-Available on PyPI: `pip install hermia`
+Available on [PyPI](https://pypi.org/project/hermia/): `pip install hermia`
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace pre-PyPI source-only install block with `pip install hermia` as the primary path; keep from-source as a secondary option
- Remove two \"PyPI publication is on the roadmap\" notes — it shipped
- Fix `publish.yml` to use `pypa/gh-action-pypi-publish@release/v1` (SHA pinning doesn't work for Docker container actions; this is what actually made the publish succeed)

## Test plan

- [ ] README renders correctly on GitHub
- [ ] `publish.yml` matches the working version that produced the live PyPI release

🤖 Generated with [Claude Code](https://claude.com/claude-code)