### PR TITLE
feat(v0.2): --verbose / --quiet flags for fleet mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ analysis/*.md
 analysis/*.html
 docs/*.docx
 
+hermia-fleet-spill.yaml
+
 # Secret scanning
 # .secrets.baseline is intentionally tracked (audited false-positive list)
 # .gitleaks.toml is intentionally tracked (custom rules)

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -83,6 +83,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if (args.verbose or args.quiet) and not args.fleet:
+        parser.error("--verbose and --quiet can only be used with --fleet")
+
     if args.audit is not None:
         from hermia.audit import run_audit
         from hermia.screens import RESULTS_DIR

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -56,6 +56,17 @@ def main() -> None:
         metavar="FILE",
         help="YAML fleet config; runs headless eval against all hosts and exits",
     )
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Verbose fleet output: show t/s and failure reason per test",
+    )
+    verbosity_group.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Quiet fleet output: suppress progress, print only saved path on completion",
+    )
     parser.add_argument(
         "--audit",
         nargs="?",
@@ -91,9 +102,10 @@ def main() -> None:
         from hermia.fleet import load_fleet_config, run_fleet
         from hermia.screens import RESULTS_DIR
 
+        verbosity = 1 if args.verbose else (-1 if args.quiet else 0)
         try:
             entries = load_fleet_config(Path(args.fleet))
-            run_fleet(entries, repeat=args.repeat, results_dir=RESULTS_DIR)
+            run_fleet(entries, repeat=args.repeat, results_dir=RESULTS_DIR, verbosity=verbosity)
         except (ValueError, RuntimeError, OSError) as exc:
             print(f"hermia: {exc}", file=sys.stderr)
             sys.exit(1)

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -127,7 +127,7 @@ def run_fleet(
 
                     if verbosity >= 0:
                         status = "✓" if not result.get("failure_reason") else "✗"
-                        line = f"  {status} {model}:{test['id']} ({result['elapsed_sec']}s)"
+                        line = f"  {status} {model}:{test['id']} ({result.get('elapsed_sec', 0.0)}s)"
                         if verbosity >= 1:
                             tps = result.get("tokens_per_sec") or 0.0
                             reason = result.get("failure_reason") or ""

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -1,6 +1,7 @@
 """Headless fleet eval runner — multi-host batch evaluation from YAML config."""
 
 import os
+import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -90,8 +91,11 @@ def run_fleet(
             requested_set = set(requested)
             models = [m for m in all_models if m["name"] in requested_set]
             missing = requested_set - {m["name"] for m in models}
-            if missing and verbosity >= 0:
-                print_fn(f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}")
+            if missing:
+                print(
+                    f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}",
+                    file=sys.stderr,
+                )
         else:
             models = all_models
 

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -127,7 +127,8 @@ def run_fleet(
 
                     if verbosity >= 0:
                         status = "✓" if not result.get("failure_reason") else "✗"
-                        line = f"  {status} {model}:{test['id']} ({result.get('elapsed_sec', 0.0)}s)"
+                        elapsed = result.get("elapsed_sec", 0.0)
+                        line = f"  {status} {model}:{test['id']} ({elapsed}s)"
                         if verbosity >= 1:
                             tps = result.get("tokens_per_sec") or 0.0
                             reason = result.get("failure_reason") or ""

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -129,8 +129,8 @@ def run_fleet(
                         status = "✓" if not result.get("failure_reason") else "✗"
                         line = f"  {status} {model}:{test['id']} ({result['elapsed_sec']}s)"
                         if verbosity >= 1:
-                            tps = result.get("tokens_per_sec", 0.0)
-                            reason = result.get("failure_reason", "")
+                            tps = result.get("tokens_per_sec") or 0.0
+                            reason = result.get("failure_reason") or ""
                             line += f"  {tps:.1f} t/s"
                             if reason:
                                 line += f"  [{reason}]"

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -60,8 +60,15 @@ def run_fleet(
     repeat: int,
     results_dir: Path,
     print_fn: Callable[[str], None] = print,
+    verbosity: int = 0,
 ) -> Path:
-    """Run headless eval against all fleet entries. Returns path to JSONL output."""
+    """Run headless eval against all fleet entries. Returns path to JSONL output.
+
+    verbosity:
+        -1  quiet   — suppress all progress; print only ``Saved: <path>`` on completion
+         0  normal  — host headers + per-test pass/fail lines  (default)
+         1  verbose — normal output + t/s and failure_reason detail per test
+    """
     from hermia.metrics import MetricsSampler
     from hermia.results import append_result, open_run
     from hermia.robustness import score_rows
@@ -83,14 +90,16 @@ def run_fleet(
             requested_set = set(requested)
             models = [m for m in all_models if m["name"] in requested_set]
             missing = requested_set - {m["name"] for m in models}
-            if missing:
+            if missing and verbosity >= 0:
                 print_fn(f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}")
         else:
             models = all_models
-        print_fn(
-            f"[{idx}/{len(entries)}] {name} ({host_url})"
-            f" — {len(models)} models, {len(tests)} tests"
-        )
+
+        if verbosity >= 0:
+            print_fn(
+                f"[{idx}/{len(entries)}] {name} ({host_url})"
+                f" — {len(models)} models, {len(tests)} tests"
+            )
 
         sampler = MetricsSampler()
         for model_entry in models:
@@ -115,7 +124,17 @@ def run_fleet(
                     result["pass_count"] = rob.pass_count
                     result["robustness_n"] = rob.n
                     append_result(result, jsonl_path, csv_path)
-                    status = "✓" if not result.get("failure_reason") else "✗"
-                    print_fn(f"  {status} {model}:{test['id']} ({result['elapsed_sec']}s)")
 
+                    if verbosity >= 0:
+                        status = "✓" if not result.get("failure_reason") else "✗"
+                        line = f"  {status} {model}:{test['id']} ({result['elapsed_sec']}s)"
+                        if verbosity >= 1:
+                            tps = result.get("tokens_per_sec", 0.0)
+                            reason = result.get("failure_reason", "")
+                            line += f"  {tps:.1f} t/s"
+                            if reason:
+                                line += f"  [{reason}]"
+                        print_fn(line)
+
+    print_fn(f"Saved: {jsonl_path}")
     return jsonl_path

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -61,6 +61,7 @@ def run_fleet(
     repeat: int,
     results_dir: Path,
     print_fn: Callable[[str], None] = print,
+    stderr_fn: Callable[[str], None] = lambda msg: print(msg, file=sys.stderr),
     verbosity: int = 0,
 ) -> Path:
     """Run headless eval against all fleet entries. Returns path to JSONL output.
@@ -92,9 +93,8 @@ def run_fleet(
             models = [m for m in all_models if m["name"] in requested_set]
             missing = requested_set - {m["name"] for m in models}
             if missing:
-                print(
-                    f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}",
-                    file=sys.stderr,
+                stderr_fn(
+                    f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}"
                 )
         else:
             models = all_models

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -127,7 +127,7 @@ def run_fleet(
 
                     if verbosity >= 0:
                         status = "✓" if not result.get("failure_reason") else "✗"
-                        elapsed = result.get("elapsed_sec", 0.0)
+                        elapsed = result.get("elapsed_sec") or 0.0
                         line = f"  {status} {model}:{test['id']} ({elapsed}s)"
                         if verbosity >= 1:
                             tps = result.get("tokens_per_sec") or 0.0

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -391,7 +391,7 @@ def _run_fleet_capture(tmp_path: Path, verbosity: int) -> list[str]:
     with (
         patch("hermia.runner.load_tests_all", return_value=_tests),
         patch("hermia.runner.get_available_models", return_value=[{"name": "m1"}]),
-        patch("hermia.runner.run_test", return_value=dict(_MINIMAL_RESULT)),
+        patch("hermia.runner.run_test", side_effect=lambda *a, **kw: dict(_MINIMAL_RESULT)),
         patch("hermia.results.open_run", return_value=_run_files),
         patch("hermia.results.append_result"),
         patch("hermia.metrics.MetricsSampler", return_value=MagicMock()),
@@ -450,7 +450,7 @@ def test_run_fleet_verbose_includes_failure_reason_when_present(tmp_path: Path) 
     with (
         patch("hermia.runner.load_tests_all", return_value=_tests),
         patch("hermia.runner.get_available_models", return_value=[{"name": "m1"}]),
-        patch("hermia.runner.run_test", return_value=dict(failing_result)),
+        patch("hermia.runner.run_test", side_effect=lambda *a, **kw: dict(failing_result)),
         patch("hermia.results.open_run", return_value=_run_files),
         patch("hermia.results.append_result"),
         patch("hermia.metrics.MetricsSampler", return_value=MagicMock()),

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -372,3 +372,103 @@ def test_run_fleet_result_has_fleet_host_start(tmp_path: Path) -> None:
     from datetime import datetime
     dt = datetime.fromisoformat(fake_result["fleet_host_start"])
     assert dt.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# verbosity levels
+# ---------------------------------------------------------------------------
+
+
+def _run_fleet_capture(tmp_path: Path, verbosity: int) -> list[str]:
+    """Run run_fleet with given verbosity and return captured print_fn lines."""
+    from hermia.fleet import run_fleet
+
+    lines: list[str] = []
+    entries = [{"name": "n1", "host": "http://host1:11434"}]
+    _tests = [{"id": "t1", "system": "s", "prompt": "p"}]
+    _run_files = (tmp_path / "out.jsonl", tmp_path / "out.csv")
+
+    with (
+        patch("hermia.runner.load_tests_all", return_value=_tests),
+        patch("hermia.runner.get_available_models", return_value=[{"name": "m1"}]),
+        patch("hermia.runner.run_test", return_value=dict(_MINIMAL_RESULT)),
+        patch("hermia.results.open_run", return_value=_run_files),
+        patch("hermia.results.append_result"),
+        patch("hermia.metrics.MetricsSampler", return_value=MagicMock()),
+    ):
+        run_fleet(entries, repeat=1, results_dir=tmp_path,
+                  print_fn=lines.append, verbosity=verbosity)
+    return lines
+
+
+def test_run_fleet_normal_prints_host_header(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=0)
+    assert any("n1" in ln and "host1" in ln for ln in lines)
+
+
+def test_run_fleet_normal_prints_per_test_line(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=0)
+    assert any("m1:t1" in ln for ln in lines)
+
+
+def test_run_fleet_normal_always_prints_saved_path(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=0)
+    assert any("Saved:" in ln for ln in lines)
+
+
+def test_run_fleet_quiet_suppresses_host_header(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=-1)
+    assert not any("n1" in ln and "host1" in ln for ln in lines)
+
+
+def test_run_fleet_quiet_suppresses_per_test_line(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=-1)
+    assert not any("m1:t1" in ln for ln in lines)
+
+
+def test_run_fleet_quiet_still_prints_saved_path(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=-1)
+    assert any("Saved:" in ln for ln in lines)
+
+
+def test_run_fleet_verbose_includes_tps(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=1)
+    test_lines = [ln for ln in lines if "m1:t1" in ln]
+    assert test_lines, "expected at least one per-test line"
+    assert any("t/s" in ln for ln in test_lines)
+
+
+def test_run_fleet_verbose_includes_failure_reason_when_present(tmp_path: Path) -> None:
+    from hermia.fleet import run_fleet
+
+    lines: list[str] = []
+    failing_result = {**_MINIMAL_RESULT, "failure_reason": "TIMEOUT: 90s", "tokens_per_sec": 0.0}
+    entries = [{"name": "n1", "host": "http://host1:11434"}]
+    _tests = [{"id": "t1", "system": "s", "prompt": "p"}]
+    _run_files = (tmp_path / "out.jsonl", tmp_path / "out.csv")
+
+    with (
+        patch("hermia.runner.load_tests_all", return_value=_tests),
+        patch("hermia.runner.get_available_models", return_value=[{"name": "m1"}]),
+        patch("hermia.runner.run_test", return_value=dict(failing_result)),
+        patch("hermia.results.open_run", return_value=_run_files),
+        patch("hermia.results.append_result"),
+        patch("hermia.metrics.MetricsSampler", return_value=MagicMock()),
+    ):
+        run_fleet(entries, repeat=1, results_dir=tmp_path,
+                  print_fn=lines.append, verbosity=1)
+
+    test_lines = [ln for ln in lines if "m1:t1" in ln]
+    assert any("TIMEOUT" in ln for ln in test_lines)
+
+
+def test_run_fleet_verbose_omits_failure_reason_on_pass(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=1)
+    test_lines = [ln for ln in lines if "m1:t1" in ln]
+    # _MINIMAL_RESULT has failure_reason="" so no bracket annotation expected
+    assert not any("[" in ln for ln in test_lines)
+
+
+def test_run_fleet_verbose_still_prints_saved_path(tmp_path: Path) -> None:
+    lines = _run_fleet_capture(tmp_path, verbosity=1)
+    assert any("Saved:" in ln for ln in lines)


### PR DESCRIPTION
## Summary

- `--verbose` / `-v` — adds t/s and failure reason detail to each per-test line in fleet output
- `--quiet` / `-q` — suppresses all progress output; prints only `Saved: <path>` on completion (scriptable/CI-friendly)
- Flags are mutually exclusive; both are no-ops outside of `--fleet` mode (TUI manages its own output)

## Usage

```bash
# Default — host headers + per-test pass/fail
hermia --fleet hermia-fleet.yaml

# Quiet — just the output path (pipe-friendly)
OUTPUT=$(hermia --fleet hermia-fleet.yaml --quiet)

# Verbose — adds t/s and failure reason per test
hermia --fleet hermia-fleet.yaml --verbose
```

## Changes

| File | What changed |
|------|-------------|
| `fleet.py` | `run_fleet()` gains `verbosity: int = 0` param; `Saved:` line always printed |
| `app.py` | `--verbose`/`-v` and `--quiet`/`-q` mutually exclusive flags; translates to `verbosity` int |

## Test plan

- [ ] 531 unit tests passing (`uv run pytest tests/unit/`)
- [ ] `hermia --fleet hermia-fleet.yaml --quiet` produces only `Saved: results/eval_*.jsonl`
- [ ] `hermia --fleet hermia-fleet.yaml --verbose` shows `t/s` on each test line
- [ ] `hermia --verbose --quiet` rejected by argparse (mutually exclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)