### PR TITLE
feat(v0.2): execution_path instrumentation + spill audit format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ analysis/*.md
 analysis/*.html
 docs/*.docx
 
+hermia-fleet-spill.yaml
+
 # Secret scanning
 # .secrets.baseline is intentionally tracked (audited false-positive list)
 # .gitleaks.toml is intentionally tracked (custom rules)

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -56,7 +56,7 @@ def analyze(rows: list[dict]) -> None:
         else:
             verdict = "KEEP    — acceptable spill"
 
-        print(f"{host:<30} {model:<45} {pass_pct:>5.1f}% {med_tps:>8.1f} {avg_vram:>8.2f}  {verdict}")
+        print(f"{host:<30.30} {model:<45.45} {pass_pct:>5.1f}% {med_tps:>8.1f} {avg_vram:>8.2f}  {verdict}")
 
     print()
 

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -15,7 +15,7 @@ BORDERLINE_TPS = 9.0      # below this = flag for review
 
 def load_rows(path: Path) -> list[dict]:
     rows = []
-    with path.open() as f:
+    with path.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -4,9 +4,10 @@
 Usage: python3 scripts/analyze_spill.py results/eval_YYYYMMDD_HHMMSS.jsonl
 """
 import json
+import statistics
 import sys
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 MIN_ACCEPTABLE_TPS = 5.0  # below this = delete
 BORDERLINE_TPS = 9.0      # below this = flag for review
@@ -26,8 +27,8 @@ def analyze(rows: list[dict]) -> None:
     # Group by (fleet_host_name, model)
     groups: dict[tuple, list[dict]] = defaultdict(list)
     for r in rows:
-        host = r.get("fleet_host_name") or r.get("host", "unknown")
-        model = r.get("model", "unknown")
+        host = str(r.get("fleet_host_name") or r.get("host") or "unknown")
+        model = str(r.get("model") or "unknown")
         groups[(host, model)].append(r)
 
     print(f"\n{'HOST':<30} {'MODEL':<45} {'PASS%':>6} {'MED t/s':>8} {'VRAM GB':>8} {'VERDICT'}")
@@ -39,7 +40,7 @@ def analyze(rows: list[dict]) -> None:
         pass_pct = 100.0 * passed / total if total else 0
 
         tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec") is not None]
-        med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
+        med_tps = statistics.median(tps_vals) if tps_vals else 0.0
 
         vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
         avg_vram = sum(vram_vals) / len(vram_vals) if vram_vals else 0.0

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -38,7 +38,7 @@ def analyze(rows: list[dict]) -> None:
         total = len(group)
         pass_pct = 100.0 * passed / total if total else 0
 
-        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec")]
+        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec") is not None]
         med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
 
         vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -44,7 +44,9 @@ def analyze(rows: list[dict]) -> None:
         vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
         avg_vram = sum(vram_vals) / len(vram_vals) if vram_vals else 0.0
 
-        if avg_vram == 0.0:
+        if not vram_vals:
+            verdict = "REVIEW  — unknown VRAM"
+        elif avg_vram == 0.0:
             verdict = "DELETE — CPU fallback (vram=0)"
         elif med_tps < MIN_ACCEPTABLE_TPS:
             verdict = f"DELETE — t/s {med_tps:.1f} below {MIN_ACCEPTABLE_TPS}"

--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Analyze a hermia JSONL result file for VRAM spill and throughput.
+
+Usage: python3 scripts/analyze_spill.py results/eval_YYYYMMDD_HHMMSS.jsonl
+"""
+import json
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+MIN_ACCEPTABLE_TPS = 5.0  # below this = delete
+BORDERLINE_TPS = 9.0      # below this = flag for review
+
+
+def load_rows(path: Path) -> list[dict]:
+    rows = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def analyze(rows: list[dict]) -> None:
+    # Group by (fleet_host_name, model)
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for r in rows:
+        host = r.get("fleet_host_name") or r.get("host", "unknown")
+        model = r.get("model", "unknown")
+        groups[(host, model)].append(r)
+
+    print(f"\n{'HOST':<30} {'MODEL':<45} {'PASS%':>6} {'MED t/s':>8} {'VRAM GB':>8} {'VERDICT'}")
+    print("-" * 115)
+
+    for (host, model), group in sorted(groups.items()):
+        passed = sum(1 for r in group if r.get("schema_compliant"))
+        total = len(group)
+        pass_pct = 100.0 * passed / total if total else 0
+
+        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec")]
+        med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
+
+        vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
+        avg_vram = sum(vram_vals) / len(vram_vals) if vram_vals else 0.0
+
+        if avg_vram == 0.0:
+            verdict = "DELETE — CPU fallback (vram=0)"
+        elif med_tps < MIN_ACCEPTABLE_TPS:
+            verdict = f"DELETE — t/s {med_tps:.1f} below {MIN_ACCEPTABLE_TPS}"
+        elif med_tps < BORDERLINE_TPS:
+            verdict = f"REVIEW  — borderline t/s {med_tps:.1f}"
+        else:
+            verdict = "KEEP    — acceptable spill"
+
+        print(f"{host:<30} {model:<45} {pass_pct:>5.1f}% {med_tps:>8.1f} {avg_vram:>8.2f}  {verdict}")
+
+    print()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 scripts/analyze_spill.py <results.jsonl>", file=sys.stderr)
+        sys.exit(1)
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    rows = load_rows(path)
+    analyze(rows)

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -65,10 +65,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--audit-format",
-        choices=["jsonl", "html"],
+        choices=["jsonl", "html", "spill"],
         default="jsonl",
         dest="audit_format",
-        help="Audit output format: jsonl (default) or html",
+        help="Audit output format: jsonl (default), html, or spill (fleet health table)",
     )
     args = parser.parse_args()
 

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -35,7 +35,7 @@ def _dominant_execution_path(group: list[dict[str, Any]]) -> str:
     vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
     if not vram_vals:
         return "unknown"
-    return "cpu" if sum(vram_vals) / len(vram_vals) == 0.0 else "probable_gpu"
+    return "cpu" if sum(vram_vals) == 0.0 else "probable_gpu"
 
 
 def _spill_verdict(path: str, med_tps: float) -> str:
@@ -82,7 +82,7 @@ def render_spill(rows: list[dict[str, Any]]) -> str:
         verdict = _spill_verdict(path, med_tps)
 
         lines.append(
-            f"{host:<32.32} {model:<40.40} {total:>4}  {pass_pct:>5.1f}%"
+            f"{host:<32.32} {model:<40.40} {total:>4} {pass_pct:>5.1f}%"
             f"  {med_tps:>8.1f}  {avg_vram:>8.2f}  {path:<12}  {verdict}"
         )
 

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -3,6 +3,7 @@
 import html as _html
 import json
 import sys
+from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator
 from datetime import datetime
 from pathlib import Path
@@ -10,6 +11,83 @@ from typing import Any
 
 from hermia.results import load_jsonl
 from hermia.runner import load_tests_all
+
+# ── Spill / fleet-health analysis ─────────────────────────────────────────────
+
+_MIN_ACCEPTABLE_TPS: float = 5.0   # below → DELETE
+_BORDERLINE_TPS: float = 9.0       # below → REVIEW
+
+
+def _dominant_execution_path(group: list[dict[str, Any]]) -> str:
+    """Return the dominant execution path for a (host, model) group.
+
+    Uses the ``execution_path`` field when present; falls back to
+    ``vram_server_gb`` heuristics for rows written before v0.2.
+    """
+    known = [
+        r["execution_path"]
+        for r in group
+        if r.get("execution_path") and r["execution_path"] != "unknown"
+    ]
+    if known:
+        return Counter(known).most_common(1)[0][0]
+    # Backward compat: derive from vram_server_gb
+    vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
+    if not vram_vals:
+        return "unknown"
+    return "cpu" if sum(vram_vals) / len(vram_vals) == 0.0 else "probable_gpu"
+
+
+def _spill_verdict(path: str, med_tps: float) -> str:
+    if path == "cpu":
+        return "DELETE — CPU fallback"
+    if med_tps < _MIN_ACCEPTABLE_TPS:
+        return f"DELETE — {med_tps:.1f} t/s (< {_MIN_ACCEPTABLE_TPS})"
+    if med_tps < _BORDERLINE_TPS:
+        return f"REVIEW  — {med_tps:.1f} t/s (borderline)"
+    return "KEEP"
+
+
+def render_spill(rows: list[dict[str, Any]]) -> str:
+    """Render a fleet health / VRAM-spill analysis table.
+
+    Groups results by (host_label, model) and emits a KEEP / REVIEW / DELETE
+    verdict per group based on execution path, pass rate, and throughput.
+    """
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        name = r.get("fleet_host_name") or r.get("host", "unknown")
+        model = r.get("model", "unknown")
+        groups[(name, model)].append(r)
+
+    header = (
+        f"{'HOST':<32} {'MODEL':<40} {'N':>4} {'PASS%':>6}"
+        f"  {'MED t/s':>8}  {'VRAM GB':>8}  {'PATH':<12}  VERDICT"
+    )
+    sep = "─" * 130
+    lines = [header, sep]
+
+    for (host, model), group in sorted(groups.items()):
+        total = len(group)
+        passed = sum(1 for r in group if r.get("schema_compliant"))
+        pass_pct = 100.0 * passed / total
+
+        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec")]
+        med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
+
+        vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
+        avg_vram = sum(vram_vals) / len(vram_vals) if vram_vals else 0.0
+
+        path = _dominant_execution_path(group)
+        verdict = _spill_verdict(path, med_tps)
+
+        lines.append(
+            f"{host:<32.32} {model:<40.40} {total:>4}  {pass_pct:>5.1f}%"
+            f"  {med_tps:>8.1f}  {avg_vram:>8.2f}  {path:<12}  {verdict}"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
 
 
 def _load_system_prompts() -> dict[str, str]:
@@ -216,6 +294,16 @@ def run_audit(
             print(f"hermia: no results found in {source}", file=sys.stderr)
             return
         content = render_html(rows)
+        if output is not None:
+            output.write_text(content, encoding="utf-8")
+        else:
+            print(content)
+    elif fmt == "spill":
+        rows = list(_iter_rows(source))
+        if not rows:
+            print(f"hermia: no results found in {source}", file=sys.stderr)
+            return
+        content = render_spill(rows)
         if output is not None:
             output.write_text(content, encoding="utf-8")
         else:

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -56,8 +56,8 @@ def render_spill(rows: list[dict[str, Any]]) -> str:
     """
     groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     for r in rows:
-        name = r.get("fleet_host_name") or r.get("host", "unknown")
-        model = r.get("model", "unknown")
+        name = str(r.get("fleet_host_name") or r.get("host") or "unknown")
+        model = str(r.get("model") or "unknown")
         groups[(name, model)].append(r)
 
     header = (
@@ -72,7 +72,7 @@ def render_spill(rows: list[dict[str, Any]]) -> str:
         passed = sum(1 for r in group if r.get("schema_compliant"))
         pass_pct = 100.0 * passed / total
 
-        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec")]
+        tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec") is not None]
         med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
 
         vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -2,6 +2,7 @@
 
 import html as _html
 import json
+import statistics
 import sys
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator
@@ -30,7 +31,7 @@ def _dominant_execution_path(group: list[dict[str, Any]]) -> str:
         if r.get("execution_path") and r["execution_path"] != "unknown"
     ]
     if known:
-        return Counter(known).most_common(1)[0][0]
+        return str(Counter(known).most_common(1)[0][0])
     # Backward compat: derive from vram_server_gb
     vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
     if not vram_vals:
@@ -73,7 +74,7 @@ def render_spill(rows: list[dict[str, Any]]) -> str:
         pass_pct = 100.0 * passed / total
 
         tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec") is not None]
-        med_tps = sorted(tps_vals)[len(tps_vals) // 2] if tps_vals else 0.0
+        med_tps = statistics.median(tps_vals) if tps_vals else 0.0
 
         vram_vals = [r["vram_server_gb"] for r in group if r.get("vram_server_gb") is not None]
         avg_vram = sum(vram_vals) / len(vram_vals) if vram_vals else 0.0

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -71,7 +71,7 @@ def render_spill(rows: list[dict[str, Any]]) -> str:
     for (host, model), group in sorted(groups.items()):
         total = len(group)
         passed = sum(1 for r in group if r.get("schema_compliant"))
-        pass_pct = 100.0 * passed / total
+        pass_pct = 100.0 * passed / total if total else 0.0
 
         tps_vals = [r["tokens_per_sec"] for r in group if r.get("tokens_per_sec") is not None]
         med_tps = statistics.median(tps_vals) if tps_vals else 0.0

--- a/src/hermia/audit.py
+++ b/src/hermia/audit.py
@@ -40,6 +40,8 @@ def _dominant_execution_path(group: list[dict[str, Any]]) -> str:
 
 
 def _spill_verdict(path: str, med_tps: float) -> str:
+    if path == "unknown":
+        return "REVIEW  — unknown execution path"
     if path == "cpu":
         return "DELETE — CPU fallback"
     if med_tps < _MIN_ACCEPTABLE_TPS:

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -43,6 +43,8 @@ _PG_COLUMNS = (
     "judge_reasoning",
     "mode",
     "vram_server_gb",
+    "model_size_server_gb",
+    "execution_path",
     "raw_system",
     "raw_prompt",
     "raw_response",

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -111,7 +111,7 @@ def compute_execution_path(
     "partial" — spill: some layers on CPU, some on GPU
     "unknown" — data unavailable
     """
-    if vram_server_gb is None or model_size_server_gb is None or model_size_server_gb == 0:
+    if vram_server_gb is None or model_size_server_gb is None or model_size_server_gb <= 0:
         return "unknown"
     ratio = vram_server_gb / model_size_server_gb
     if ratio >= 0.95:

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -74,7 +74,10 @@ def fetch_server_ps_data(
         result = dict(empty)
         data = resp.json()
         if isinstance(data, dict):
-            for m in data.get("models") or []:
+            models_list = data.get("models")
+            for m in (models_list if isinstance(models_list, list) else []):
+                if not isinstance(m, dict):
+                    continue
                 if m.get("name") == model:
                     sv = m.get("size_vram")
                     st = m.get("size")
@@ -140,7 +143,7 @@ def get_model_size_gb(model_name: str, model_list: list[dict[str, Any]]) -> floa
 def unload_model(model_name: str) -> None:
     """Evict model from VRAM."""
     # Invalidate cached /api/ps data so next load gets fresh VRAM stats
-    keys_to_remove = [k for k in _ps_cache if k[1] == model_name]
+    keys_to_remove = [k for k in list(_ps_cache) if k[1] == model_name]
     for k in keys_to_remove:
         _ps_cache.pop(k, None)
     host = get_ollama_host()

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -68,8 +68,8 @@ def fetch_server_ps_data(
         resp = requests.get(f"{host}/api/ps", timeout=2, headers=headers or {})
         if not resp.ok:
             if resp.status_code == 404:
-                _ps_cache[key] = empty
-            return empty
+                _ps_cache[key] = dict(empty)
+            return dict(empty)
 
         result = dict(empty)
         data = resp.json()
@@ -87,7 +87,7 @@ def fetch_server_ps_data(
         _ps_cache[key] = result
         return result
     except Exception:  # noqa: BLE001
-        return empty
+        return dict(empty)
 
 
 def fetch_server_vram(

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -139,6 +139,10 @@ def get_model_size_gb(model_name: str, model_list: list[dict[str, Any]]) -> floa
 
 def unload_model(model_name: str) -> None:
     """Evict model from VRAM."""
+    # Invalidate cached /api/ps data so next load gets fresh VRAM stats
+    keys_to_remove = [k for k in _ps_cache if k[1] == model_name]
+    for k in keys_to_remove:
+        _ps_cache.pop(k, None)
     host = get_ollama_host()
     try:
         requests.post(

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -44,44 +44,78 @@ def detect_mode(host: str) -> str:
     return "local" if hostname in ("localhost", "127.0.0.1", "::1") else "fleet"
 
 
-_vram_cache: dict[tuple[Any, ...], float | None] = {}
+_ps_cache: dict[tuple[Any, ...], dict[str, float | None]] = {}
+_vram_cache = _ps_cache  # backward-compat alias
+
+
+def fetch_server_ps_data(
+    host: str, model: str, headers: dict[str, str] | None = None
+) -> dict[str, float | None]:
+    """Query /api/ps; return vram_server_gb and model_size_server_gb for model in GiB.
+
+    Both values are None when the model is not found or the request fails.
+    Caches on successful response or 404. Network errors are not cached.
+    Never raises.
+    """
+    host = _normalize_host(host)
+    headers_key = tuple(sorted(headers.items())) if headers else ()
+    key = (host, model, headers_key)
+    if key in _ps_cache:
+        return _ps_cache[key]
+
+    empty: dict[str, float | None] = {"vram_server_gb": None, "model_size_server_gb": None}
+    try:
+        resp = requests.get(f"{host}/api/ps", timeout=2, headers=headers or {})
+        if not resp.ok:
+            if resp.status_code == 404:
+                _ps_cache[key] = empty
+            return empty
+
+        result = dict(empty)
+        data = resp.json()
+        if isinstance(data, dict):
+            for m in data.get("models") or []:
+                if m.get("name") == model:
+                    sv = m.get("size_vram")
+                    st = m.get("size")
+                    if sv is not None:
+                        result["vram_server_gb"] = float(sv) / (1024 ** 3)
+                    if st is not None:
+                        result["model_size_server_gb"] = float(st) / (1024 ** 3)
+                    break
+
+        _ps_cache[key] = result
+        return result
+    except Exception:  # noqa: BLE001
+        return empty
 
 
 def fetch_server_vram(
     host: str, model: str, headers: dict[str, str] | None = None
 ) -> float | None:
-    """Query /api/ps on host; return size_vram for model in GiB, or None.
+    """Return size_vram for model in GiB from /api/ps, or None."""
+    return fetch_server_ps_data(host, model, headers=headers)["vram_server_gb"]
 
-    Caches the result (including None) on a successful response or a 404 —
-    both are stable within a session. Network errors and other non-2xx
-    responses are not cached so transient failures retry. Never raises.
+
+def compute_execution_path(
+    vram_server_gb: float | None, model_size_server_gb: float | None
+) -> str:
+    """Classify inference execution path from /api/ps VRAM fields.
+
+    Returns: "gpu", "cpu", "partial", or "unknown".
+    "gpu"     — >=95% of model loaded in VRAM
+    "cpu"     — <=5% of model in VRAM (CPU fallback)
+    "partial" — spill: some layers on CPU, some on GPU
+    "unknown" — data unavailable
     """
-    host = _normalize_host(host)
-    headers_key = tuple(sorted(headers.items())) if headers else ()
-    key = (host, model, headers_key)
-    if key in _vram_cache:
-        return _vram_cache[key]
-    try:
-        resp = requests.get(f"{host}/api/ps", timeout=2, headers=headers or {})
-        if not resp.ok:
-            if resp.status_code == 404:
-                _vram_cache[key] = None
-            return None
-
-        found_vram = None
-        data = resp.json()
-        if isinstance(data, dict):
-            for m in data.get("models") or []:
-                if m.get("name") == model:
-                    size = m.get("size_vram")
-                    if size is not None:
-                        found_vram = float(size) / (1024 ** 3)
-                    break
-
-        _vram_cache[key] = found_vram
-        return found_vram
-    except Exception:  # noqa: BLE001
-        return None
+    if vram_server_gb is None or model_size_server_gb is None or model_size_server_gb == 0:
+        return "unknown"
+    ratio = vram_server_gb / model_size_server_gb
+    if ratio >= 0.95:
+        return "gpu"
+    if ratio <= 0.05:
+        return "cpu"
+    return "partial"
 
 
 def get_available_models(
@@ -233,6 +267,7 @@ def run_test(
 
     tps = tokens / elapsed if elapsed > 0 and tokens > 0 else 0
     preview = output[:120].replace("\n", " ") if output.strip() else failure_reason
+    ps_data = fetch_server_ps_data(_host, model, headers=req_headers or None)
     return {
         "model": model,
         "test_id": test["id"],
@@ -256,5 +291,8 @@ def run_test(
         "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if mode == "local" else None,
         "mode": mode,
         "host": _host,
-        "vram_server_gb": fetch_server_vram(_host, model, headers=req_headers or None),
+        **ps_data,
+        "execution_path": compute_execution_path(
+            ps_data["vram_server_gb"], ps_data["model_size_server_gb"]
+        ),
     }

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -401,6 +401,11 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                     f"GPU {gpu:.0f}%  VRAM {vram:.1f}GB  CPU {cpu:.0f}%"
                 )
                 append_log(main_line, style)
+                if result.get("execution_path") == "cpu":
+                    append_log(
+                        "       ⚠ CPU fallback detected (vram_server_gb=0) — results may be timeout artifacts",
+                        "warn",
+                    )
                 if style == "fail":
                     preview = result.get("output_preview", "")
                     if preview:

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -403,7 +403,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                 append_log(main_line, style)
                 if result.get("execution_path") == "cpu":
                     append_log(
-                        "       ⚠ CPU fallback detected (vram_server_gb=0)"
+                        "       ⚠ CPU fallback detected (vram_server_gb near zero)"
                         " — results may be timeout artifacts",
                         "warn",
                     )

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -403,7 +403,8 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                 append_log(main_line, style)
                 if result.get("execution_path") == "cpu":
                     append_log(
-                        "       ⚠ CPU fallback detected (vram_server_gb=0) — results may be timeout artifacts",
+                        "       ⚠ CPU fallback detected (vram_server_gb=0)"
+                        " — results may be timeout artifacts",
                         "warn",
                     )
                 if style == "fail":

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -7,10 +7,13 @@ from unittest.mock import patch
 import pytest
 
 from hermia.audit import (
+    _dominant_execution_path,
     _enrich,
     _iter_rows,
+    _spill_verdict,
     render_html,
     render_jsonl,
+    render_spill,
     run_audit,
 )
 
@@ -340,3 +343,194 @@ def test_render_html_host_duration_shown() -> None:
     ]
     html = render_html(rows)
     assert "5m 30s" in html
+
+
+# ── _dominant_execution_path ──────────────────────────────────────────────────
+
+
+def _spill_row(
+    host: str = "node1",
+    model: str = "qwen2.5:32b",
+    execution_path: str | None = "gpu",
+    vram_server_gb: float | None = 18.0,
+    tokens_per_sec: float = 12.0,
+    schema_compliant: bool = True,
+) -> dict:
+    r: dict = {
+        "fleet_host_name": host,
+        "model": model,
+        "tokens_per_sec": tokens_per_sec,
+        "schema_compliant": schema_compliant,
+        "vram_server_gb": vram_server_gb,
+    }
+    if execution_path is not None:
+        r["execution_path"] = execution_path
+    return r
+
+
+def test_dominant_path_gpu_from_execution_path_field() -> None:
+    group = [_spill_row(execution_path="gpu")] * 3
+    assert _dominant_execution_path(group) == "gpu"
+
+
+def test_dominant_path_cpu_from_execution_path_field() -> None:
+    group = [_spill_row(execution_path="cpu", vram_server_gb=0.0)] * 3
+    assert _dominant_execution_path(group) == "cpu"
+
+
+def test_dominant_path_partial_majority() -> None:
+    group = [
+        _spill_row(execution_path="partial"),
+        _spill_row(execution_path="partial"),
+        _spill_row(execution_path="gpu"),
+    ]
+    assert _dominant_execution_path(group) == "partial"
+
+
+def test_dominant_path_falls_back_to_vram_zero_when_no_field() -> None:
+    group = [_spill_row(execution_path=None, vram_server_gb=0.0)]
+    assert _dominant_execution_path(group) == "cpu"
+
+
+def test_dominant_path_falls_back_to_probable_gpu_when_vram_nonzero() -> None:
+    group = [_spill_row(execution_path=None, vram_server_gb=18.0)]
+    assert _dominant_execution_path(group) == "probable_gpu"
+
+
+def test_dominant_path_unknown_when_no_field_and_no_vram() -> None:
+    group = [_spill_row(execution_path=None, vram_server_gb=None)]
+    assert _dominant_execution_path(group) == "unknown"
+
+
+def test_dominant_path_ignores_unknown_values() -> None:
+    group = [
+        _spill_row(execution_path="unknown"),
+        _spill_row(execution_path="gpu"),
+    ]
+    assert _dominant_execution_path(group) == "gpu"
+
+
+# ── _spill_verdict ────────────────────────────────────────────────────────────
+
+
+def test_spill_verdict_delete_cpu_fallback() -> None:
+    assert _spill_verdict("cpu", 3.3) == "DELETE — CPU fallback"
+
+
+def test_spill_verdict_delete_low_tps() -> None:
+    v = _spill_verdict("gpu", 2.0)
+    assert v.startswith("DELETE")
+    assert "t/s" in v
+
+
+def test_spill_verdict_review_borderline_tps() -> None:
+    v = _spill_verdict("gpu", 7.5)
+    assert v.startswith("REVIEW")
+    assert "t/s" in v
+
+
+def test_spill_verdict_keep() -> None:
+    assert _spill_verdict("gpu", 12.0) == "KEEP"
+
+
+def test_spill_verdict_keep_partial_spill_fast_enough() -> None:
+    assert _spill_verdict("partial", 10.0) == "KEEP"
+
+
+# ── render_spill ──────────────────────────────────────────────────────────────
+
+
+def test_render_spill_contains_header() -> None:
+    rows = [_spill_row()]
+    out = render_spill(rows)
+    assert "HOST" in out
+    assert "MODEL" in out
+    assert "VERDICT" in out
+
+
+def test_render_spill_keep_verdict_for_gpu_fast_node() -> None:
+    rows = [_spill_row(execution_path="gpu", tokens_per_sec=12.0, schema_compliant=True)] * 5
+    out = render_spill(rows)
+    assert "KEEP" in out
+
+
+def test_render_spill_delete_verdict_for_cpu_fallback() -> None:
+    rows = [_spill_row(execution_path="cpu", vram_server_gb=0.0, tokens_per_sec=3.3)] * 5
+    out = render_spill(rows)
+    assert "DELETE" in out
+    assert "CPU fallback" in out
+
+
+def test_render_spill_review_verdict_for_borderline_tps() -> None:
+    rows = [_spill_row(execution_path="gpu", tokens_per_sec=7.5)] * 5
+    out = render_spill(rows)
+    assert "REVIEW" in out
+
+
+def test_render_spill_groups_by_host_and_model() -> None:
+    rows = [
+        _spill_row(host="node-a", model="qwen2.5:32b", execution_path="gpu"),
+        _spill_row(host="node-b", model="qwen2.5:14b", execution_path="cpu", vram_server_gb=0.0),
+    ]
+    out = render_spill(rows)
+    assert "node-a" in out
+    assert "node-b" in out
+    assert "qwen2.5:32b" in out
+    assert "qwen2.5:14b" in out
+
+
+def test_render_spill_shows_pass_pct() -> None:
+    rows = [
+        _spill_row(schema_compliant=True),
+        _spill_row(schema_compliant=True),
+        _spill_row(schema_compliant=False),
+        _spill_row(schema_compliant=False),
+    ]
+    out = render_spill(rows)
+    assert "50.0%" in out
+
+
+def test_render_spill_backward_compat_old_rows_no_execution_path() -> None:
+    """Rows without execution_path field fall back to vram heuristic."""
+    rows = [_spill_row(execution_path=None, vram_server_gb=0.0, tokens_per_sec=3.3)] * 3
+    out = render_spill(rows)
+    assert "DELETE" in out
+    assert "CPU fallback" in out
+
+
+# ── run_audit spill format ────────────────────────────────────────────────────
+
+
+def test_run_audit_spill_to_stdout(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    jl = tmp_path / "eval_20260531_120000.jsonl"
+    row = {
+        **_make_row(),
+        "execution_path": "gpu",
+        "vram_server_gb": 18.0,
+        "model_size_server_gb": 20.0,
+        "tokens_per_sec": 12.0,
+    }
+    jl.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    run_audit(jl, fmt="spill")
+    out = capsys.readouterr().out
+    assert "HOST" in out
+    assert "KEEP" in out
+
+
+def test_run_audit_spill_to_file(tmp_path: Path) -> None:
+    jl = tmp_path / "eval_20260531_120000.jsonl"
+    row = {**_make_row(), "execution_path": "cpu", "vram_server_gb": 0.0, "tokens_per_sec": 3.3}
+    jl.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    out_file = tmp_path / "spill.txt"
+    run_audit(jl, fmt="spill", output=out_file)
+    content = out_file.read_text(encoding="utf-8")
+    assert "DELETE" in content
+
+
+def test_run_audit_spill_empty_warns_stderr(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    run_audit(tmp_path, fmt="spill")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no results found" in captured.err

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -498,6 +498,32 @@ def test_render_spill_backward_compat_old_rows_no_execution_path() -> None:
     assert "CPU fallback" in out
 
 
+def test_render_spill_zero_tps_rows_included_in_median() -> None:
+    """0.0 t/s (timeouts) must be included in median — not silently dropped."""
+    # 4 timeout rows (0.0 t/s) + 1 fast row (100.0 t/s).
+    # If 0.0 is dropped, median = 100.0 → KEEP (wrong).
+    # If 0.0 is included, median = 0.0 → DELETE (correct).
+    rows = [_spill_row(execution_path="gpu", tokens_per_sec=0.0)] * 4
+    rows += [_spill_row(execution_path="gpu", tokens_per_sec=100.0)]
+    out = render_spill(rows)
+    assert "DELETE" in out
+
+
+def test_render_spill_none_host_and_model_do_not_crash() -> None:
+    """Rows with None host/model must not raise TypeError in format specifier."""
+    rows = [{
+        "fleet_host_name": None,
+        "host": None,
+        "model": None,
+        "tokens_per_sec": 10.0,
+        "schema_compliant": True,
+        "vram_server_gb": 8.0,
+        "execution_path": "gpu",
+    }]
+    out = render_spill(rows)  # must not raise
+    assert "unknown" in out
+
+
 # ── run_audit spill format ────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -9,6 +9,8 @@ import requests
 import hermia.runner as _runner_mod
 from hermia.runner import (
     _strip_fences,
+    compute_execution_path,
+    fetch_server_ps_data,
     get_available_models,
     get_model_size_gb,
     load_tests,
@@ -18,10 +20,10 @@ from hermia.runner import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_vram_cache() -> None:
-    _runner_mod._vram_cache.clear()
+def _clear_ps_cache() -> None:
+    _runner_mod._ps_cache.clear()
     yield
-    _runner_mod._vram_cache.clear()
+    _runner_mod._ps_cache.clear()
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -393,6 +395,86 @@ def test_fetch_server_vram_missing_size_vram_key() -> None:
         assert fetch_server_vram("http://localhost:11434", "qwen2.5:32b") is None
 
 
+# ── fetch_server_ps_data ──────────────────────────────────────────────────────
+
+def test_fetch_server_ps_data_returns_both_fields() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "models": [
+            {"name": "qwen2.5:32b", "size_vram": 18 * 1024**3, "size": 20 * 1024**3},
+        ]
+    }
+    with patch("hermia.runner.requests.get", return_value=mock_resp):
+        data = fetch_server_ps_data("http://localhost:11434", "qwen2.5:32b")
+    assert abs(data["vram_server_gb"] - 18.0) < 0.01
+    assert abs(data["model_size_server_gb"] - 20.0) < 0.01
+
+
+def test_fetch_server_ps_data_model_not_found_returns_nones() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"models": [{"name": "other:7b", "size_vram": 5 * 1024**3}]}
+    with patch("hermia.runner.requests.get", return_value=mock_resp):
+        data = fetch_server_ps_data("http://localhost:11434", "qwen2.5:32b")
+    assert data["vram_server_gb"] is None
+    assert data["model_size_server_gb"] is None
+
+
+def test_fetch_server_ps_data_missing_size_vram_key() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "models": [{"name": "qwen2.5:32b", "size": 20 * 1024**3}]  # no size_vram
+    }
+    with patch("hermia.runner.requests.get", return_value=mock_resp):
+        data = fetch_server_ps_data("http://localhost:11434", "qwen2.5:32b")
+    assert data["vram_server_gb"] is None
+    assert abs(data["model_size_server_gb"] - 20.0) < 0.01
+
+
+def test_fetch_server_ps_data_connection_error_returns_nones() -> None:
+    with patch("hermia.runner.requests.get", side_effect=requests.exceptions.ConnectionError):
+        data = fetch_server_ps_data("http://192.0.2.1:11434", "qwen2.5:32b")
+    assert data["vram_server_gb"] is None
+    assert data["model_size_server_gb"] is None
+
+
+# ── compute_execution_path ────────────────────────────────────────────────────
+
+def test_compute_execution_path_gpu_full_offload() -> None:
+    assert compute_execution_path(18.0, 18.0) == "gpu"
+
+
+def test_compute_execution_path_gpu_near_full() -> None:
+    assert compute_execution_path(19.1, 20.0) == "gpu"
+
+
+def test_compute_execution_path_cpu_zero_vram() -> None:
+    assert compute_execution_path(0.0, 20.0) == "cpu"
+
+
+def test_compute_execution_path_cpu_near_zero() -> None:
+    assert compute_execution_path(0.8, 20.0) == "cpu"
+
+
+def test_compute_execution_path_partial_spill() -> None:
+    assert compute_execution_path(10.0, 20.0) == "partial"
+
+
+def test_compute_execution_path_unknown_when_vram_none() -> None:
+    assert compute_execution_path(None, 20.0) == "unknown"
+
+
+def test_compute_execution_path_unknown_when_size_none() -> None:
+    assert compute_execution_path(18.0, None) == "unknown"
+
+
+def test_compute_execution_path_unknown_when_both_none() -> None:
+    assert compute_execution_path(None, None) == "unknown"
+
+
+def test_compute_execution_path_unknown_when_size_zero() -> None:
+    assert compute_execution_path(0.0, 0.0) == "unknown"
+
+
 # ── run_test — mode and vram_server_gb fields ─────────────────────────────────
 
 def test_run_test_has_mode_field_local() -> None:
@@ -724,3 +806,56 @@ def test_run_test_signals_empty_when_extractor_returns_non_dict() -> None:
             with patch.dict("hermia.runner.SIGNAL_EXTRACTORS", bad_extractor):
                 result = run_test("qwen2.5:32b", _CLASSIFICATION_TEST, _mock_sampler())
     assert result["signals"] == {}
+
+
+# ── run_test — execution_path and model_size_server_gb ────────────────────────
+
+def _mock_ps_with_sizes(vram_bytes: int, total_bytes: int) -> MagicMock:
+    m = MagicMock()
+    m.json.return_value = {
+        "models": [{"name": "qwen2.5:32b", "size_vram": vram_bytes, "size": total_bytes}]
+    }
+    return m
+
+
+def test_run_test_execution_path_gpu_when_fully_loaded() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+    total = 20 * 1024**3
+    ps_mock = _mock_ps_with_sizes(vram_bytes=total, total_bytes=total)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.requests.get", return_value=ps_mock):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["execution_path"] == "gpu"
+    assert abs(result["model_size_server_gb"] - 20.0) < 0.01
+
+
+def test_run_test_execution_path_cpu_when_zero_vram() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+    ps_mock = _mock_ps_with_sizes(vram_bytes=0, total_bytes=20 * 1024**3)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.requests.get", return_value=ps_mock):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["execution_path"] == "cpu"
+    assert result["vram_server_gb"] == 0.0
+
+
+def test_run_test_execution_path_partial_when_spilled() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+    ps_mock = _mock_ps_with_sizes(vram_bytes=10 * 1024**3, total_bytes=20 * 1024**3)
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.requests.get", return_value=ps_mock):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["execution_path"] == "partial"
+
+
+def test_run_test_execution_path_unknown_when_ps_unavailable() -> None:
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+    with patch("hermia.runner.requests.post", return_value=mock_resp):
+        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    assert result["execution_path"] == "unknown"
+    assert result["model_size_server_gb"] is None


### PR DESCRIPTION
## Summary

- **`execution_path` per result row** — every eval result now records whether the model ran on GPU, CPU (fallback), or partially spilled, derived from `/api/ps` `size_vram` / `size` ratio
- **`model_size_server_gb` field** — total model size from `/api/ps`, stored alongside `vram_server_gb`; enables the ratio computation and Postgres export
- **Live TUI warning** — `⚠ CPU fallback detected` appended in the runner screen when `execution_path == "cpu"`, so operators catch GPU fallback during the run rather than in post-analysis
- **`hermia --audit-format spill`** — fleet health table grouping results by (host, model) with KEEP / REVIEW / DELETE verdicts; backward-compatible with pre-v0.2 JSONL rows via `vram_server_gb` heuristic fallback

## Motivation

The May 27 fleet run produced silent CPU fallback on both the Windows RX 7800 XT (ROCm) and Marcus RTX 3090 (CUDA) — `vram_server_gb=0`, 3 t/s, timeouts. Both nodes had been excluded manually from comparative analysis. This change makes that exclusion automatic and detectable at run time.

## Changes

| File | What changed |
|------|-------------|
| `runner.py` | `fetch_server_ps_data()` replaces direct `size_vram` extraction; `compute_execution_path()` pure classifier; `run_test()` emits `vram_server_gb`, `model_size_server_gb`, `execution_path` |
| `export.py` | `model_size_server_gb` and `execution_path` added to Postgres column list |
| `screens.py` | CPU-fallback warning in run log |
| `audit.py` | `render_spill()` + `run_audit(fmt="spill")` |
| `app.py` | `--audit-format spill` wired |
| `scripts/analyze_spill.py` | Committed the existing script (was untracked) |

## Test plan

- [ ] 560 unit tests passing (`uv run pytest tests/unit/`)
- [ ] `hermia --audit results/ --audit-format spill` produces KEEP/DELETE/REVIEW table
- [ ] CPU-fallback warning visible in TUI when running against a node with `vram_server_gb=0`
- [ ] `hermia-push --dry-run` shows `execution_path` and `model_size_server_gb` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)