### PR TITLE
fix(screens): resolve RESULTS_DIR relative to cwd, not package location

### DIFF
--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -102,8 +102,7 @@ def _backfill_aggregates(run_results: list[dict[str, Any]]) -> None:
         row["robustness_n"] = result.n
 
 
-PROJECT_ROOT = Path(__file__).parents[2]
-RESULTS_DIR = PROJECT_ROOT / "results"
+RESULTS_DIR = Path("results")
 
 
 class SelectionScreen(Screen):  # type: ignore[type-arg]


### PR DESCRIPTION
## Summary

- `PROJECT_ROOT = Path(__file__).parents[2]` in `screens.py` resolved correctly from source but pointed into the Python site-packages tree when installed as a wheel — `results/` would be written into the package install directory, not the user's working directory
- Replace with `RESULTS_DIR = Path("results")` so hermia always writes results relative to the user's invocation directory, regardless of install method
- Removes the now-unused `PROJECT_ROOT` constant from `screens.py` (same class of bug fixed in `runner.py` by #77)

## Test plan

- [ ] 744 tests pass (verified locally)
- [ ] `hermia --fleet <yaml>` writes `results/` in the working directory when installed via `pip install hermia`

🤖 Generated with [Claude Code](https://claude.com/claude-code)