### PR TITLE
fix(build): remove redundant force-include causing duplicate wheel entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,6 @@ hermia-analyze = "hermia.analyze:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/hermia"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/hermia/test-datasets" = "hermia/test-datasets"
-
 [tool.ruff]
 src = ["src"]
 line-length = 100


### PR DESCRIPTION
## Problem

The `v0.1.3` publish failed with PyPI 400: *"Duplicate filename in local headers"*. The `force-include` directive added in #77 caused `agentic-tasks.json` to appear twice in the wheel ZIP — once automatically (hatch includes all files under `src/hermia/` via `packages = ["src/hermia"]`) and once explicitly via `force-include`.

## Fix

Remove the `[tool.hatch.build.targets.wheel.force-include]` section. Dataset is bundled correctly without it.

## Verification

Built wheel locally — `agentic-tasks.json` appears exactly once at `hermia/test-datasets/agentic-tasks.json`.

## Test plan

- [ ] CI passes
- [ ] After merge, delete and re-push `v0.1.3` tag → publish workflow succeeds → `pip install hermia==0.1.3` on Windows works

🤖 Generated with [Claude Code](https://claude.com/claude-code)