### PR TITLE
docs: remove redundant hermia launch command from source install block

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Or from source:
 git clone https://github.com/scottblydotcom/hermia
 cd hermia
 pip install -e .
-hermia
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Remove `hermia` from the from-source install block — Quickstart section covers launching the tool

Caught in Opus review of PR #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)