### PR TITLE
chore: bump version to v0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermia"
-version = "0.1.1"
+version = "0.1.2"
 description = "Interactive LLM agentic evaluation TUI for local and cloud models"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Patch release — 5 commits since v0.1.1:

- fix(tests): rework classification-routing into fair adversarial probe (#71)
- fix(tests): guard RunnerScreen poll loops against NoMatches race (#70)
- docs: remove redundant install block (#69)
- docs: PyPI launch cleanup (#68)
- fix: correct pypa/gh-action-pypi-publish SHA (#67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)