### PR TITLE
fix(screens): guard call_from_thread+query_one pairs against mount race

### DIFF
--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -258,6 +258,25 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
     def action_go_back(self) -> None:
         self.app.pop_screen()
 
+    # ── Thread-safe UI helpers (called via call_from_thread) ─────────────────
+    def _safe_update_log(self, content: str) -> None:
+        try:
+            self.query_one("#log-content", Static).update(content)
+        except NoMatches:
+            pass
+
+    def _safe_advance_progress(self) -> None:
+        try:
+            self.query_one(ProgressBar).advance(1)
+        except NoMatches:
+            pass
+
+    def _safe_update_summary(self, text: str) -> None:
+        try:
+            self.query_one("#summary-content", Static).update(text)
+        except NoMatches:
+            pass
+
     @work(thread=True)
     def run_evals(self) -> None:
         tests = load_tests(self.test_ids)
@@ -268,14 +287,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         def append_log(line: str, style: str = "") -> None:
             log_lines.append((line, style))
             content = "\n".join(f"[{s}]{ln}[/{s}]" if s else ln for ln, s in log_lines[-100:])
-
-            def _update_log(c: str = content) -> None:
-                try:
-                    self.query_one("#log-content", Static).update(c)
-                except NoMatches:
-                    pass
-
-            self.app.call_from_thread(_update_log)
+            self.app.call_from_thread(self._safe_update_log, content)
 
         # ── Preflight ────────────────────────────────────────────────────────
         app = self.app
@@ -359,13 +371,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                     self.all_results.append(result)
                     append_result(result, jsonl_path, csv_path=None)
                     run_results_for_test.append(result)
-                    def _advance_progress() -> None:
-                        try:
-                            self.query_one(ProgressBar).advance(1)
-                        except NoMatches:
-                            pass
-
-                    self.app.call_from_thread(_advance_progress)
+                    self.app.call_from_thread(self._safe_advance_progress)
 
                 # Compute aggregates after all N runs, then patch the already-written
                 # rows in the JSONL. CSV written here so aggregate fields are included.
@@ -427,12 +433,5 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         lines.append(f"Saved: {jsonl_path.name}  |  {csv_path.name}")
 
         summary_text = "\n".join(lines)
-
-        def _update_summary(t: str = summary_text) -> None:
-            try:
-                self.query_one("#summary-content", Static).update(t)
-            except NoMatches:
-                pass
-
-        self.app.call_from_thread(_update_summary)
+        self.app.call_from_thread(self._safe_update_summary, summary_text)
         append_log("\nDone! See summary below.", "pass")

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, ScrollableContainer
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, Checkbox, Footer, Header, Label, ProgressBar, Static
 
@@ -267,7 +268,14 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         def append_log(line: str, style: str = "") -> None:
             log_lines.append((line, style))
             content = "\n".join(f"[{s}]{ln}[/{s}]" if s else ln for ln, s in log_lines[-100:])
-            self.app.call_from_thread(self.query_one("#log-content", Static).update, content)
+
+            def _update_log(c: str = content) -> None:
+                try:
+                    self.query_one("#log-content", Static).update(c)
+                except NoMatches:
+                    pass
+
+            self.app.call_from_thread(_update_log)
 
         # ── Preflight ────────────────────────────────────────────────────────
         app = self.app
@@ -351,7 +359,13 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                     self.all_results.append(result)
                     append_result(result, jsonl_path, csv_path=None)
                     run_results_for_test.append(result)
-                    self.app.call_from_thread(self.query_one(ProgressBar).advance, 1)
+                    def _advance_progress() -> None:
+                        try:
+                            self.query_one(ProgressBar).advance(1)
+                        except NoMatches:
+                            pass
+
+                    self.app.call_from_thread(_advance_progress)
 
                 # Compute aggregates after all N runs, then patch the already-written
                 # rows in the JSONL. CSV written here so aggregate fields are included.
@@ -412,7 +426,13 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
             lines.append(f"\nBest: [bold]{scored[0][0]}[/bold] ({scored[0][3] * 100:.0f}/100)")
         lines.append(f"Saved: {jsonl_path.name}  |  {csv_path.name}")
 
-        self.app.call_from_thread(
-            self.query_one("#summary-content", Static).update, "\n".join(lines)
-        )
+        summary_text = "\n".join(lines)
+
+        def _update_summary(t: str = summary_text) -> None:
+            try:
+                self.query_one("#summary-content", Static).update(t)
+            except NoMatches:
+                pass
+
+        self.app.call_from_thread(_update_summary)
         append_log("\nDone! See summary below.", "pass")

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -284,13 +284,14 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         sampler = MetricsSampler()
         self._live_sampler = sampler
 
+        app = self.app
+
         def append_log(line: str, style: str = "") -> None:
             log_lines.append((line, style))
             content = "\n".join(f"[{s}]{ln}[/{s}]" if s else ln for ln, s in log_lines[-100:])
-            self.app.call_from_thread(self._safe_update_log, content)
+            app.call_from_thread(self._safe_update_log, content)
 
         # ── Preflight ────────────────────────────────────────────────────────
-        app = self.app
         pf = run_preflight(
             self.models, app.model_list, RESULTS_DIR, fleet_mode=app.fleet_mode  # type: ignore[attr-defined]
         )
@@ -371,7 +372,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                     self.all_results.append(result)
                     append_result(result, jsonl_path, csv_path=None)
                     run_results_for_test.append(result)
-                    self.app.call_from_thread(self._safe_advance_progress)
+                    app.call_from_thread(self._safe_advance_progress)
 
                 # Compute aggregates after all N runs, then patch the already-written
                 # rows in the JSONL. CSV written here so aggregate fields are included.
@@ -433,5 +434,5 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         lines.append(f"Saved: {jsonl_path.name}  |  {csv_path.name}")
 
         summary_text = "\n".join(lines)
-        self.app.call_from_thread(self._safe_update_summary, summary_text)
+        app.call_from_thread(self._safe_update_summary, summary_text)
         append_log("\nDone! See summary below.", "pass")


### PR DESCRIPTION
## Problem

`RunnerScreen.run_evals` is a `@work(thread=True)` method. In three places it called `query_one()` **in the worker thread** to get a widget reference, then passed that reference's method to `call_from_thread`:

```python
# BAD — query_one runs in the thread, before the widget may be mounted
self.app.call_from_thread(self.query_one("#log-content", Static).update, content)
```

If the widget wasn't mounted yet when the worker started, `query_one` raised `NoMatches` inside the thread → `WorkerFailed` → flaky CI failure.

## Fix

Move `query_one` inside the callable so it runs on the main thread (where the widget tree is stable). Swallow `NoMatches` in case the screen is torn down mid-run:

```python
def _update_log(c: str = content) -> None:
    try:
        self.query_one("#log-content", Static).update(c)
    except NoMatches:
        pass
self.app.call_from_thread(_update_log)
```

Fixed all three sites: `#log-content` (append_log), `ProgressBar.advance`, `#summary-content`.

## Test

26/26 `test_screens_pilot` tests pass. 737/737 full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)