### PR TITLE
fix: default results to ~/.hermia/results/, show full path in output

### DIFF
--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -104,9 +104,8 @@ def _backfill_aggregates(run_results: list[dict[str, Any]]) -> None:
 
 def _default_results_dir() -> Path:
     env = os.environ.get("HERMIA_RESULTS_DIR")
-    if env:
-        return Path(env)
-    return Path.home() / ".hermia" / "results"
+    base = Path(env) if env else Path.home() / ".hermia" / "results"
+    return base.expanduser().resolve()
 
 
 RESULTS_DIR = _default_results_dir()
@@ -443,7 +442,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
 
         if scored:
             lines.append(f"\nBest: [bold]{scored[0][0]}[/bold] ({scored[0][3] * 100:.0f}/100)")
-        lines.append(f"Saved: {jsonl_path}  |  {csv_path.name}")
+        lines.append(f"Saved: {jsonl_path}  |  {csv_path}")
 
         summary_text = "\n".join(lines)
         app.call_from_thread(self._safe_update_summary, summary_text)

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -102,7 +102,14 @@ def _backfill_aggregates(run_results: list[dict[str, Any]]) -> None:
         row["robustness_n"] = result.n
 
 
-RESULTS_DIR = Path("results")
+def _default_results_dir() -> Path:
+    env = os.environ.get("HERMIA_RESULTS_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".hermia" / "results"
+
+
+RESULTS_DIR = _default_results_dir()
 
 
 class SelectionScreen(Screen):  # type: ignore[type-arg]
@@ -322,7 +329,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
         jsonl_path, csv_path = open_run(RESULTS_DIR)
         run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
         run_host = socket.gethostname()
-        append_log(f"Writing results to {jsonl_path.name} (appended after each test)", "info")
+        append_log(f"Writing results to {jsonl_path} (appended after each test)", "info")
         append_log("", "")
 
         load_stats: dict[str, dict[str, float]] = {}
@@ -436,7 +443,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
 
         if scored:
             lines.append(f"\nBest: [bold]{scored[0][0]}[/bold] ({scored[0][3] * 100:.0f}/100)")
-        lines.append(f"Saved: {jsonl_path.name}  |  {csv_path.name}")
+        lines.append(f"Saved: {jsonl_path}  |  {csv_path.name}")
 
         summary_text = "\n".join(lines)
         app.call_from_thread(self._safe_update_summary, summary_text)


### PR DESCRIPTION
## Summary

- `RESULTS_DIR` now defaults to `~/.hermia/results/` instead of `./results/` relative to CWD — results land in the same place regardless of where `hermia` is invoked from
- `HERMIA_RESULTS_DIR` env var overrides the default for CI/scripted/custom workflows
- "Writing results to …" and "Saved: …" messages now show the full absolute path

## Why

Users installing via `pip install -e .` from a git clone and running `hermia` from a different directory were surprised to find results scattered across their filesystem. The CWD-relative default also made the preflight output ambiguous (showed only the filename, not the full path).

## Test plan
- [ ] All 804 existing tests pass
- [ ] Run `hermia` from home dir — confirm results land in `~/.hermia/results/`
- [ ] Run `HERMIA_RESULTS_DIR=/tmp/test hermia` — confirm override works
- [ ] Confirm preflight and summary show full absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)