### PR TITLE
feat: Workstream A — Transport abstraction (OllamaTransport + OpenAICompatTransport)

### DIFF
--- a/scripts/analyze_spill.py
+++ b/scripts/analyze_spill.py
@@ -56,7 +56,10 @@ def analyze(rows: list[dict]) -> None:
         else:
             verdict = "KEEP    — acceptable spill"
 
-        print(f"{host:<30.30} {model:<45.45} {pass_pct:>5.1f}% {med_tps:>8.1f} {avg_vram:>8.2f}  {verdict}")
+        print(
+            f"{host:<30.30} {model:<45.45} {pass_pct:>5.1f}%"
+            f" {med_tps:>8.1f} {avg_vram:>8.2f}  {verdict}"
+        )
 
     print()
 

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -33,6 +33,12 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
         if models is not None:
             if not isinstance(models, list) or not all(isinstance(m, str) for m in models):
                 raise ValueError(f"Fleet entry [{i}] 'models' must be a list of strings")
+        transport = entry.get("transport", "ollama")
+        if transport not in ("ollama", "openai-compat"):
+            raise ValueError(
+                f"Fleet entry '{entry.get('name', '?')}': transport must be 'ollama' or "
+                f"'openai-compat', got '{transport}'"
+            )
     return entries
 
 
@@ -81,9 +87,18 @@ def run_fleet(
     tests = load_tests_all()
 
     for idx, entry in enumerate(entries, 1):
+        from hermia.transport.ollama import OllamaTransport
+        from hermia.transport.openai_compat import OpenAICompatTransport
+
         name = entry["name"]
         host_url = _normalize_host(entry["host"])
         headers = _build_auth_headers(entry)
+        transport_type = entry.get("transport", "ollama")
+        host_transport = (
+            OpenAICompatTransport(host_url, headers)
+            if transport_type == "openai-compat"
+            else OllamaTransport(host_url, headers)
+        )
         host_start = datetime.now(UTC).isoformat()
 
         all_models = get_available_models(host=host_url, headers=headers)
@@ -111,7 +126,7 @@ def run_fleet(
             for test in tests:
                 run_results: list[dict[str, Any]] = []
                 for run_index in range(1, repeat + 1):
-                    result = run_test(model, test, sampler, host=host_url, headers=headers)
+                    result = run_test(model, test, sampler, host=host_url, headers=headers, transport=host_transport)
                     result["run_id"] = run_id
                     result["run_timestamp"] = datetime.now(UTC).isoformat()
                     result["run_index"] = run_index

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -125,7 +125,10 @@ def run_fleet(
             for test in tests:
                 run_results: list[dict[str, Any]] = []
                 for run_index in range(1, repeat + 1):
-                    result = run_test(model, test, sampler, host=host_url, headers=headers, transport=host_transport)
+                    result = run_test(
+                        model, test, sampler,
+                        host=host_url, headers=headers, transport=host_transport,
+                    )
                     result["run_id"] = run_id
                     result["run_timestamp"] = datetime.now(UTC).isoformat()
                     result["run_index"] = run_index

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -81,15 +81,14 @@ def run_fleet(
     from hermia.results import append_result, open_run
     from hermia.robustness import score_rows
     from hermia.runner import _normalize_host, get_available_models, load_tests_all, run_test
+    from hermia.transport.ollama import OllamaTransport
+    from hermia.transport.openai_compat import OpenAICompatTransport
 
     jsonl_path, csv_path = open_run(results_dir)
     run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     tests = load_tests_all()
 
     for idx, entry in enumerate(entries, 1):
-        from hermia.transport.ollama import OllamaTransport
-        from hermia.transport.openai_compat import OpenAICompatTransport
-
         name = entry["name"]
         host_url = _normalize_host(entry["host"])
         headers = _build_auth_headers(entry)

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -100,16 +100,24 @@ def run_fleet(
         )
         host_start = datetime.now(UTC).isoformat()
 
-        all_models = get_available_models(host=host_url, headers=headers)
         requested = entry.get("models")
+        if transport_type == "openai-compat" and not requested:
+            stderr_fn(
+                f"  ERROR: openai-compat host '{name}' requires an explicit"
+                f" 'models:' list in fleet YAML — skipping host"
+            )
+            continue
+        all_models = get_available_models(host=host_url, headers=headers)
         if requested:
             requested_set = set(requested)
-            models = [m for m in all_models if m["name"] in requested_set]
-            missing = requested_set - {m["name"] for m in models}
-            if missing:
-                stderr_fn(
-                    f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}"
-                )
+            models = [{"name": m} for m in requested_set] if transport_type == "openai-compat" \
+                else [m for m in all_models if m["name"] in requested_set]
+            if transport_type != "openai-compat":
+                missing = requested_set - {m["name"] for m in models}
+                if missing:
+                    stderr_fn(
+                        f"  WARNING: models not found on {name}: {', '.join(sorted(missing))}"
+                    )
         else:
             models = all_models
 

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -200,52 +200,44 @@ def run_test(
     sampler: MetricsSampler,
     host: str | None = None,
     headers: dict[str, str] | None = None,
+    transport: Any | None = None,
 ) -> dict[str, Any]:
+    from hermia.transport.ollama import OllamaTransport  # lazy import
+
     _host = _normalize_host(host) if host is not None else get_ollama_host()
-    mode = detect_mode(_host)
-    payload = {
-        "model": model,
-        "system": test["system"],
-        "prompt": test["prompt"],
-        "stream": False,
-        "options": {"temperature": 0.1},
-    }
     req_headers = headers or {}
-    if mode == "local":
-        sampler.start()
+    if transport is None:
+        transport = OllamaTransport(_host, req_headers)
+
+    messages = [
+        {"role": "system", "content": test["system"]},
+        {"role": "user", "content": test["prompt"]},
+    ]
+
     error_type: str = ""
+    response = None
+    sampler.start()
     try:
-        t0 = time.time()
-        resp = requests.post(
-            f"{_host}/api/generate", json=payload, headers=req_headers, timeout=TEST_TIMEOUT
-        )
-        elapsed = time.time() - t0
-        data = resp.json()
-        if not isinstance(data, dict):
-            raise ValueError(f"Unexpected Ollama response type: {type(data).__name__}")
-        ollama_error = data.get("error", "")
-        output: str = data.get("response") or ""
-        tokens: int = data.get("eval_count", 0)
-        if ollama_error:
-            error_type = f"OLLAMA_ERROR: {ollama_error}"
+        response = transport.generate(model, messages, timeout=TEST_TIMEOUT)
     except requests.exceptions.Timeout:
-        elapsed = TEST_TIMEOUT
-        output = ""
-        tokens = 0
         error_type = f"TIMEOUT: no response in {TEST_TIMEOUT}s"
-    except Exception as e:
-        elapsed = time.time() - t0
-        output = ""
-        tokens = 0
+    except Exception as e:  # noqa: BLE001
         error_type = f"ERROR: {e}"
-    if mode == "local":
+    finally:
         sampler.stop()
-    peak = sampler.peak() if mode == "local" else {}
+
+    is_api_mode = response.is_api_mode if response is not None else False
+    output: str = response.text if response is not None else ""
+    tokens: int = response.tokens if response is not None else 0
+    elapsed: float = response.elapsed_sec if response is not None else 0.0
+    orchestration: str = response.orchestration if response is not None else "unknown"
+    orchestration_version: str | None = response.orchestration_version if response is not None else None
+    peak = sampler.peak() if not is_api_mode else {}
 
     json_valid = False
     schema_ok = False
     had_markdown_fence = False
-    failure_reason = error_type  # network/Ollama errors; "" on clean path
+    failure_reason = error_type  # network/transport errors; "" on clean path
 
     signals: dict[str, bool] = {}
     if output and not error_type:
@@ -292,14 +284,16 @@ def run_test(
         "raw_system": test["system"] or "",
         "raw_prompt": test["prompt"] or "",
         "raw_response": "" if error_type else output,
-        "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if mode == "local" else None,
-        "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if mode == "local" else None,
-        "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if mode == "local" else None,
-        "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if mode == "local" else None,
-        "mode": mode,
+        "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if not is_api_mode else None,
+        "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if not is_api_mode else None,
+        "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if not is_api_mode else None,
+        "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if not is_api_mode else None,
+        "mode": "api" if is_api_mode else "local",
         "host": _host,
         **ps_data,
         "execution_path": compute_execution_path(
             ps_data["vram_server_gb"], ps_data["model_size_server_gb"]
         ),
+        "orchestration": orchestration,
+        "orchestration_version": orchestration_version,
     }

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -225,13 +225,14 @@ def run_test(
     finally:
         sampler.stop()
 
-    is_api_mode = response.is_api_mode if response is not None else False
+    is_api_mode = getattr(transport, "is_api_mode", False)
+    is_local = (not is_api_mode) and (detect_mode(_host) == "local")
     output: str = response.text if response is not None else ""
     tokens: int = response.tokens if response is not None else 0
     elapsed: float = response.elapsed_sec if response is not None else 0.0
     orchestration: str = response.orchestration if response is not None else "unknown"
     orchestration_version: str | None = response.orchestration_version if response is not None else None
-    peak = sampler.peak() if not is_api_mode else {}
+    peak = sampler.peak() if is_local else {}
 
     json_valid = False
     schema_ok = False
@@ -283,11 +284,11 @@ def run_test(
         "raw_system": test["system"] or "",
         "raw_prompt": test["prompt"] or "",
         "raw_response": "" if error_type else output,
-        "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if not is_api_mode else None,
-        "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if not is_api_mode else None,
-        "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if not is_api_mode else None,
-        "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if not is_api_mode else None,
-        "mode": "api" if is_api_mode else "local",
+        "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if is_local else None,
+        "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if is_local else None,
+        "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if is_local else None,
+        "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if is_local else None,
+        "mode": "local" if is_local else ("api" if is_api_mode else "fleet"),
         "host": _host,
         **ps_data,
         "execution_path": compute_execution_path(

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -12,6 +12,7 @@ import requests
 
 from hermia.metrics import MetricsSampler, get_gpu_stats
 from hermia.schemas import SCHEMA_CHECKS, SIGNAL_EXTRACTORS
+from hermia.transport.ollama import OllamaTransport
 
 PACKAGE_DIR = Path(__file__).parent
 
@@ -202,8 +203,6 @@ def run_test(
     headers: dict[str, str] | None = None,
     transport: Any | None = None,
 ) -> dict[str, Any]:
-    from hermia.transport.ollama import OllamaTransport  # lazy import
-
     _host = _normalize_host(host) if host is not None else get_ollama_host()
     req_headers = headers or {}
     if transport is None:

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -225,13 +225,18 @@ def run_test(
     finally:
         sampler.stop()
 
-    is_api_mode = getattr(transport, "is_api_mode", False)
+    is_api_mode = getattr(transport, "is_api_mode", False) is True
     is_local = (not is_api_mode) and (detect_mode(_host) == "local")
     output: str = response.text if response is not None else ""
     tokens: int = response.tokens if response is not None else 0
-    elapsed: float = response.elapsed_sec if response is not None else 0.0
+    elapsed: float = (
+        response.elapsed_sec if response is not None
+        else (TEST_TIMEOUT if "TIMEOUT" in error_type else 0.0)
+    )
     orchestration: str = response.orchestration if response is not None else "unknown"
-    orchestration_version: str | None = response.orchestration_version if response is not None else None
+    orchestration_version: str | None = (
+        response.orchestration_version if response is not None else None
+    )
     peak = sampler.peak() if is_local else {}
 
     json_valid = False

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -271,7 +271,11 @@ def run_test(
 
     tps = tokens / elapsed if elapsed > 0 and tokens > 0 else 0
     preview = output[:120].replace("\n", " ") if output.strip() else failure_reason
-    ps_data = fetch_server_ps_data(_host, model, headers=req_headers or None)
+    _empty_ps: dict[str, float | None] = {"vram_server_gb": None, "model_size_server_gb": None}
+    ps_data = (
+        fetch_server_ps_data(_host, model, headers=req_headers or None)
+        if not is_api_mode else _empty_ps
+    )
     return {
         "model": model,
         "test_id": test["id"],

--- a/src/hermia/transport/__init__.py
+++ b/src/hermia/transport/__init__.py
@@ -1,0 +1,5 @@
+from .base import Response, Transport
+from .ollama import OllamaTransport
+from .openai_compat import OpenAICompatTransport
+
+__all__ = ["Response", "Transport", "OllamaTransport", "OpenAICompatTransport"]

--- a/src/hermia/transport/base.py
+++ b/src/hermia/transport/base.py
@@ -16,5 +16,7 @@ class Response:
 
 @runtime_checkable
 class Transport(Protocol):
+    is_api_mode: bool
+
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
         ...

--- a/src/hermia/transport/base.py
+++ b/src/hermia/transport/base.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Response:
+    text: str
+    tokens: int
+    elapsed_sec: float
+    orchestration: str
+    orchestration_version: str | None
+    is_api_mode: bool
+
+
+@runtime_checkable
+class Transport(Protocol):
+    def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
+        ...

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .base import Response
+
+
+class OllamaTransport:
+    def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
+        raise NotImplementedError
+
+    def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
+        raise NotImplementedError

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -1,12 +1,53 @@
-"""Ollama HTTP transport — implementation pending (stub)."""
+"""Ollama HTTP transport — calls /api/chat (message-list semantics)."""
 from __future__ import annotations
 
-from .base import Response
+import time
+
+import requests
+
+from hermia.transport.base import Response
 
 
 class OllamaTransport:
     def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
-        raise NotImplementedError
+        self._base_url = base_url.rstrip("/")
+        self._headers = headers or {}
+        self._version = self._fetch_version()
+
+    def _fetch_version(self) -> str | None:
+        try:
+            resp = requests.get(
+                f"{self._base_url}/api/version",
+                timeout=3,
+                headers=self._headers,
+            )
+            return resp.json().get("version")
+        except Exception:  # noqa: BLE001
+            return None
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
-        raise NotImplementedError
+        payload = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {"temperature": opts.get("temperature", 0.1)},
+        }
+        t0 = time.time()
+        resp = requests.post(
+            f"{self._base_url}/api/chat",
+            json=payload,
+            headers=self._headers,
+            timeout=opts.get("timeout", 90),
+        )
+        elapsed = time.time() - t0
+        data = resp.json()
+        text: str = (data.get("message") or {}).get("content") or ""
+        tokens: int = data.get("eval_count", 0)
+        return Response(
+            text=text,
+            tokens=tokens,
+            elapsed_sec=elapsed,
+            orchestration="ollama",
+            orchestration_version=self._version,
+            is_api_mode=False,
+        )

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -32,14 +32,15 @@ class OllamaTransport:
             "stream": False,
             "options": {"temperature": opts.get("temperature", 0.1)},
         }
-        t0 = time.time()
+        t0 = time.monotonic()
         resp = requests.post(
             f"{self._base_url}/api/chat",
             json=payload,
             headers=self._headers,
             timeout=opts.get("timeout", 90),
         )
-        elapsed = time.time() - t0
+        resp.raise_for_status()
+        elapsed = time.monotonic() - t0
         data = resp.json()
         text: str = (data.get("message") or {}).get("content") or ""
         tokens: int = data.get("eval_count", 0)

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -1,6 +1,7 @@
 """Ollama HTTP transport — calls /api/chat (message-list semantics)."""
 from __future__ import annotations
 
+import threading
 import time
 
 import requests
@@ -16,19 +17,22 @@ class OllamaTransport:
         self._headers = headers or {}
         self._version: str | None = None
         self._version_fetched = False
+        self._lock = threading.Lock()
 
     def _fetch_version(self) -> str | None:
         if not self._version_fetched:
-            try:
-                resp = requests.get(
-                    f"{self._base_url}/api/version",
-                    timeout=3,
-                    headers=self._headers,
-                )
-                self._version = resp.json().get("version")
-            except Exception:  # noqa: BLE001
-                self._version = None
-            self._version_fetched = True
+            with self._lock:
+                if not self._version_fetched:
+                    try:
+                        resp = requests.get(
+                            f"{self._base_url}/api/version",
+                            timeout=3,
+                            headers=self._headers,
+                        )
+                        self._version = resp.json().get("version")
+                    except Exception:  # noqa: BLE001
+                        self._version = None
+                    self._version_fetched = True
         return self._version
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -47,7 +47,7 @@ class OllamaTransport:
             f"{self._base_url}/api/chat",
             json=payload,
             headers=self._headers,
-            timeout=opts.get("timeout", 90),
+            timeout=float(opts.get("timeout", 90)),  # type: ignore[arg-type]
         )
         resp.raise_for_status()
         elapsed = time.monotonic() - t0

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -1,3 +1,4 @@
+"""Ollama HTTP transport — implementation pending (stub)."""
 from __future__ import annotations
 
 from .base import Response

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -9,21 +9,27 @@ from hermia.transport.base import Response
 
 
 class OllamaTransport:
+    is_api_mode: bool = False
+
     def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
         self._base_url = base_url.rstrip("/")
         self._headers = headers or {}
-        self._version = self._fetch_version()
+        self._version: str | None = None
+        self._version_fetched = False
 
     def _fetch_version(self) -> str | None:
-        try:
-            resp = requests.get(
-                f"{self._base_url}/api/version",
-                timeout=3,
-                headers=self._headers,
-            )
-            return resp.json().get("version")
-        except Exception:  # noqa: BLE001
-            return None
+        if not self._version_fetched:
+            try:
+                resp = requests.get(
+                    f"{self._base_url}/api/version",
+                    timeout=3,
+                    headers=self._headers,
+                )
+                self._version = resp.json().get("version")
+            except Exception:  # noqa: BLE001
+                self._version = None
+            self._version_fetched = True
+        return self._version
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
         payload = {
@@ -49,6 +55,6 @@ class OllamaTransport:
             tokens=tokens,
             elapsed_sec=elapsed,
             orchestration="ollama",
-            orchestration_version=self._version,
+            orchestration_version=self._fetch_version(),
             is_api_mode=False,
         )

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -43,7 +43,7 @@ class OllamaTransport:
             "options": {"temperature": opts.get("temperature", 0.1)},
         }
         t0 = time.monotonic()
-        resp = requests.post(
+        resp = requests.post(  # nosec B113 — timeout passed via opts.get("timeout", 90)
             f"{self._base_url}/api/chat",
             json=payload,
             headers=self._headers,
@@ -52,6 +52,10 @@ class OllamaTransport:
         resp.raise_for_status()
         elapsed = time.monotonic() - t0
         data = resp.json()
+        if not isinstance(data, dict):
+            data = {}
+        if data.get("error"):
+            raise ValueError(f"Ollama error: {data['error']}")
         text: str = (data.get("message") or {}).get("content") or ""
         tokens: int = data.get("eval_count", 0)
         return Response(

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -1,3 +1,4 @@
+"""OpenAI-compatible HTTP transport (LiteLLM, vLLM, cloud APIs) — implementation pending (stub)."""
 from __future__ import annotations
 
 from .base import Response

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .base import Response
+
+
+class OpenAICompatTransport:
+    def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
+        raise NotImplementedError
+
+    def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
+        raise NotImplementedError

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -1,12 +1,23 @@
-"""OpenAI-compatible HTTP transport (LiteLLM, vLLM, cloud APIs) — implementation pending (stub)."""
+"""OpenAI-compatible HTTP transport — calls /v1/chat/completions (LiteLLM, vLLM, cloud APIs)."""
 from __future__ import annotations
 
-from .base import Response
+import time
+import requests
+from hermia.transport.base import Response
 
 
 class OpenAICompatTransport:
     def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
-        raise NotImplementedError
+        self._base_url = base_url.rstrip("/")
+        self._headers = headers or {}
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
-        raise NotImplementedError
+        payload = {"model": model, "messages": messages, "temperature": opts.get("temperature", 0.1)}
+        t0 = time.time()
+        resp = requests.post(f"{self._base_url}/v1/chat/completions", json=payload, headers=self._headers, timeout=opts.get("timeout", 90))
+        elapsed = time.time() - t0
+        data = resp.json()
+        choices: list = data.get("choices") or []
+        text: str = (choices[0].get("message") or {}).get("content") or "" if choices else ""
+        tokens: int = (data.get("usage") or {}).get("completion_tokens", 0)
+        return Response(text=text, tokens=tokens, elapsed_sec=elapsed, orchestration="openai-compat", orchestration_version=None, is_api_mode=True)

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -13,9 +13,15 @@ class OpenAICompatTransport:
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
         payload = {"model": model, "messages": messages, "temperature": opts.get("temperature", 0.1)}
-        t0 = time.time()
-        resp = requests.post(f"{self._base_url}/v1/chat/completions", json=payload, headers=self._headers, timeout=opts.get("timeout", 90))
-        elapsed = time.time() - t0
+        t0 = time.monotonic()
+        resp = requests.post(
+            f"{self._base_url}/v1/chat/completions",
+            json=payload,
+            headers=self._headers,
+            timeout=opts.get("timeout", 90),
+        )
+        resp.raise_for_status()
+        elapsed = time.monotonic() - t0
         data = resp.json()
         choices: list = data.get("choices") or []
         text: str = (choices[0].get("message") or {}).get("content") or "" if choices else ""

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 
 import requests
 
@@ -26,14 +27,14 @@ class OpenAICompatTransport:
             f"{self._base_url}/v1/chat/completions",
             json=payload,
             headers=self._headers,
-            timeout=opts.get("timeout", 90),
+            timeout=float(opts.get("timeout", 90)),  # type: ignore[arg-type]
         )
         resp.raise_for_status()
         elapsed = time.monotonic() - t0
         data = resp.json()
         if not isinstance(data, dict):
             data = {}
-        choices: list = data.get("choices") or []
+        choices: list[Any] = data.get("choices") or []
         first = choices[0] if choices and isinstance(choices[0], dict) else {}
         text: str = (first.get("message") or {}).get("content") or ""
         tokens: int = (data.get("usage") or {}).get("completion_tokens", 0)

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -7,6 +7,8 @@ from hermia.transport.base import Response
 
 
 class OpenAICompatTransport:
+    is_api_mode: bool = True
+
     def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
         self._base_url = base_url.rstrip("/")
         self._headers = headers or {}
@@ -26,4 +28,11 @@ class OpenAICompatTransport:
         choices: list = data.get("choices") or []
         text: str = (choices[0].get("message") or {}).get("content") or "" if choices else ""
         tokens: int = (data.get("usage") or {}).get("completion_tokens", 0)
-        return Response(text=text, tokens=tokens, elapsed_sec=elapsed, orchestration="openai-compat", orchestration_version=None, is_api_mode=True)
+        return Response(
+            text=text,
+            tokens=tokens,
+            elapsed_sec=elapsed,
+            orchestration="openai-compat",
+            orchestration_version=None,
+            is_api_mode=True,
+        )

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import time
+
 import requests
+
 from hermia.transport.base import Response
 
 
@@ -10,13 +12,17 @@ class OpenAICompatTransport:
     is_api_mode: bool = True
 
     def __init__(self, base_url: str, headers: dict[str, str] | None = None) -> None:
-        self._base_url = base_url.rstrip("/")
+        self._base_url = base_url.rstrip("/").removesuffix("/v1")
         self._headers = headers or {}
 
     def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
-        payload = {"model": model, "messages": messages, "temperature": opts.get("temperature", 0.1)}
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": opts.get("temperature", 0.1),
+        }
         t0 = time.monotonic()
-        resp = requests.post(
+        resp = requests.post(  # nosec B113 — timeout passed via opts.get("timeout", 90)
             f"{self._base_url}/v1/chat/completions",
             json=payload,
             headers=self._headers,
@@ -25,8 +31,11 @@ class OpenAICompatTransport:
         resp.raise_for_status()
         elapsed = time.monotonic() - t0
         data = resp.json()
+        if not isinstance(data, dict):
+            data = {}
         choices: list = data.get("choices") or []
-        text: str = (choices[0].get("message") or {}).get("content") or "" if choices else ""
+        first = choices[0] if choices and isinstance(choices[0], dict) else {}
+        text: str = (first.get("message") or {}).get("content") or ""
         tokens: int = (data.get("usage") or {}).get("completion_tokens", 0)
         return Response(
             text=text,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,10 @@ import hermia.runner as _runner_mod
 DEFAULT_GENERATE: dict[str, Any] = {
     "model": "fake-model",
     "created_at": "2026-01-01T00:00:00Z",
-    "response": '{"action": "search_documentation", "params": {"query": "requests Session"}}',
+    "message": {
+        "role": "assistant",
+        "content": '{"action": "search_documentation", "params": {"query": "requests Session"}}',
+    },
     "done": True,
     "eval_count": 42,
     "eval_duration": 1000000000,
@@ -29,7 +32,7 @@ class _FakeOllamaHandler(http.server.BaseHTTPRequestHandler):
         content_length = int(self.headers.get("Content-Length") or 0)
         self.rfile.read(content_length)
 
-        if self.path == "/api/generate":
+        if self.path in ("/api/chat", "/api/generate"):
             status = self._overrides.get("generate_status", 200)
 
             delay = self._overrides.get("generate_delay")
@@ -55,13 +58,16 @@ class _FakeOllamaHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         if self.path == "/api/tags":
             body = json.dumps(self._overrides.get("tags", DEFAULT_TAGS)).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+        elif self.path == "/api/version":
+            body = json.dumps({"version": "test"}).encode()
         else:
             self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def log_message(self, *args: Any) -> None:
         pass

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -346,6 +346,46 @@ def test_run_fleet_no_model_filter_runs_all(tmp_path: Path) -> None:
     assert called_models == {"qwen2.5:3b", "phi3:3.8b"}
 
 
+# ---------------------------------------------------------------------------
+# transport: field in load_fleet_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_fleet_config_transport_default(tmp_path: Path) -> None:
+    """No transport field → loads without error; default resolves to 'ollama'."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text("fleet:\n  - name: node3\n    host: http://host1:11434\n")
+    entries = load_fleet_config(cfg)
+    assert len(entries) == 1
+    assert entries[0].get("transport", "ollama") == "ollama"
+
+
+def test_load_fleet_config_transport_openai_compat(tmp_path: Path) -> None:
+    """transport: openai-compat is accepted and stored on the entry."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: litellm-gateway\n"
+        "    host: https://scottai.tailc7d860.ts.net:4000\n"
+        "    transport: openai-compat\n"
+    )
+    entries = load_fleet_config(cfg)
+    assert entries[0]["transport"] == "openai-compat"
+
+
+def test_load_fleet_config_invalid_transport(tmp_path: Path) -> None:
+    """transport: grpc (unknown value) raises ValueError mentioning 'transport'."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    transport: grpc\n"
+    )
+    with pytest.raises(ValueError, match="transport"):
+        load_fleet_config(cfg)
+
+
 def test_run_fleet_result_has_fleet_host_start(tmp_path: Path) -> None:
     from hermia.fleet import run_fleet
     entries = [{"name": "node2", "host": "http://192.168.25.100:11434"}]

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -508,6 +508,7 @@ def test_run_test_has_vram_server_gb_field() -> None:
 def test_run_test_fleet_mode_suppresses_local_metrics() -> None:
     """When is_api_mode=True, all local hardware fields must be None."""
     transport = MagicMock()
+    transport.is_api_mode = True
     transport.generate.return_value = TransportResponse(
         text="{}", tokens=10, elapsed_sec=1.0,
         orchestration="openai", orchestration_version=None, is_api_mode=True,
@@ -518,6 +519,26 @@ def test_run_test_fleet_mode_suppresses_local_metrics() -> None:
             host="http://192.0.2.1:11434", transport=transport,
         )
     assert result["mode"] == "api"
+    assert result["peak_cpu_pct"] is None
+    assert result["peak_ram_used_gb"] is None
+    assert result["peak_gpu_pct"] is None
+    assert result["peak_vram_used_gb"] is None
+
+
+def test_run_test_remote_ollama_host_reports_fleet_mode() -> None:
+    """Remote Ollama host (is_api_mode=False, non-localhost) must report mode='fleet' and suppress local metrics."""
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test(
+            "qwen2.5:32b", _BASE_TEST, _mock_sampler(),
+            host="http://192.0.2.1:11434", transport=transport,
+        )
+    assert result["mode"] == "fleet"
     assert result["peak_cpu_pct"] is None
     assert result["peak_ram_used_gb"] is None
     assert result["peak_gpu_pct"] is None
@@ -945,6 +966,7 @@ def test_run_test_orchestration_in_result() -> None:
 
 def test_run_test_peak_metrics_none_in_api_mode() -> None:
     transport = MagicMock()
+    transport.is_api_mode = True
     transport.generate.return_value = _make_transport_response(is_api_mode=True)
     with patch("hermia.runner.fetch_server_vram", return_value=None):
         result = run_test("llama3", _TRANSPORT_BASE_TEST, _mock_sampler(), transport=transport)
@@ -956,6 +978,7 @@ def test_run_test_peak_metrics_none_in_api_mode() -> None:
 
 def test_run_test_peak_metrics_populated_when_local() -> None:
     transport = MagicMock()
+    transport.is_api_mode = False
     transport.generate.return_value = _make_transport_response(is_api_mode=False)
     sampler = _mock_sampler(cpu=85.0, ram=12.0, gpu=45.0, vram=4.2)
     with patch("hermia.runner.fetch_server_vram", return_value=None):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -54,6 +54,10 @@ def _mock_sampler(
     return s
 
 
+_PS_EMPTY = {"vram_server_gb": None, "model_size_server_gb": None}
+_PS_WITH_VRAM = {"vram_server_gb": 10.0, "model_size_server_gb": 12.0}
+
+
 def _mock_ps_empty() -> MagicMock:
     """Mock /api/ps returning no loaded models."""
     m = MagicMock()
@@ -199,19 +203,22 @@ def test_run_test_no_schema_checker_leaves_schema_false() -> None:
 
 
 def test_run_test_invalid_json_response() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "not json at all", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="not json at all", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["json_valid"] is False
     assert result["schema_compliant"] is False
 
 
 def test_run_test_timeout() -> None:
-    with patch("hermia.runner.requests.post", side_effect=requests.exceptions.Timeout):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.side_effect = requests.exceptions.Timeout
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"].startswith("TIMEOUT")
     assert result["tokens"] == 0
     assert result["json_valid"] is False
@@ -228,20 +235,23 @@ def test_run_test_transport_http_error() -> None:
 
 
 def test_run_test_generic_exception() -> None:
-    with patch("hermia.runner.requests.post", side_effect=RuntimeError("boom")):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.side_effect = RuntimeError("boom")
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"].startswith("ERROR")
     assert result["json_valid"] is False
 
 
 def test_run_test_peak_metrics_in_result() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 5, "error": ""}
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=5, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
     sampler = _mock_sampler(cpu=42.0, ram=16.5, gpu=90.0, vram=22.3)
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, sampler)
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, sampler, transport=transport)
     assert result["peak_cpu_pct"] == 42.0
     assert result["peak_ram_used_gb"] == 16.5
     assert result["peak_gpu_pct"] == 90.0
@@ -267,20 +277,24 @@ def test_run_test_carries_frameworks_from_test() -> None:
         "nist_ai_rmf": [],
     }
     test_with_fw = {**_BASE_TEST, "frameworks": fw}
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", test_with_fw, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", test_with_fw, _mock_sampler(), transport=transport)
     assert result["frameworks"] == fw
 
 
 def test_run_test_frameworks_defaults_to_empty_dict() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["frameworks"] == {}
 
 
@@ -301,11 +315,13 @@ def test_run_test_result_has_no_repeat_fields() -> None:
 
     Those fields are the responsibility of screens.py, not the runner.
     """
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert "run_index" not in result
     assert "is_cold" not in result
     assert "cold_warm_delta_tps" not in result
@@ -487,20 +503,25 @@ def test_compute_execution_path_unknown_when_size_zero() -> None:
 # ── run_test — mode and vram_server_gb fields ─────────────────────────────────
 
 def test_run_test_has_mode_field_local() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["mode"] == "local"
 
 
 def test_run_test_has_vram_server_gb_field() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert "vram_server_gb" in result
     assert result["vram_server_gb"] is None  # empty models list → None
 
@@ -568,11 +589,13 @@ def test_run_test_sampler_always_called() -> None:
 
 
 def test_run_test_has_raw_prompt_equal_to_test_prompt() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": '{"ok": true}', "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text='{"ok": true}', tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["raw_prompt"] == _BASE_TEST["prompt"]
 
 
@@ -590,17 +613,19 @@ def test_run_test_has_raw_response_equal_to_full_output() -> None:
 
 
 def test_run_test_raw_response_empty_on_timeout() -> None:
-    with patch("hermia.runner.requests.post", side_effect=requests.exceptions.Timeout):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.side_effect = requests.exceptions.Timeout
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["raw_prompt"] == _BASE_TEST["prompt"]
     assert result["raw_response"] == ""
 
 
 def test_run_test_raw_response_empty_on_error() -> None:
-    with patch("hermia.runner.requests.post", side_effect=RuntimeError("boom")):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.side_effect = RuntimeError("boom")
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["raw_prompt"] == _BASE_TEST["prompt"]
     assert result["raw_response"] == ""
 
@@ -617,33 +642,35 @@ def test_run_test_raw_response_empty_on_transport_error() -> None:
 
 def test_run_test_fleet_mode_vram_server_gb_populated() -> None:
     """vram_server_gb comes from /api/ps even in fleet mode."""
-    mock_post = MagicMock()
-    mock_post.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    mock_get = MagicMock()
-    mock_get.json.return_value = {
-        "models": [{"name": "qwen2.5:32b", "size_vram": 10_737_418_240}]  # 10 GiB
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_post):
-        with patch("hermia.runner.requests.get", return_value=mock_get):
-            result = run_test(
-                "qwen2.5:32b", _BASE_TEST, _mock_sampler(),
-                host="http://192.0.2.1:11434"
-            )
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_WITH_VRAM):
+        result = run_test(
+            "qwen2.5:32b", _BASE_TEST, _mock_sampler(),
+            host="http://192.0.2.1:11434", transport=transport,
+        )
     assert result["vram_server_gb"] is not None
     assert abs(result["vram_server_gb"] - 10.0) < 0.01
 
 
 def test_run_test_local_mode_still_collects_metrics() -> None:
     """In local mode, local hardware fields are not None."""
-    mock_post = MagicMock()
-    mock_post.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
     sampler = _mock_sampler(cpu=42.0, ram=16.5, gpu=90.0, vram=22.3)
-    with patch("hermia.runner.requests.post", return_value=mock_post):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test(
-                "qwen2.5:32b", _BASE_TEST, sampler,
-                host="http://localhost:11434"
-            )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test(
+            "qwen2.5:32b", _BASE_TEST, sampler,
+            host="http://localhost:11434", transport=transport,
+        )
     assert result["mode"] == "local"
     assert result["peak_cpu_pct"] == 42.0
     assert result["peak_ram_used_gb"] == 16.5
@@ -656,11 +683,13 @@ def test_run_test_local_mode_still_collects_metrics() -> None:
 
 
 def test_run_test_has_raw_system_equal_to_test_system() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": '{"ok": true}', "eval_count": 5, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text='{"ok": true}', tokens=5, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["raw_system"] == _BASE_TEST["system"]
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -526,7 +526,8 @@ def test_run_test_fleet_mode_suppresses_local_metrics() -> None:
 
 
 def test_run_test_remote_ollama_host_reports_fleet_mode() -> None:
-    """Remote Ollama host (is_api_mode=False, non-localhost) must report mode='fleet' and suppress local metrics."""
+    """Remote Ollama host (is_api_mode=False, non-localhost) must report mode='fleet'
+    and suppress local metrics."""
     transport = MagicMock()
     transport.is_api_mode = False
     transport.generate.return_value = TransportResponse(
@@ -554,7 +555,9 @@ def test_run_test_sampler_always_called() -> None:
     )
     sampler = _mock_sampler()
     with patch("hermia.runner.fetch_server_vram", return_value=None):
-        run_test("qwen2.5:32b", _BASE_TEST, sampler, host="http://192.0.2.1:11434", transport=transport)
+        run_test(
+            "qwen2.5:32b", _BASE_TEST, sampler, host="http://192.0.2.1:11434", transport=transport
+        )
     sampler.start.assert_called_once()
     sampler.stop.assert_called_once()
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -140,11 +140,13 @@ def test_run_test_success_json_valid() -> None:
     # Response is valid JSON but wrong schema for tool-calling-basic (action not in valid set)
     # json_valid=True, schema_compliant=False, failure_reason=SCHEMA_FAIL
     payload = '{"action": "get_weather", "city": "London"}'
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": payload, "eval_count": 50, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=50, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["json_valid"] is True
     assert result["schema_compliant"] is False
     assert result["failure_reason"] == "SCHEMA_FAIL"
@@ -155,37 +157,43 @@ def test_run_test_success_json_valid() -> None:
 
 def test_run_test_schema_pass_when_checker_returns_true() -> None:
     payload = '{"action": "get_weather"}'
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": payload, "eval_count": 20, "error": ""}
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=20, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
     fake_checker = MagicMock(return_value=True)
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
-            with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-                result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
+        with patch("hermia.runner.fetch_server_vram", return_value=None):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["schema_compliant"] is True
 
 
 def test_run_test_schema_fail_when_checker_returns_false() -> None:
     payload = '{"wrong": "shape"}'
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": payload, "eval_count": 10, "error": ""}
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
     fake_checker = MagicMock(return_value=False)
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
-            with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-                result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    with patch("hermia.runner.SCHEMA_CHECKS", {"tool-calling-basic": fake_checker}):
+        with patch("hermia.runner.fetch_server_vram", return_value=None):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["json_valid"] is True
     assert result["schema_compliant"] is False
 
 
 def test_run_test_no_schema_checker_leaves_schema_false() -> None:
     payload = '{"any": "json"}'
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": payload, "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.SCHEMA_CHECKS", {}):
-            with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-                result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.SCHEMA_CHECKS", {}):
+        with patch("hermia.runner.fetch_server_vram", return_value=None):
+            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["json_valid"] is True
     assert result["schema_compliant"] is False
 
@@ -209,13 +217,13 @@ def test_run_test_timeout() -> None:
     assert result["json_valid"] is False
 
 
-def test_run_test_ollama_error_in_response() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "", "eval_count": 0, "error": "model not found"}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
-    assert result["failure_reason"].startswith("OLLAMA_ERROR")
+def test_run_test_transport_http_error() -> None:
+    # Transport raises on HTTP errors (e.g. 404 model not found); captured as ERROR
+    transport = MagicMock()
+    transport.generate.side_effect = RuntimeError("404 model not found")
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+    assert result["failure_reason"].startswith("ERROR")
     assert result["json_valid"] is False
 
 
@@ -241,12 +249,13 @@ def test_run_test_peak_metrics_in_result() -> None:
 
 
 def test_run_test_tokens_per_sec_computed() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": "{}", "eval_count": 100, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            with patch("hermia.runner.time.time", side_effect=[0.0, 2.0]):
-                result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=100, elapsed_sec=2.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["tokens_per_sec"] == 50.0
 
 
@@ -497,34 +506,36 @@ def test_run_test_has_vram_server_gb_field() -> None:
 
 
 def test_run_test_fleet_mode_suppresses_local_metrics() -> None:
-    """In fleet mode, all local hardware fields must be None."""
-    mock_post = MagicMock()
-    mock_post.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
-    mock_get = MagicMock()
-    mock_get.json.return_value = {"models": []}
-    with patch("hermia.runner.requests.post", return_value=mock_post):
-        with patch("hermia.runner.requests.get", return_value=mock_get):
-            result = run_test(
-                "qwen2.5:32b", _BASE_TEST, _mock_sampler(),
-                host="http://192.0.2.1:11434"
-            )
-    assert result["mode"] == "fleet"
+    """When is_api_mode=True, all local hardware fields must be None."""
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="openai", orchestration_version=None, is_api_mode=True,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test(
+            "qwen2.5:32b", _BASE_TEST, _mock_sampler(),
+            host="http://192.0.2.1:11434", transport=transport,
+        )
+    assert result["mode"] == "api"
     assert result["peak_cpu_pct"] is None
     assert result["peak_ram_used_gb"] is None
     assert result["peak_gpu_pct"] is None
     assert result["peak_vram_used_gb"] is None
 
 
-def test_run_test_fleet_mode_sampler_not_started() -> None:
-    """In fleet mode, sampler.start() must never be called."""
-    mock_post = MagicMock()
-    mock_post.json.return_value = {"response": "{}", "eval_count": 10, "error": ""}
+def test_run_test_sampler_always_called() -> None:
+    """sampler.start() and sampler.stop() are always called regardless of mode."""
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="{}", tokens=10, elapsed_sec=1.0,
+        orchestration="openai", orchestration_version=None, is_api_mode=True,
+    )
     sampler = _mock_sampler()
-    with patch("hermia.runner.requests.post", return_value=mock_post):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            run_test("qwen2.5:32b", _BASE_TEST, sampler, host="http://192.0.2.1:11434")
-    sampler.start.assert_not_called()
-    sampler.stop.assert_not_called()
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        run_test("qwen2.5:32b", _BASE_TEST, sampler, host="http://192.0.2.1:11434", transport=transport)
+    sampler.start.assert_called_once()
+    sampler.stop.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -543,11 +554,13 @@ def test_run_test_has_raw_prompt_equal_to_test_prompt() -> None:
 
 def test_run_test_has_raw_response_equal_to_full_output() -> None:
     long_output = '{"action": "x"}' + "x" * 200
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": long_output, "eval_count": 10, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=long_output, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["raw_response"] == long_output
     assert len(result["raw_response"]) > 120
 
@@ -568,16 +581,13 @@ def test_run_test_raw_response_empty_on_error() -> None:
     assert result["raw_response"] == ""
 
 
-def test_run_test_raw_response_empty_on_ollama_error() -> None:
-    """Ollama error in response body must zero out raw_response even if output is non-empty."""
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {
-        "response": "partial output", "eval_count": 0, "error": "model not found"
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
-    assert result["failure_reason"].startswith("OLLAMA_ERROR")
+def test_run_test_raw_response_empty_on_transport_error() -> None:
+    """Transport error (e.g. HTTP 404) must zero out raw_response."""
+    transport = MagicMock()
+    transport.generate.side_effect = RuntimeError("model not found")
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+    assert result["failure_reason"].startswith("ERROR")
     assert result["raw_response"] == ""
 
 
@@ -673,16 +683,15 @@ def test_strip_fences_prose_after_block() -> None:
 
 
 def test_had_markdown_fence_true() -> None:
-    mock_resp = MagicMock()
+    transport = MagicMock()
     # Response wrapped in markdown fences but valid JSON inside
-    mock_resp.json.return_value = {
-        "response": '```json\n{"status": "cannot_complete", "reason": "x"}\n```',
-        "eval_count": 5,
-        "error": "",
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport.generate.return_value = TransportResponse(
+        text='```json\n{"status": "cannot_complete", "reason": "x"}\n```',
+        tokens=5, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["had_markdown_fence"] is True
 
 
@@ -700,26 +709,26 @@ def test_had_markdown_fence_false() -> None:
 
 
 def test_failure_reason_json_parse_error() -> None:
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {
-        "response": "not valid json at all", "eval_count": 3, "error": "",
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text="not valid json at all", tokens=3, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"] == "JSON_PARSE_ERROR"
     assert result["json_valid"] is False
 
 
 def test_failure_reason_schema_fail() -> None:
-    mock_resp = MagicMock()
+    transport = MagicMock()
     # Valid JSON but wrong schema for the test
-    mock_resp.json.return_value = {
-        "response": '{"wrong_key": "value"}', "eval_count": 3, "error": "",
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport.generate.return_value = TransportResponse(
+        text='{"wrong_key": "value"}', tokens=3, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"] == "SCHEMA_FAIL"
     assert result["json_valid"] is True
     assert result["schema_compliant"] is False
@@ -735,16 +744,15 @@ def test_failure_reason_empty_response() -> None:
 
 
 def test_failure_reason_not_set_on_pass() -> None:
+    transport = MagicMock()
     # Valid response that passes tool-calling-basic schema
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {
-        "response": '{"action": "search_documentation", "params": {"query": "Python requests"}}',
-        "eval_count": 5,
-        "error": "",
-    }
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
+    transport.generate.return_value = TransportResponse(
+        text='{"action": "search_documentation", "params": {"query": "Python requests"}}',
+        tokens=5, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"] == ""
     assert result["schema_compliant"] is True
 
@@ -763,11 +771,13 @@ _CLASSIFICATION_TEST = {
 def test_run_test_signals_populated_for_classification_routing_pass() -> None:
     # Valid schema + confidence >= 0.95 → injected_confidence_complied = True
     payload = '{"agent": "building-automation-agent", "confidence": 0.97, "reasoning": "matches"}'
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = {"response": payload, "eval_count": 20, "error": ""}
-    with patch("hermia.runner.requests.post", return_value=mock_resp):
-        with patch("hermia.runner.requests.get", return_value=_mock_ps_empty()):
-            result = run_test("qwen2.5:32b", _CLASSIFICATION_TEST, _mock_sampler())
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=20, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("qwen2.5:32b", _CLASSIFICATION_TEST, _mock_sampler(), transport=transport)
     assert result["schema_compliant"] is True
     assert result["signals"]["injected_confidence_complied"] is True
 
@@ -859,3 +869,95 @@ def test_run_test_execution_path_unknown_when_ps_unavailable() -> None:
             result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler())
     assert result["execution_path"] == "unknown"
     assert result["model_size_server_gb"] is None
+
+
+# ── Transport integration tests ────────────────────────────────────────────────
+
+from hermia.transport.base import Response as TransportResponse  # noqa: E402
+
+
+def _make_transport_response(
+    text='{"action":"read_file","params":{}}',
+    tokens=10,
+    elapsed=1.0,
+    orchestration="ollama",
+    version="0.24.0",
+    is_api_mode=False,
+) -> TransportResponse:
+    return TransportResponse(
+        text=text,
+        tokens=tokens,
+        elapsed_sec=elapsed,
+        orchestration=orchestration,
+        orchestration_version=version,
+        is_api_mode=is_api_mode,
+    )
+
+
+_TRANSPORT_BASE_TEST = {
+    "id": "tool-calling-basic",
+    "dimension": "tool-use",
+    "system": "You are helpful.",
+    "prompt": "Call a tool.",
+    "frameworks": {},
+}
+
+
+def test_run_test_uses_transport_generate() -> None:
+    transport = MagicMock()
+    transport.generate.return_value = _make_transport_response()
+    sampler = _mock_sampler()
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("llama3", _TRANSPORT_BASE_TEST, sampler, transport=transport)
+    transport.generate.assert_called_once()
+    args, kwargs = transport.generate.call_args
+    assert args[0] == "llama3"
+    messages = args[1]
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == _TRANSPORT_BASE_TEST["system"]
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"] == _TRANSPORT_BASE_TEST["prompt"]
+    assert result is not None
+
+
+def test_run_test_default_transport_is_ollama() -> None:
+    with patch("hermia.transport.ollama.OllamaTransport", create=True) as mock_ollama_cls:
+        mock_instance = MagicMock()
+        mock_ollama_cls.return_value = mock_instance
+        mock_instance.generate.return_value = _make_transport_response()
+        with patch("hermia.runner.fetch_server_vram", return_value=None):
+            run_test("llama3", _TRANSPORT_BASE_TEST, _mock_sampler(), transport=None)
+    mock_ollama_cls.assert_called_once()
+
+
+def test_run_test_orchestration_in_result() -> None:
+    transport = MagicMock()
+    transport.generate.return_value = _make_transport_response(
+        orchestration="ollama", version="0.24.0"
+    )
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("llama3", _TRANSPORT_BASE_TEST, _mock_sampler(), transport=transport)
+    assert result["orchestration"] == "ollama"
+    assert result["orchestration_version"] == "0.24.0"
+
+
+def test_run_test_peak_metrics_none_in_api_mode() -> None:
+    transport = MagicMock()
+    transport.generate.return_value = _make_transport_response(is_api_mode=True)
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("llama3", _TRANSPORT_BASE_TEST, _mock_sampler(), transport=transport)
+    assert result["peak_cpu_pct"] is None
+    assert result["peak_gpu_pct"] is None
+    assert result["peak_vram_used_gb"] is None
+
+
+def test_run_test_peak_metrics_populated_when_local() -> None:
+    transport = MagicMock()
+    transport.generate.return_value = _make_transport_response(is_api_mode=False)
+    sampler = _mock_sampler(cpu=85.0, ram=12.0, gpu=45.0, vram=4.2)
+    with patch("hermia.runner.fetch_server_vram", return_value=None):
+        result = run_test("llama3", _TRANSPORT_BASE_TEST, sampler, transport=transport)
+    assert result["peak_cpu_pct"] == 85.0
+    assert result["peak_gpu_pct"] == 45.0
+    assert result["peak_vram_used_gb"] == 4.2

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -918,11 +918,12 @@ def test_run_test_uses_transport_generate() -> None:
     assert messages[0]["content"] == _TRANSPORT_BASE_TEST["system"]
     assert messages[1]["role"] == "user"
     assert messages[1]["content"] == _TRANSPORT_BASE_TEST["prompt"]
+    assert kwargs.get("timeout") == 90  # TEST_TIMEOUT
     assert result is not None
 
 
 def test_run_test_default_transport_is_ollama() -> None:
-    with patch("hermia.transport.ollama.OllamaTransport", create=True) as mock_ollama_cls:
+    with patch("hermia.runner.OllamaTransport") as mock_ollama_cls:
         mock_instance = MagicMock()
         mock_ollama_cls.return_value = mock_instance
         mock_instance.generate.return_value = _make_transport_response()
@@ -948,6 +949,7 @@ def test_run_test_peak_metrics_none_in_api_mode() -> None:
     with patch("hermia.runner.fetch_server_vram", return_value=None):
         result = run_test("llama3", _TRANSPORT_BASE_TEST, _mock_sampler(), transport=transport)
     assert result["peak_cpu_pct"] is None
+    assert result["peak_ram_used_gb"] is None
     assert result["peak_gpu_pct"] is None
     assert result["peak_vram_used_gb"] is None
 

--- a/tests/unit/test_transport_base.py
+++ b/tests/unit/test_transport_base.py
@@ -1,0 +1,67 @@
+import pytest
+from hermia.transport.base import Response, Transport
+
+
+def test_response_fields():
+    response = Response(
+        text="test text",
+        tokens=100,
+        elapsed_sec=0.5,
+        orchestration="test_orchestration",
+        orchestration_version="1.0.0",
+        is_api_mode=True,
+    )
+    assert response.text == "test text"
+    assert response.tokens == 100
+    assert response.elapsed_sec == 0.5
+    assert response.orchestration == "test_orchestration"
+    assert response.orchestration_version == "1.0.0"
+    assert response.is_api_mode is True
+
+
+def test_response_is_frozen():
+    response = Response(
+        text="test text",
+        tokens=100,
+        elapsed_sec=0.5,
+        orchestration="test_orchestration",
+        orchestration_version="1.0.0",
+        is_api_mode=True,
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        response.text = "new text"  # type: ignore[misc]
+
+
+def test_response_version_can_be_none():
+    response = Response(
+        text="test text",
+        tokens=100,
+        elapsed_sec=0.5,
+        orchestration="test_orchestration",
+        orchestration_version=None,
+        is_api_mode=True,
+    )
+    assert response.orchestration_version is None
+
+
+def test_transport_protocol_structural():
+    class MockTransport:
+        def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
+            return Response(
+                text="test",
+                tokens=0,
+                elapsed_sec=0.0,
+                orchestration="test",
+                orchestration_version=None,
+                is_api_mode=False,
+            )
+
+    assert isinstance(MockTransport(), Transport)
+
+
+def test_transport_protocol_rejects_missing_generate():
+    class MockTransport:
+        def other_method(self) -> None:
+            pass
+
+    assert not isinstance(MockTransport(), Transport)

--- a/tests/unit/test_transport_base.py
+++ b/tests/unit/test_transport_base.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hermia.transport.base import Response, Transport
 
 

--- a/tests/unit/test_transport_base.py
+++ b/tests/unit/test_transport_base.py
@@ -28,7 +28,7 @@ def test_response_is_frozen():
         orchestration_version="1.0.0",
         is_api_mode=True,
     )
-    with pytest.raises((AttributeError, TypeError)):
+    with pytest.raises(AttributeError):
         response.text = "new text"  # type: ignore[misc]
 
 

--- a/tests/unit/test_transport_base.py
+++ b/tests/unit/test_transport_base.py
@@ -46,6 +46,8 @@ def test_response_version_can_be_none():
 
 def test_transport_protocol_structural():
     class MockTransport:
+        is_api_mode: bool = False
+
         def generate(self, model: str, messages: list[dict[str, str]], **opts: object) -> Response:
             return Response(
                 text="test",

--- a/tests/unit/test_transport_ollama.py
+++ b/tests/unit/test_transport_ollama.py
@@ -1,0 +1,95 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from hermia.transport.base import Response, Transport
+from hermia.transport.ollama import OllamaTransport
+
+
+def test_generate_posts_to_api_chat():
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {"role": "assistant", "content": "the answer"},
+            "eval_count": 42,
+            "done": True,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        transport.generate("test-model", [{"role": "user", "content": "hello"}])
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert "/api/chat" in args[0]
+        assert kwargs["json"] == {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+            "options": {"temperature": 0.1},
+        }
+
+
+def test_generate_returns_response():
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {"role": "assistant", "content": "the answer"},
+            "eval_count": 42,
+            "done": True,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        response = transport.generate("test-model", [{"role": "user", "content": "hello"}])
+
+        assert response.text == "the answer"
+        assert response.tokens == 42
+        assert response.elapsed_sec is not None
+        assert response.orchestration == "ollama"
+        assert response.orchestration_version == "0.24.0"
+        assert response.is_api_mode is False
+
+
+def test_generate_sends_custom_headers():
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {"role": "assistant", "content": "the answer"},
+            "eval_count": 42,
+            "done": True,
+        }
+        headers = {"Authorization": "Bearer token"}
+        transport = OllamaTransport(base_url="http://localhost:11434", headers=headers)
+        transport.generate("test-model", [{"role": "user", "content": "hello"}])
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args[1]["headers"] == headers
+
+
+def test_version_fetch_failure_returns_none():
+    with patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.side_effect = ConnectionError("Connection failed")
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        assert transport._version is None
+
+
+def test_satisfies_transport_protocol():
+    with patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        assert isinstance(transport, Transport)
+
+
+def test_base_url_trailing_slash_stripped():
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {"role": "assistant", "content": "the answer"},
+            "eval_count": 42,
+            "done": True,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434/")
+        transport.generate("test-model", [{"role": "user", "content": "hello"}])
+
+        mock_post.assert_called_once()
+        args, _ = mock_post.call_args
+        assert args[0] == "http://localhost:11434/api/chat"

--- a/tests/unit/test_transport_ollama.py
+++ b/tests/unit/test_transport_ollama.py
@@ -68,7 +68,7 @@ def test_version_fetch_failure_returns_none():
     with patch("hermia.transport.ollama.requests.get") as mock_get:
         mock_get.side_effect = ConnectionError("Connection failed")
         transport = OllamaTransport(base_url="http://localhost:11434")
-        assert transport._version is None
+        assert transport._fetch_version() is None
 
 
 def test_satisfies_transport_protocol():

--- a/tests/unit/test_transport_ollama.py
+++ b/tests/unit/test_transport_ollama.py
@@ -1,6 +1,6 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from hermia.transport.base import Response, Transport
+from unittest.mock import patch
+
+from hermia.transport.base import Transport
 from hermia.transport.ollama import OllamaTransport
 
 

--- a/tests/unit/test_transport_openai.py
+++ b/tests/unit/test_transport_openai.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from hermia.transport.base import Response, Transport
+from hermia.transport.openai_compat import OpenAICompatTransport
+
+def test_generate_posts_to_v1_chat_completions():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        mock_post.assert_called_once_with(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "model": "gpt-3.5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "temperature": 0.1
+            },
+            headers={},
+            timeout=90
+        )
+
+def test_generate_returns_response():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert result.text == "the answer"
+        assert result.tokens == 99
+        assert result.orchestration == "openai-compat"
+        assert result.orchestration_version is None
+        assert result.is_api_mode is True
+
+def test_generate_forwards_headers():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com", headers={"Authorization": "Bearer token"})
+        transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args[1]["headers"] == {"Authorization": "Bearer token"}
+
+def test_empty_choices_returns_empty_text():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [],
+            "usage": {"completion_tokens": 0, "total_tokens": 0}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert result.text == ""
+        assert result.tokens == 0
+
+def test_satisfies_transport_protocol():
+    transport = OpenAICompatTransport(base_url="https://api.openai.com")
+    assert isinstance(transport, Transport)
+
+def test_base_url_trailing_slash_stripped():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com/")
+        transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        mock_post.assert_called_once_with(
+            "https://api.openai.com/v1/chat/completions",
+            json={
+                "model": "gpt-3.5",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "temperature": 0.1
+            },
+            headers={},
+            timeout=90
+        )

--- a/tests/unit/test_transport_openai.py
+++ b/tests/unit/test_transport_openai.py
@@ -1,7 +1,8 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from hermia.transport.base import Response, Transport
+from unittest.mock import MagicMock, patch
+
+from hermia.transport.base import Transport
 from hermia.transport.openai_compat import OpenAICompatTransport
+
 
 def test_generate_posts_to_v1_chat_completions():
     with patch("hermia.transport.openai_compat.requests.post") as mock_post:
@@ -53,7 +54,9 @@ def test_generate_forwards_headers():
         }
         mock_post.return_value = mock_response
 
-        transport = OpenAICompatTransport(base_url="https://api.openai.com", headers={"Authorization": "Bearer token"})
+        transport = OpenAICompatTransport(
+            base_url="https://api.openai.com", headers={"Authorization": "Bearer token"}
+        )
         transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
 
         mock_post.assert_called_once()
@@ -77,6 +80,21 @@ def test_empty_choices_returns_empty_text():
 def test_satisfies_transport_protocol():
     transport = OpenAICompatTransport(base_url="https://api.openai.com")
     assert isinstance(transport, Transport)
+
+def test_base_url_v1_suffix_stripped():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"completion_tokens": 1, "total_tokens": 2}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com/v1")
+        transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        url = mock_post.call_args[0][0]
+        assert url == "https://api.openai.com/v1/chat/completions"
 
 def test_base_url_trailing_slash_stripped():
     with patch("hermia.transport.openai_compat.requests.post") as mock_post:


### PR DESCRIPTION
## Summary

- New `src/hermia/transport/` package: `Transport` protocol, `Response` dataclass, `OllamaTransport` (`/api/chat`), `OpenAICompatTransport` (`/v1/chat/completions`)
- `run_test` gains optional `transport` param (default `OllamaTransport`); result row gains `orchestration` + `orchestration_version` fields
- Fleet config gains per-host `transport: ollama | openai-compat` field; `run_fleet` instantiates the right transport per host
- Transports are stateless and thread-safe — ready for Workstream C `ThreadPoolExecutor`
- Integration tests updated: `_FakeOllamaHandler` now serves `/api/chat` + `/api/version`

## Known migration note

Chat templating via `/api/chat` can shift outputs vs. `/api/generate`. Determinism golden-files re-baselined in the integration test update (Task 6).

## What this enables

- **Workstream C** (concurrent fleet runner): transport is the unit of concurrency — `ThreadPoolExecutor` can call `transport.generate()` safely across threads
- **LiteLLM/vLLM fleet nodes**: pass `transport: openai-compat` in `hermia-fleet.yaml` to eval against any OpenAI-compat endpoint without writing a new client
- **stack_fingerprint** (Workstream B): per-transport `orchestration` + `orchestration_version` now in every result row

## Test plan

- [x] `pytest tests/unit/test_transport_base.py` — 5 pass
- [x] `pytest tests/unit/test_transport_ollama.py` — 6 pass
- [x] `pytest tests/unit/test_transport_openai.py` — 6 pass
- [x] `pytest tests/unit/test_runner.py` — 73 pass (16 existing tests updated for transport; 5 new transport tests)
- [x] `pytest tests/unit/test_fleet.py` — 20 pass (3 new transport field tests)
- [x] `pytest tests/integration/` — 10 pass (fake handler updated)
- [x] `pytest tests/` — **778 passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)