### PR TITLE
fix(tests): guard RunnerScreen poll loops against NoMatches race

### DIFF
--- a/tests/unit/test_screens_pilot.py
+++ b/tests/unit/test_screens_pilot.py
@@ -351,7 +351,10 @@ def test_run_evals_happy_path(tmp_path: Path) -> None:
                 summary = ""
                 for _ in range(30):
                     await pilot.pause(delay=0.1)
-                    summary = str(pilot.app.screen.query_one("#summary-content").render())
+                    try:
+                        summary = str(pilot.app.screen.query_one("#summary-content").render())
+                    except NoMatches:
+                        continue
                     if "EVAL SUMMARY" in summary:
                         break
 

--- a/tests/unit/test_screens_pilot.py
+++ b/tests/unit/test_screens_pilot.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from textual.app import App
+from textual.css.query import NoMatches
 from textual.widgets import Checkbox, Label, ProgressBar, Static
 
 from hermia.preflight import ModelCheck, PreflightReport
@@ -381,7 +382,10 @@ def test_run_evals_no_runnable_models(tmp_path: Path) -> None:
                 log_content = ""
                 for _ in range(30):
                     await pilot.pause(delay=0.1)
-                    log_content = str(pilot.app.screen.query_one("#log-content").render())
+                    try:
+                        log_content = str(pilot.app.screen.query_one("#log-content").render())
+                    except NoMatches:
+                        continue
                     if "No models can run" in log_content:
                         break
 
@@ -416,7 +420,10 @@ def test_run_evals_skipped_model_logged(tmp_path: Path) -> None:
                 log_content = ""
                 for _ in range(30):
                     await pilot.pause(delay=0.1)
-                    log_content = str(pilot.app.screen.query_one("#log-content").render())
+                    try:
+                        log_content = str(pilot.app.screen.query_one("#log-content").render())
+                    except NoMatches:
+                        continue
                     if "Skipping" in log_content:
                         break
 


### PR DESCRIPTION
## Summary
- `_RunnerDirectApp.on_mount()` calls `push_screen(RunnerScreen(...))`, which is async — the `RunnerScreen` may not be fully composed when the first `pilot.pause()` fires, causing `query_one("#log-content")` to raise `NoMatches` intermittently.
- Wrapped both `#log-content` poll loops (`test_run_evals_no_runnable_models`, `test_run_evals_skipped_model_logged`) in `try/except NoMatches: continue` so the loop retries after the next pause instead of crashing.

## Test plan
- [x] `pytest tests/unit/test_screens_pilot.py::test_run_evals_skipped_model_logged tests/unit/test_screens_pilot.py::test_run_evals_no_runnable_models -v` — both pass
- [x] Full suite: `pytest tests/` — 737 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)