### PR TITLE
feat(agent): hermia-agent v1 — GET /gpu gaming-gate endpoint

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,0 +1,45 @@
+name: hermia-agent CI
+
+on:
+  push:
+    paths:
+      - cmd/hermia-agent/**
+      - .github/workflows/agent.yml
+  pull_request:
+    paths:
+      - cmd/hermia-agent/**
+      - .github/workflows/agent.yml
+
+jobs:
+  build:
+    name: Windows build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: cmd/hermia-agent/go.sum
+      - name: go vet
+        run: go vet ./...
+        working-directory: cmd/hermia-agent
+      - name: go build
+        run: go build -o hermia-agent.exe ./...
+        working-directory: cmd/hermia-agent
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: '0'
+
+  test:
+    name: Cross-platform unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: cmd/hermia-agent/go.sum
+      - name: go test (pure functions)
+        run: go test -v -run 'TestParseInstanceName|TestAggregateEngineCounters|TestBearerAuth' ./...
+        working-directory: cmd/hermia-agent

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -40,6 +40,6 @@ jobs:
         with:
           go-version: '1.22'
           cache-dependency-path: cmd/hermia-agent/go.sum
-      - name: go test (pure functions)
-        run: go test -v -run 'TestParseInstanceName|TestAggregateEngineCounters|TestBearerAuth' ./...
+      - name: go test
+        run: go test -v ./...
         working-directory: cmd/hermia-agent

--- a/cmd/hermia-agent/auth.go
+++ b/cmd/hermia-agent/auth.go
@@ -26,6 +26,7 @@ func newBearerAuth(token string) func(http.Handler) http.Handler {
 			gotHash := sha256.Sum256([]byte(gotToken))
 			if subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) != 1 {
 				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("WWW-Authenticate", `Bearer realm="hermia-agent"`)
 				w.WriteHeader(http.StatusUnauthorized)
 				json.NewEncoder(w).Encode(errResponse{Status: "error", Error: "unauthorized"}) //nolint:errcheck
 				return

--- a/cmd/hermia-agent/auth.go
+++ b/cmd/hermia-agent/auth.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type errResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+func newBearerAuth(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			var gotToken string
+			if strings.HasPrefix(authHeader, "Bearer ") {
+				gotToken = authHeader[7:]
+			}
+			if subtle.ConstantTimeCompare([]byte(gotToken), []byte(token)) != 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(errResponse{Status: "error", Error: "unauthorized"}) //nolint:errcheck
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/cmd/hermia-agent/auth.go
+++ b/cmd/hermia-agent/auth.go
@@ -18,8 +18,9 @@ func newBearerAuth(token string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
 			var gotToken string
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				gotToken = authHeader[7:]
+			// RFC 7235 §2.1: scheme tokens are case-insensitive.
+			if scheme, rest, found := strings.Cut(authHeader, " "); found && strings.EqualFold(scheme, "Bearer") {
+				gotToken = rest
 			}
 			gotHash := sha256.Sum256([]byte(gotToken))
 			wantHash := sha256.Sum256([]byte(token))

--- a/cmd/hermia-agent/auth.go
+++ b/cmd/hermia-agent/auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"net/http"
@@ -20,7 +21,9 @@ func newBearerAuth(token string) func(http.Handler) http.Handler {
 			if strings.HasPrefix(authHeader, "Bearer ") {
 				gotToken = authHeader[7:]
 			}
-			if subtle.ConstantTimeCompare([]byte(gotToken), []byte(token)) != 1 {
+			gotHash := sha256.Sum256([]byte(gotToken))
+			wantHash := sha256.Sum256([]byte(token))
+			if subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) != 1 {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
 				json.NewEncoder(w).Encode(errResponse{Status: "error", Error: "unauthorized"}) //nolint:errcheck

--- a/cmd/hermia-agent/auth.go
+++ b/cmd/hermia-agent/auth.go
@@ -14,6 +14,7 @@ type errResponse struct {
 }
 
 func newBearerAuth(token string) func(http.Handler) http.Handler {
+	wantHash := sha256.Sum256([]byte(token))
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
@@ -23,7 +24,6 @@ func newBearerAuth(token string) func(http.Handler) http.Handler {
 				gotToken = rest
 			}
 			gotHash := sha256.Sum256([]byte(gotToken))
-			wantHash := sha256.Sum256([]byte(token))
 			if subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) != 1 {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)

--- a/cmd/hermia-agent/auth_test.go
+++ b/cmd/hermia-agent/auth_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBearerAuth(t *testing.T) {
+	const validToken = "correct-token"
+
+	// newBearerAuth uses crypto/subtle.ConstantTimeCompare internally.
+	// These are functional correctness tests; timing properties are not verified here.
+	authMiddleware := newBearerAuth(validToken)
+
+	tests := []struct {
+		name          string
+		authHeader    string
+		expectStatus  int
+		expectBody    string
+		handlerCalled bool
+	}{
+		{
+			name:          "Valid token passes",
+			authHeader:    "Bearer correct-token",
+			expectStatus:  http.StatusOK,
+			handlerCalled: true,
+		},
+		{
+			name:          "Wrong token",
+			authHeader:    "Bearer wrong-token",
+			expectStatus:  http.StatusUnauthorized,
+			expectBody:    `"status":"error"`,
+			handlerCalled: false,
+		},
+		{
+			name:          "Missing Authorization header",
+			authHeader:    "",
+			expectStatus:  http.StatusUnauthorized,
+			expectBody:    `"error":"unauthorized"`,
+			handlerCalled: false,
+		},
+		{
+			name:          "Malformed header no Bearer prefix",
+			authHeader:    "sometoken",
+			expectStatus:  http.StatusUnauthorized,
+			expectBody:    `"error":"unauthorized"`,
+			handlerCalled: false,
+		},
+		{
+			name:          "Empty token after Bearer",
+			authHeader:    "Bearer ",
+			expectStatus:  http.StatusUnauthorized,
+			expectBody:    `"error":"unauthorized"`,
+			handlerCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handlerCalled bool
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/gpu", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			authMiddleware(inner).ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.expectStatus)
+			}
+			if handlerCalled != tt.handlerCalled {
+				t.Errorf("handlerCalled = %v, want %v", handlerCalled, tt.handlerCalled)
+			}
+			if tt.expectBody != "" && !strings.Contains(rec.Body.String(), tt.expectBody) {
+				t.Errorf("body = %q, want it to contain %q", rec.Body.String(), tt.expectBody)
+			}
+		})
+	}
+}

--- a/cmd/hermia-agent/auth_test.go
+++ b/cmd/hermia-agent/auth_test.go
@@ -42,6 +42,12 @@ func TestBearerAuth(t *testing.T) {
 			handlerCalled: false,
 		},
 		{
+			name:          "Lowercase bearer scheme accepted (RFC 7235)",
+			authHeader:    "bearer correct-token",
+			expectStatus:  http.StatusOK,
+			handlerCalled: true,
+		},
+		{
 			name:          "Malformed header no Bearer prefix",
 			authHeader:    "sometoken",
 			expectStatus:  http.StatusUnauthorized,

--- a/cmd/hermia-agent/go.mod
+++ b/cmd/hermia-agent/go.mod
@@ -1,0 +1,5 @@
+module github.com/scottbly/hermia/cmd/hermia-agent
+
+go 1.22
+
+require golang.org/x/sys v0.21.0

--- a/cmd/hermia-agent/go.sum
+++ b/cmd/hermia-agent/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/cmd/hermia-agent/gpu_aggregate.go
+++ b/cmd/hermia-agent/gpu_aggregate.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+type gpuResult struct {
+	Engines map[string]float64
+	Gaming  bool
+	Err     error
+}
+
 type pdhSample struct {
 	instance string
 	value    float64

--- a/cmd/hermia-agent/gpu_aggregate.go
+++ b/cmd/hermia-agent/gpu_aggregate.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+type pdhSample struct {
+	instance string
+	value    float64
+}
+
+type parsedInstance struct {
+	physIdx int
+	gpuIdx  int
+	engType string
+}
+
+func parseInstanceName(name string) parsedInstance {
+	p := parsedInstance{engType: "Other"}
+
+	if i := strings.Index(name, "phys_"); i != -1 {
+		rest := name[i+5:]
+		if end := strings.Index(rest, "_"); end != -1 {
+			if v, err := strconv.Atoi(rest[:end]); err == nil {
+				p.physIdx = v
+			}
+		}
+	}
+
+	if i := strings.Index(name, "gpu_"); i != -1 {
+		rest := name[i+4:]
+		if end := strings.Index(rest, "_"); end != -1 {
+			if v, err := strconv.Atoi(rest[:end]); err == nil {
+				p.gpuIdx = v
+			}
+		}
+	}
+
+	if i := strings.Index(name, "engtype_"); i != -1 {
+		rest := name[i+8:]
+		// delimit at the next underscore so a future suffix (e.g. "3D_v2")
+		// doesn't cause silent misclassification to "Other"
+		if end := strings.Index(rest, "_"); end != -1 {
+			rest = rest[:end]
+		}
+		switch rest {
+		case "3D", "Compute", "Copy", "VideoDecode", "VideoEncode":
+			p.engType = rest
+		}
+	}
+
+	return p
+}
+
+func aggregateEngineCounters(samples []pdhSample) map[string]float64 {
+	engines := make(map[string]float64)
+	for _, s := range samples {
+		p := parseInstanceName(s.instance)
+		engines[p.engType] += s.value
+	}
+	return engines
+}

--- a/cmd/hermia-agent/gpu_aggregate.go
+++ b/cmd/hermia-agent/gpu_aggregate.go
@@ -22,18 +22,20 @@ func parseInstanceName(name string) parsedInstance {
 	if i := strings.Index(name, "phys_"); i != -1 {
 		rest := name[i+5:]
 		if end := strings.Index(rest, "_"); end != -1 {
-			if v, err := strconv.Atoi(rest[:end]); err == nil {
-				p.physIdx = v
-			}
+			rest = rest[:end]
+		}
+		if v, err := strconv.Atoi(rest); err == nil {
+			p.physIdx = v
 		}
 	}
 
 	if i := strings.Index(name, "gpu_"); i != -1 {
 		rest := name[i+4:]
 		if end := strings.Index(rest, "_"); end != -1 {
-			if v, err := strconv.Atoi(rest[:end]); err == nil {
-				p.gpuIdx = v
-			}
+			rest = rest[:end]
+		}
+		if v, err := strconv.Atoi(rest); err == nil {
+			p.gpuIdx = v
 		}
 	}
 

--- a/cmd/hermia-agent/gpu_aggregate_test.go
+++ b/cmd/hermia-agent/gpu_aggregate_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseInstanceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected parsedInstance
+	}{
+		{
+			name:     "Standard 3D engine",
+			input:    "pid_4132_luid_0x00000000000A1234_phys_0_gpu_0_engtype_3D",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "3D"},
+		},
+		{
+			name:     "Compute engine",
+			input:    "pid_880_luid_0x00000000000A1234_phys_0_gpu_0_engtype_Compute",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "Compute"},
+		},
+		{
+			name:     "Copy engine",
+			input:    "pid_1024_luid_0x00000000000A1234_phys_0_gpu_0_engtype_Copy",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "Copy"},
+		},
+		{
+			name:     "VideoDecode engine",
+			input:    "pid_512_luid_0x00000000000A1234_phys_0_gpu_1_engtype_VideoDecode",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 1, engType: "VideoDecode"},
+		},
+		{
+			name:     "VideoEncode engine",
+			input:    "pid_512_luid_0x00000000000A1234_phys_0_gpu_2_engtype_VideoEncode",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 2, engType: "VideoEncode"},
+		},
+		{
+			name:     "Unknown engine type",
+			input:    "pid_512_luid_0x00000000000A1234_phys_0_gpu_0_engtype_Scheduler",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "Other"},
+		},
+		{
+			name:     "Multi-GPU second physical",
+			input:    "pid_4132_luid_0x00000000000B5678_phys_1_gpu_0_engtype_3D",
+			expected: parsedInstance{physIdx: 1, gpuIdx: 0, engType: "3D"},
+		},
+		{
+			name:     "Malformed no engtype",
+			input:    "pid_4132_luid_0x00000000000A1234_phys_0_gpu_0",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "Other"},
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: parsedInstance{physIdx: 0, gpuIdx: 0, engType: "Other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseInstanceName(tt.input)
+			if result.physIdx != tt.expected.physIdx {
+				t.Errorf("physIdx = %v, want %v", result.physIdx, tt.expected.physIdx)
+			}
+			if result.gpuIdx != tt.expected.gpuIdx {
+				t.Errorf("gpuIdx = %v, want %v", result.gpuIdx, tt.expected.gpuIdx)
+			}
+			if result.engType != tt.expected.engType {
+				t.Errorf("engType = %q, want %q", result.engType, tt.expected.engType)
+			}
+		})
+	}
+}
+
+func TestAggregateEngineCounters(t *testing.T) {
+	const eps = 0.001
+
+	tests := []struct {
+		name     string
+		samples  []pdhSample
+		expected map[string]float64
+	}{
+		{
+			// ROCm inference leaves 3D near zero; benchmark pegs it
+			name: "Gaming state",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 93.6},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Compute", value: 0.0},
+			},
+			expected: map[string]float64{
+				"3D":      93.6,
+				"Compute": 0.0,
+			},
+		},
+		{
+			// ROCm registers as Compute, 3D stays flat
+			name: "Inference state",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 0.1},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Compute", value: 1847300.0},
+			},
+			expected: map[string]float64{
+				"3D":      0.1,
+				"Compute": 1847300.0,
+			},
+		},
+		{
+			name: "Idle state",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 0.05},
+			},
+			expected: map[string]float64{
+				"3D": 0.05,
+			},
+		},
+		{
+			name: "All-zeros",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 0.0},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Compute", value: 0.0},
+			},
+			expected: map[string]float64{
+				"3D":      0.0,
+				"Compute": 0.0,
+			},
+		},
+		{
+			name: "Missing 3D key",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Compute", value: 10.0},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Copy", value: 20.0},
+			},
+			expected: map[string]float64{
+				"Compute": 10.0,
+				"Copy":    20.0,
+			},
+		},
+		{
+			name: "Multi-instance same engine summing",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 30.0},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_1_engtype_3D", value: 31.5},
+				{instance: "pid_1_luid_0x1_phys_0_gpu_2_engtype_3D", value: 32.1},
+			},
+			expected: map[string]float64{
+				"3D": 93.6,
+			},
+		},
+		{
+			// v1 sums globally across physical GPUs
+			name: "Multi-GPU global sum",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 85.0},
+				{instance: "pid_1_luid_0x1_phys_1_gpu_0_engtype_3D", value: 8.6},
+			},
+			expected: map[string]float64{
+				"3D": 93.6,
+			},
+		},
+		{
+			name: "Gate boundary exactly 10.0",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 10.0},
+			},
+			expected: map[string]float64{"3D": 10.0},
+		},
+		{
+			name: "Just over threshold",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 10.1},
+			},
+			expected: map[string]float64{"3D": 10.1},
+		},
+		{
+			name: "Just under threshold",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_3D", value: 9.9},
+			},
+			expected: map[string]float64{"3D": 9.9},
+		},
+		{
+			name: "Unknown engine type bucketed as Other",
+			samples: []pdhSample{
+				{instance: "pid_1_luid_0x1_phys_0_gpu_0_engtype_Scheduler", value: 5.0},
+			},
+			expected: map[string]float64{"Other": 5.0},
+		},
+		{
+			name:     "Empty slice",
+			samples:  []pdhSample{},
+			expected: map[string]float64{},
+		},
+		{
+			name:     "Nil slice",
+			samples:  nil,
+			expected: map[string]float64{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := aggregateEngineCounters(tt.samples)
+			for k, want := range tt.expected {
+				got, exists := result[k]
+				if !exists {
+					t.Errorf("missing key %q in result", k)
+					continue
+				}
+				if got < want-eps || got > want+eps {
+					t.Errorf("key %q: got %v, want %v", k, got, want)
+				}
+			}
+			for k, v := range result {
+				if _, exists := tt.expected[k]; !exists {
+					t.Errorf("unexpected key %q = %v in result", k, v)
+				}
+			}
+		})
+	}
+}

--- a/cmd/hermia-agent/gpu_stub.go
+++ b/cmd/hermia-agent/gpu_stub.go
@@ -2,7 +2,10 @@
 
 package main
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // gpuResult is redeclared here for non-Windows builds (tests + Linux CI).
 type gpuResult struct {
@@ -11,6 +14,6 @@ type gpuResult struct {
 	Err     error
 }
 
-func queryGPU(_ float64) gpuResult {
+func queryGPU(_ context.Context, _ float64) gpuResult {
 	return gpuResult{Err: errors.New("PDH not supported on this platform")}
 }

--- a/cmd/hermia-agent/gpu_stub.go
+++ b/cmd/hermia-agent/gpu_stub.go
@@ -7,13 +7,6 @@ import (
 	"errors"
 )
 
-// gpuResult is redeclared here for non-Windows builds (tests + Linux CI).
-type gpuResult struct {
-	Engines map[string]float64
-	Gaming  bool
-	Err     error
-}
-
 func queryGPU(_ context.Context, _ float64) gpuResult {
 	return gpuResult{Err: errors.New("PDH not supported on this platform")}
 }

--- a/cmd/hermia-agent/gpu_stub.go
+++ b/cmd/hermia-agent/gpu_stub.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import "errors"
+
+// gpuResult is redeclared here for non-Windows builds (tests + Linux CI).
+type gpuResult struct {
+	Engines map[string]float64
+	Gaming  bool
+	Err     error
+}
+
+func queryGPU(_ float64) gpuResult {
+	return gpuResult{Err: errors.New("PDH not supported on this platform")}
+}

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -95,12 +95,12 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 
 	// sizing probe: PDH returns PDH_MORE_DATA when instances exist,
 	// ERROR_SUCCESS / PDH_NO_DATA / PDH_CSTATUS_NO_INSTANCE when idle.
-	var bufSize, itemCount uint32
+	var bufSize uint32
 	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
 		hCounter,
 		pdhFmtDouble,
 		uintptr(unsafe.Pointer(&bufSize)),
-		uintptr(unsafe.Pointer(&itemCount)),
+		uintptr(unsafe.Pointer(new(uint32))),
 		0,
 	)
 	if ret == errorSuccess || ret == pdhNoData || ret == pdhCStatusNoInst {
@@ -109,6 +109,9 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 	}
 	if ret != pdhMoreData {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW (size): 0x%08X", ret)}
+	}
+	if bufSize == 0 {
+		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: pdhMoreData with bufSize=0")}
 	}
 
 	// fill call: cap fillCount to the allocated buffer to guard against

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	pdhFmtDouble  = 0x00000200
-	pdhMoreData   = 0x800007D2
-	errorSuccess  = 0
+	pdhFmtDouble        = 0x00000200
+	pdhMoreData         = 0x800007D2
+	errorSuccess        = 0
+	pdhCStatusValidData = 0x00000000 // counter value is valid
+	pdhCStatusNewData   = 0x00000001 // counter value is valid and new
 )
 
 var (
@@ -37,12 +39,6 @@ type pdhFmtCounterValue struct {
 type pdhFmtCounterValueItemW struct {
 	SzName   *uint16
 	FmtValue pdhFmtCounterValue
-}
-
-type gpuResult struct {
-	Engines map[string]float64
-	Gaming  bool
-	Err     error
 }
 
 func queryGPU(ctx context.Context, threshold float64) gpuResult {
@@ -131,6 +127,10 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 	samples := make([]pdhSample, 0, fillCount)
 	for i := uint32(0); i < fillCount; i++ {
 		item := (*pdhFmtCounterValueItemW)(unsafe.Pointer(&buf[uintptr(i)*itemSize]))
+		// Skip entries with invalid or stale CStatus — only sum confirmed-valid values.
+		if item.FmtValue.CStatus != pdhCStatusValidData && item.FmtValue.CStatus != pdhCStatusNewData {
+			continue
+		}
 		samples = append(samples, pdhSample{
 			instance: windows.UTF16PtrToString(item.SzName),
 			value:    item.FmtValue.Double,

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 	"unsafe"
 
@@ -63,6 +64,9 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		0,
 		uintptr(unsafe.Pointer(&hCounter)),
 	)
+	// Proc.Call takes ...uintptr (variadic), breaking Go's Rule 4 safe-pointer
+	// guarantee. KeepAlive pins the backing []uint16 until after the DLL call.
+	runtime.KeepAlive(counterPath)
 	if ret != errorSuccess {
 		return gpuResult{Err: fmt.Errorf("PdhAddEnglishCounterW: 0x%08X", ret)}
 	}

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -18,6 +18,8 @@ const (
 	errorSuccess        = 0
 	pdhCStatusValidData = 0x00000000 // counter value is valid
 	pdhCStatusNewData   = 0x00000001 // counter value is valid and new
+	pdhNoData           = 0xC0000BC6 // counter has no data; no instances active
+	pdhCStatusNoInst    = 0x800007D3 // counter instance does not exist
 )
 
 var (
@@ -92,7 +94,7 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 	}
 
 	// sizing probe: PDH returns PDH_MORE_DATA when instances exist,
-	// or ERROR_SUCCESS when the counter set is empty.
+	// ERROR_SUCCESS / PDH_NO_DATA / PDH_CSTATUS_NO_INSTANCE when idle.
 	var bufSize, itemCount uint32
 	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
 		hCounter,
@@ -101,7 +103,7 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		uintptr(unsafe.Pointer(&itemCount)),
 		0,
 	)
-	if ret == errorSuccess {
+	if ret == errorSuccess || ret == pdhNoData || ret == pdhCStatusNoInst {
 		// No GPU engine instances active — machine is idle.
 		return gpuResult{Engines: make(map[string]float64), Gaming: false}
 	}
@@ -120,6 +122,7 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		uintptr(unsafe.Pointer(&fillCount)),
 		uintptr(unsafe.Pointer(unsafe.SliceData(buf))),
 	)
+	runtime.KeepAlive(buf) // same variadic-uintptr GC hazard as counterPath
 	if ret != errorSuccess {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
 	}

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -127,13 +127,14 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
 	}
 
+	// Cap fillCount to what buf can hold before creating the typed slice.
 	itemSize := unsafe.Sizeof(pdhFmtCounterValueItemW{})
 	if maxItems := uint32(uintptr(len(buf)) / itemSize); fillCount > maxItems {
 		fillCount = maxItems
 	}
+	items := unsafe.Slice((*pdhFmtCounterValueItemW)(unsafe.Pointer(unsafe.SliceData(buf))), fillCount)
 	samples := make([]pdhSample, 0, fillCount)
-	for i := uint32(0); i < fillCount; i++ {
-		item := (*pdhFmtCounterValueItemW)(unsafe.Pointer(&buf[uintptr(i)*itemSize]))
+	for _, item := range items {
 		// Skip entries with invalid or stale CStatus — only sum confirmed-valid values.
 		if item.FmtValue.CStatus != pdhCStatusValidData && item.FmtValue.CStatus != pdhCStatusNewData {
 			continue

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -45,24 +44,18 @@ type gpuResult struct {
 	Err     error
 }
 
-var pdhMu sync.Mutex
-
 func queryGPU(threshold float64) gpuResult {
-	// Serialize PDH handle lifetime; mutex is released before the 1s sleep so
-	// concurrent requests don't queue behind the mandatory inter-sample delay.
-	pdhMu.Lock()
-
+	// Each request opens its own independent PDH query handle — no shared
+	// mutable state, so no mutex is needed for concurrent requests.
 	var hQuery uintptr
 	ret, _, _ := procPdhOpenQuery.Call(0, 0, uintptr(unsafe.Pointer(&hQuery)))
 	if ret != errorSuccess {
-		pdhMu.Unlock()
 		return gpuResult{Err: fmt.Errorf("PdhOpenQuery: 0x%08X", ret)}
 	}
+	defer procPdhCloseQuery.Call(hQuery)
 
 	counterPath, err := windows.UTF16PtrFromString(`\GPU Engine(*)\Utilization Percentage`)
 	if err != nil {
-		procPdhCloseQuery.Call(hQuery)
-		pdhMu.Unlock()
 		return gpuResult{Err: fmt.Errorf("UTF16PtrFromString: %w", err)}
 	}
 
@@ -74,28 +67,16 @@ func queryGPU(threshold float64) gpuResult {
 		uintptr(unsafe.Pointer(&hCounter)),
 	)
 	if ret != errorSuccess {
-		procPdhCloseQuery.Call(hQuery)
-		pdhMu.Unlock()
 		return gpuResult{Err: fmt.Errorf("PdhAddEnglishCounterW: 0x%08X", ret)}
 	}
 
 	// baseline collect — establishes counter state; values discarded
 	ret, _, _ = procPdhCollectQueryData.Call(hQuery)
 	if ret != errorSuccess {
-		procPdhCloseQuery.Call(hQuery)
-		pdhMu.Unlock()
 		return gpuResult{Err: fmt.Errorf("PdhCollectQueryData (baseline): 0x%08X", ret)}
 	}
 
-	// Release lock before the mandatory inter-sample sleep so concurrent
-	// requests are not serialized across the full 1-second measurement window.
-	pdhMu.Unlock()
 	time.Sleep(1 * time.Second)
-	pdhMu.Lock()
-	defer func() {
-		procPdhCloseQuery.Call(hQuery)
-		pdhMu.Unlock()
-	}()
 
 	// actual collect
 	ret, _, _ = procPdhCollectQueryData.Call(hQuery)
@@ -104,7 +85,7 @@ func queryGPU(threshold float64) gpuResult {
 	}
 
 	// sizing probe: PDH returns PDH_MORE_DATA when instances exist,
-	// or ERROR_SUCCESS / PDH_NO_DATA when the counter set is empty.
+	// or ERROR_SUCCESS when the counter set is empty.
 	var bufSize, itemCount uint32
 	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
 		hCounter,
@@ -113,7 +94,7 @@ func queryGPU(threshold float64) gpuResult {
 		uintptr(unsafe.Pointer(&itemCount)),
 		0,
 	)
-	if ret == errorSuccess || itemCount == 0 {
+	if ret == errorSuccess {
 		// No GPU engine instances active — machine is idle.
 		return gpuResult{Engines: make(map[string]float64), Gaming: false}
 	}
@@ -121,8 +102,8 @@ func queryGPU(threshold float64) gpuResult {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW (size): 0x%08X", ret)}
 	}
 
-	// fill call: use a fresh itemCount variable so the sizing estimate is
-	// preserved for bounds checking regardless of what Windows writes here.
+	// fill call: cap fillCount to the allocated buffer to guard against
+	// TOCTOU (new GPU instances appearing between the size probe and fill).
 	buf := make([]byte, bufSize)
 	var fillCount uint32
 	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
@@ -130,13 +111,16 @@ func queryGPU(threshold float64) gpuResult {
 		pdhFmtDouble,
 		uintptr(unsafe.Pointer(&bufSize)),
 		uintptr(unsafe.Pointer(&fillCount)),
-		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(unsafe.SliceData(buf))),
 	)
 	if ret != errorSuccess {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
 	}
 
 	itemSize := unsafe.Sizeof(pdhFmtCounterValueItemW{})
+	if maxItems := uint32(uintptr(len(buf)) / itemSize); fillCount > maxItems {
+		fillCount = maxItems
+	}
 	samples := make([]pdhSample, 0, fillCount)
 	for i := uint32(0); i < fillCount; i++ {
 		item := (*pdhFmtCounterValueItemW)(unsafe.Pointer(&buf[uintptr(i)*itemSize]))

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 	"unsafe"
@@ -44,7 +45,7 @@ type gpuResult struct {
 	Err     error
 }
 
-func queryGPU(threshold float64) gpuResult {
+func queryGPU(ctx context.Context, threshold float64) gpuResult {
 	// Each request opens its own independent PDH query handle — no shared
 	// mutable state, so no mutex is needed for concurrent requests.
 	var hQuery uintptr
@@ -76,7 +77,13 @@ func queryGPU(threshold float64) gpuResult {
 		return gpuResult{Err: fmt.Errorf("PdhCollectQueryData (baseline): 0x%08X", ret)}
 	}
 
-	time.Sleep(1 * time.Second)
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return gpuResult{Err: ctx.Err()}
+	case <-timer.C:
+	}
 
 	// actual collect
 	ret, _, _ = procPdhCollectQueryData.Call(hQuery)

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -95,12 +95,12 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 
 	// sizing probe: PDH returns PDH_MORE_DATA when instances exist,
 	// ERROR_SUCCESS / PDH_NO_DATA / PDH_CSTATUS_NO_INSTANCE when idle.
-	var bufSize uint32
+	var bufSize, itemCount uint32
 	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
 		hCounter,
 		pdhFmtDouble,
 		uintptr(unsafe.Pointer(&bufSize)),
-		uintptr(unsafe.Pointer(new(uint32))),
+		uintptr(unsafe.Pointer(&itemCount)),
 		0,
 	)
 	if ret == errorSuccess || ret == pdhNoData || ret == pdhCStatusNoInst {
@@ -130,7 +130,12 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
 	}
 
-	// Cap fillCount to what buf can hold before creating the typed slice.
+	// PDH packs struct array + string data into buf: [N×sizeof(struct)][string bytes…].
+	// len(buf)/sizeof(struct) therefore overcounts the true item capacity, but the
+	// unsafe.Slice safety invariant only requires fillCount×sizeof(struct) ≤ len(buf),
+	// which this cap guarantees. On the SUCCESS path PDH itself ensures fillCount is
+	// correct; the cap is defence-in-depth against a misbehaving PDH returning a
+	// fillCount so large that unsafe.Slice would read past buf's end.
 	itemSize := unsafe.Sizeof(pdhFmtCounterValueItemW{})
 	if maxItems := uint32(uintptr(len(buf)) / itemSize); fillCount > maxItems {
 		fillCount = maxItems

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -122,8 +122,8 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 		uintptr(unsafe.Pointer(&fillCount)),
 		uintptr(unsafe.Pointer(unsafe.SliceData(buf))),
 	)
-	runtime.KeepAlive(buf) // same variadic-uintptr GC hazard as counterPath
 	if ret != errorSuccess {
+		runtime.KeepAlive(buf)
 		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
 	}
 
@@ -143,6 +143,9 @@ func queryGPU(ctx context.Context, threshold float64) gpuResult {
 			value:    item.FmtValue.Double,
 		})
 	}
+	// KeepAlive after the loop: item.SzName is a self-referential pointer into
+	// buf's backing array; pin buf through all dereferences, not just the Call.
+	runtime.KeepAlive(buf)
 
 	engines := aggregateEngineCounters(samples)
 	return gpuResult{

--- a/cmd/hermia-agent/gpu_windows.go
+++ b/cmd/hermia-agent/gpu_windows.go
@@ -1,0 +1,154 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	pdhFmtDouble  = 0x00000200
+	pdhMoreData   = 0x800007D2
+	errorSuccess  = 0
+)
+
+var (
+	modPdh                           = windows.NewLazySystemDLL("pdh.dll")
+	procPdhOpenQuery                 = modPdh.NewProc("PdhOpenQuery")
+	procPdhCloseQuery                = modPdh.NewProc("PdhCloseQuery")
+	procPdhAddEnglishCounterW        = modPdh.NewProc("PdhAddEnglishCounterW")
+	procPdhCollectQueryData          = modPdh.NewProc("PdhCollectQueryData")
+	procPdhGetFormattedCounterArrayW = modPdh.NewProc("PdhGetFormattedCounterArrayW")
+)
+
+// matches PDH_FMT_COUNTERVALUE on 64-bit Windows: DWORD CStatus + 4-byte pad + 8-byte double union
+type pdhFmtCounterValue struct {
+	CStatus uint32
+	_       [4]byte
+	Double  float64
+}
+
+// matches PDH_FMT_COUNTERVALUE_ITEM_W: LPWSTR + PDH_FMT_COUNTERVALUE
+type pdhFmtCounterValueItemW struct {
+	SzName   *uint16
+	FmtValue pdhFmtCounterValue
+}
+
+type gpuResult struct {
+	Engines map[string]float64
+	Gaming  bool
+	Err     error
+}
+
+var pdhMu sync.Mutex
+
+func queryGPU(threshold float64) gpuResult {
+	// Serialize PDH handle lifetime; mutex is released before the 1s sleep so
+	// concurrent requests don't queue behind the mandatory inter-sample delay.
+	pdhMu.Lock()
+
+	var hQuery uintptr
+	ret, _, _ := procPdhOpenQuery.Call(0, 0, uintptr(unsafe.Pointer(&hQuery)))
+	if ret != errorSuccess {
+		pdhMu.Unlock()
+		return gpuResult{Err: fmt.Errorf("PdhOpenQuery: 0x%08X", ret)}
+	}
+
+	counterPath, err := windows.UTF16PtrFromString(`\GPU Engine(*)\Utilization Percentage`)
+	if err != nil {
+		procPdhCloseQuery.Call(hQuery)
+		pdhMu.Unlock()
+		return gpuResult{Err: fmt.Errorf("UTF16PtrFromString: %w", err)}
+	}
+
+	var hCounter uintptr
+	ret, _, _ = procPdhAddEnglishCounterW.Call(
+		hQuery,
+		uintptr(unsafe.Pointer(counterPath)),
+		0,
+		uintptr(unsafe.Pointer(&hCounter)),
+	)
+	if ret != errorSuccess {
+		procPdhCloseQuery.Call(hQuery)
+		pdhMu.Unlock()
+		return gpuResult{Err: fmt.Errorf("PdhAddEnglishCounterW: 0x%08X", ret)}
+	}
+
+	// baseline collect — establishes counter state; values discarded
+	ret, _, _ = procPdhCollectQueryData.Call(hQuery)
+	if ret != errorSuccess {
+		procPdhCloseQuery.Call(hQuery)
+		pdhMu.Unlock()
+		return gpuResult{Err: fmt.Errorf("PdhCollectQueryData (baseline): 0x%08X", ret)}
+	}
+
+	// Release lock before the mandatory inter-sample sleep so concurrent
+	// requests are not serialized across the full 1-second measurement window.
+	pdhMu.Unlock()
+	time.Sleep(1 * time.Second)
+	pdhMu.Lock()
+	defer func() {
+		procPdhCloseQuery.Call(hQuery)
+		pdhMu.Unlock()
+	}()
+
+	// actual collect
+	ret, _, _ = procPdhCollectQueryData.Call(hQuery)
+	if ret != errorSuccess {
+		return gpuResult{Err: fmt.Errorf("PdhCollectQueryData: 0x%08X", ret)}
+	}
+
+	// sizing probe: PDH returns PDH_MORE_DATA when instances exist,
+	// or ERROR_SUCCESS / PDH_NO_DATA when the counter set is empty.
+	var bufSize, itemCount uint32
+	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
+		hCounter,
+		pdhFmtDouble,
+		uintptr(unsafe.Pointer(&bufSize)),
+		uintptr(unsafe.Pointer(&itemCount)),
+		0,
+	)
+	if ret == errorSuccess || itemCount == 0 {
+		// No GPU engine instances active — machine is idle.
+		return gpuResult{Engines: make(map[string]float64), Gaming: false}
+	}
+	if ret != pdhMoreData {
+		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW (size): 0x%08X", ret)}
+	}
+
+	// fill call: use a fresh itemCount variable so the sizing estimate is
+	// preserved for bounds checking regardless of what Windows writes here.
+	buf := make([]byte, bufSize)
+	var fillCount uint32
+	ret, _, _ = procPdhGetFormattedCounterArrayW.Call(
+		hCounter,
+		pdhFmtDouble,
+		uintptr(unsafe.Pointer(&bufSize)),
+		uintptr(unsafe.Pointer(&fillCount)),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+	if ret != errorSuccess {
+		return gpuResult{Err: fmt.Errorf("PdhGetFormattedCounterArrayW: 0x%08X", ret)}
+	}
+
+	itemSize := unsafe.Sizeof(pdhFmtCounterValueItemW{})
+	samples := make([]pdhSample, 0, fillCount)
+	for i := uint32(0); i < fillCount; i++ {
+		item := (*pdhFmtCounterValueItemW)(unsafe.Pointer(&buf[uintptr(i)*itemSize]))
+		samples = append(samples, pdhSample{
+			instance: windows.UTF16PtrToString(item.SzName),
+			value:    item.FmtValue.Double,
+		})
+	}
+
+	engines := aggregateEngineCounters(samples)
+	return gpuResult{
+		Engines: engines,
+		Gaming:  engines["3D"] > threshold,
+	}
+}

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -80,7 +80,7 @@ func main() {
 	log.Printf("WARNING: serving without TLS on %s:%s — isolated VLAN only, not for untrusted networks", *bind, *port)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		result := queryGPU(*threshold)
+		result := queryGPU(r.Context(), *threshold)
 		sampledAt := time.Now().UTC().Format(time.RFC3339)
 		w.Header().Set("Content-Type", "application/json")
 

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -124,10 +125,11 @@ func main() {
 	mux.Handle("/gpu", newBearerAuth(token)(http.HandlerFunc(handler)))
 
 	srv := &http.Server{
-		Addr:         *bind + ":" + *port,
-		Handler:      mux,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		Addr:              net.JoinHostPort(*bind, *port),
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 
 	go func() {

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -63,6 +63,9 @@ func main() {
 	if *errorMode != "fail-closed" && *errorMode != "fail-open" {
 		log.Fatalf("invalid --error-mode %q: must be fail-closed or fail-open", *errorMode)
 	}
+	if *threshold < 0.0 || *threshold > 100.0 {
+		log.Fatalf("invalid --threshold %.2f: must be in [0.0, 100.0]", *threshold)
+	}
 
 	token := os.Getenv(*tokenEnv)
 	if token == "" {
@@ -85,6 +88,7 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 
 		if result.Err != nil {
+			log.Printf("ERROR: pdh query: %v", result.Err)
 			if *errorMode == "fail-closed" {
 				w.WriteHeader(http.StatusOK)
 				json.NewEncoder(w).Encode(gpuResponse{ //nolint:errcheck

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -63,8 +63,8 @@ func main() {
 	if *errorMode != "fail-closed" && *errorMode != "fail-open" {
 		log.Fatalf("invalid --error-mode %q: must be fail-closed or fail-open", *errorMode)
 	}
-	if *threshold < 0.0 || *threshold > 100.0 {
-		log.Fatalf("invalid --threshold %.2f: must be in [0.0, 100.0]", *threshold)
+	if *threshold < 0.0 {
+		log.Fatalf("invalid --threshold %.2f: must be >= 0.0", *threshold)
 	}
 
 	token := os.Getenv(*tokenEnv)

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -45,7 +45,7 @@ func main() {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			defaultThreshold = f
 		} else {
-			log.Printf("WARNING: HERMIA_AGENT_THRESHOLD=%q is not a valid float, using default %.1f", v, defaultThreshold)
+			log.Fatalf("HERMIA_AGENT_THRESHOLD=%q is not a valid float", v)
 		}
 	}
 	threshold := flag.Float64("threshold", defaultThreshold, "3D engine % above which owner is gaming")
@@ -99,6 +99,7 @@ func main() {
 				json.NewEncoder(w).Encode(gpuResponse{ //nolint:errcheck
 					Status:      "error",
 					NodeID:      *nodeID,
+					Gaming:      false, // explicit: fail-open allows dispatch
 					Error:       "pdh_query_failed",
 					ErrorDetail: result.Err.Error(),
 					SampledAt:   sampledAt,

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -25,14 +25,6 @@ type gpuResponse struct {
 	ErrorDetail      string             `json:"error_detail,omitempty"`
 }
 
-type gpuErrResponse struct {
-	Status      string `json:"status"`
-	NodeID      string `json:"node_id"`
-	Error       string `json:"error"`
-	ErrorDetail string `json:"error_detail,omitempty"`
-	SampledAt   string `json:"sampled_at"`
-}
-
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -80,11 +72,12 @@ func main() {
 		*nodeID = hostname
 	}
 
-	log.Printf("WARNING: serving without TLS on %s:%s — isolated VLAN only, not for untrusted networks", *bind, *port)
+	addr := net.JoinHostPort(*bind, *port)
+	log.Printf("WARNING: serving without TLS on %s — isolated VLAN only, not for untrusted networks", addr)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		result := queryGPU(r.Context(), *threshold)
 		sampledAt := time.Now().UTC().Format(time.RFC3339)
+		result := queryGPU(r.Context(), *threshold)
 		w.Header().Set("Content-Type", "application/json")
 
 		if result.Err != nil {
@@ -103,7 +96,7 @@ func main() {
 				})
 			} else {
 				w.WriteHeader(http.StatusServiceUnavailable)
-				json.NewEncoder(w).Encode(gpuErrResponse{ //nolint:errcheck
+				json.NewEncoder(w).Encode(gpuResponse{ //nolint:errcheck
 					Status:      "error",
 					NodeID:      *nodeID,
 					Error:       "pdh_query_failed",
@@ -126,10 +119,10 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/gpu", newBearerAuth(token)(http.HandlerFunc(handler)))
+	mux.Handle("GET /gpu", newBearerAuth(token)(http.HandlerFunc(handler)))
 
 	srv := &http.Server{
-		Addr:              net.JoinHostPort(*bind, *port),
+		Addr:              addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 3 * time.Second,
 		ReadTimeout:       5 * time.Second,
@@ -137,7 +130,7 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("hermia-agent listening on %s:%s", *bind, *port)
+		log.Printf("hermia-agent listening on %s", addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("ListenAndServe: %v", err)
 		}

--- a/cmd/hermia-agent/main.go
+++ b/cmd/hermia-agent/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+type gpuResponse struct {
+	Status           string             `json:"status"`
+	NodeID           string             `json:"node_id"`
+	Gaming           bool               `json:"gaming"`
+	GateThresholdPct float64            `json:"gate_threshold_pct"`
+	Engines          map[string]float64 `json:"engines"`
+	SampledAt        string             `json:"sampled_at"`
+	Error            string             `json:"error,omitempty"`
+	ErrorDetail      string             `json:"error_detail,omitempty"`
+}
+
+type gpuErrResponse struct {
+	Status      string `json:"status"`
+	NodeID      string `json:"node_id"`
+	Error       string `json:"error"`
+	ErrorDetail string `json:"error_detail,omitempty"`
+	SampledAt   string `json:"sampled_at"`
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	// Env vars set flag defaults; explicit CLI flags override them.
+	port := flag.String("port", envOr("HERMIA_AGENT_PORT", "11435"), "port to listen on")
+	bind := flag.String("bind", envOr("HERMIA_AGENT_BIND", "0.0.0.0"), "address to bind")
+	tokenEnv := flag.String("token-env", envOr("HERMIA_AGENT_TOKEN_ENV", "HERMIA_AGENT_TOKEN"), "env var holding the bearer token")
+	nodeID := flag.String("node-id", envOr("HERMIA_AGENT_NODE_ID", ""), "node identifier (default: hostname)")
+	errorMode := flag.String("error-mode", envOr("HERMIA_AGENT_ERROR_MODE", "fail-closed"), "fail-closed or fail-open")
+
+	defaultThreshold := 10.0
+	if v := os.Getenv("HERMIA_AGENT_THRESHOLD"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			defaultThreshold = f
+		} else {
+			log.Printf("WARNING: HERMIA_AGENT_THRESHOLD=%q is not a valid float, using default %.1f", v, defaultThreshold)
+		}
+	}
+	threshold := flag.Float64("threshold", defaultThreshold, "3D engine % above which owner is gaming")
+
+	flag.Parse()
+
+	if *errorMode != "fail-closed" && *errorMode != "fail-open" {
+		log.Fatalf("invalid --error-mode %q: must be fail-closed or fail-open", *errorMode)
+	}
+
+	token := os.Getenv(*tokenEnv)
+	if token == "" {
+		log.Fatalf("token env var %q is not set; refusing to start unauthenticated", *tokenEnv)
+	}
+
+	if *nodeID == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Fatalf("os.Hostname: %v", err)
+		}
+		*nodeID = hostname
+	}
+
+	log.Printf("WARNING: serving without TLS on %s:%s — isolated VLAN only, not for untrusted networks", *bind, *port)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		result := queryGPU(*threshold)
+		sampledAt := time.Now().UTC().Format(time.RFC3339)
+		w.Header().Set("Content-Type", "application/json")
+
+		if result.Err != nil {
+			if *errorMode == "fail-closed" {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(gpuResponse{ //nolint:errcheck
+					Status:           "ok",
+					NodeID:           *nodeID,
+					Gaming:           true,
+					GateThresholdPct: *threshold,
+					Engines:          map[string]float64{},
+					SampledAt:        sampledAt,
+					Error:            "pdh_query_failed",
+					ErrorDetail:      result.Err.Error(),
+				})
+			} else {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(gpuErrResponse{ //nolint:errcheck
+					Status:      "error",
+					NodeID:      *nodeID,
+					Error:       "pdh_query_failed",
+					ErrorDetail: result.Err.Error(),
+					SampledAt:   sampledAt,
+				})
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gpuResponse{ //nolint:errcheck
+			Status:           "ok",
+			NodeID:           *nodeID,
+			Gaming:           result.Gaming,
+			GateThresholdPct: *threshold,
+			Engines:          result.Engines,
+			SampledAt:        sampledAt,
+		})
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/gpu", newBearerAuth(token)(http.HandlerFunc(handler)))
+
+	srv := &http.Server{
+		Addr:         *bind + ":" + *port,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		log.Printf("hermia-agent listening on %s:%s", *bind, *port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("ListenAndServe: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	log.Println("shutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("Shutdown: %v", err)
+	}
+	log.Println("stopped")
+}

--- a/docs/superpowers/specs/2026-06-02-hermia-agent-gpu-gate-design.md
+++ b/docs/superpowers/specs/2026-06-02-hermia-agent-gpu-gate-design.md
@@ -71,7 +71,8 @@ inference. (Source: `project_gaming_gate_prototype` memory; capture tool
 cmd/hermia-agent/
 ├── main.go              — flags/env, server setup, auth middleware, signal handling
 ├── gpu_windows.go       — PDH query, engine aggregation, gate decision (//go:build windows)
-├── gpu_windows_test.go  — table-driven tests for the pure aggregation function
+├── gpu_aggregate_test.go — table-driven tests for the pure aggregation function
+├── gpu_aggregate.go     — pure aggregation functions (cross-platform)
 ├── auth.go              — bearer middleware (crypto/subtle), platform-agnostic
 ├── auth_test.go         — auth middleware tests
 ├── go.mod               — own module; one external dep: golang.org/x/sys
@@ -95,8 +96,7 @@ ignores it; a dedicated `agent.yml` workflow handles the Go build.
 ```
 request → auth middleware (constant-time bearer check)
         → [401 if invalid, BEFORE any PDH work]
-        → mutex (serialize concurrent PDH collections, share one result)
-        → PDH on-demand query (see §4)
+        → PDH on-demand query (see §4)  [per-request independent handle; no mutex needed]
         → aggregate engines, compute gaming = 3D > threshold
         → write JSON response per error mode
 ```
@@ -185,6 +185,9 @@ never dispatches into an unread signal.
 {
   "status": "error",
   "node_id": "fleet-node-20",
+  "gaming": false,
+  "gate_threshold_pct": 0,
+  "engines": null,
   "error": "pdh_query_failed",
   "error_detail": "PdhCollectQueryData returned 0xC0000BC4",
   "sampled_at": "2026-06-02T14:23:01Z"

--- a/docs/superpowers/specs/2026-06-02-hermia-agent-gpu-gate-design.md
+++ b/docs/superpowers/specs/2026-06-02-hermia-agent-gpu-gate-design.md
@@ -1,0 +1,326 @@
+# hermia-agent — GPU Gaming-Gate Endpoint (v1)
+
+**Date:** 2026-06-02
+**Status:** Approved design — ready for implementation plan
+**Workstream:** v0.2 Workstream B (hermia-agent sidecar)
+**Scope of this spec:** First cut. The `GET /gpu` gaming-gate endpoint only.
+`GET /fingerprint` is explicitly deferred to a later iteration.
+
+---
+
+## 1. Purpose
+
+`hermia-agent` is a lightweight static Go binary that runs on each fleet node. Its first
+and only endpoint in this iteration answers one question for the orchestration layer:
+
+> **Is the owner of this machine actively gaming right now?**
+
+If yes, the fleet should skip dispatching inference work to that node. This lets Scott
+lean harder on the local fleet for inference without risking a visible stutter during
+someone's gaming session — a production-grade replacement for the coarse Ollama-liveness
+proxy used today (windows_exporter's native GPU collector was tried and rejected: it
+crashes the 3090 service).
+
+### The validated signal
+
+Windows PDH GPU Engine counters break GPU utilization out **per engine type**. Empirical
+three-state capture on the target box (`.20`, AMD RX 7800 XT, ROCm, Ollama 0.24) confirmed:
+
+| State | `engtype_3D` avg | `engtype_Compute` avg |
+|-------|------------------|------------------------|
+| Idle (model loaded, no generation) | 0.1% | ~0% |
+| Inference (active ROCm generation) | 0.1% | ~1.75M% (cooked) |
+| Gaming (benchmark) | 93.6% | ~2k% variable |
+
+**Decision rule:** `engtype_3D > 10%` → owner is gaming → skip dispatch. The 10% threshold
+gives a ~9.9-point margin above the inference noise floor. ROCm/HIP inference registers as
+`engtype_Compute`, leaving `3D` flat — so 3D-engine % cleanly separates gaming from
+inference. (Source: `project_gaming_gate_prototype` memory; capture tool
+`hometech/gpu_engine_capture.ps1`.)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In scope (v1)
+- A single authenticated `GET /gpu` endpoint
+- On-demand PDH query (no background polling)
+- Per-engine-type utilization aggregation
+- Gaming gate boolean derived from `engtype_3D` vs a configurable threshold
+- Bearer-token auth (constant-time compare)
+- Configurable port, bind address, threshold, error mode, node id
+- Static Windows amd64 binary, isolated Go module under `cmd/hermia-agent/`
+- Fail-closed / fail-open error modes
+
+### Explicitly NOT in scope (v1)
+- `GET /fingerprint` (GPU model, VRAM, driver, ROCm/CUDA/Ollama versions) — next iteration
+- TLS / transport encryption — cleartext on isolated VLAN only; see
+  `backlog_hermia_agent_tls` (HARD GATE before any non-lab deployment)
+- Per-GPU isolation on multi-GPU nodes — global sum for v1; parse retains the
+  `phys_N`/`gpu_N` discriminator so per-GPU is a later enhancement, not a rewrite
+- Background sampling / caching — deliberately rejected (see §6)
+- Non-Windows builds — Linux/macOS agents come with the fingerprint work
+- The Python receiver/consumer side in Hermia — separate task after the API is proven
+
+---
+
+## 3. Architecture
+
+### Directory layout
+```
+cmd/hermia-agent/
+├── main.go              — flags/env, server setup, auth middleware, signal handling
+├── gpu_windows.go       — PDH query, engine aggregation, gate decision (//go:build windows)
+├── gpu_windows_test.go  — table-driven tests for the pure aggregation function
+├── auth.go              — bearer middleware (crypto/subtle), platform-agnostic
+├── auth_test.go         — auth middleware tests
+├── go.mod               — own module; one external dep: golang.org/x/sys
+└── go.sum
+```
+
+The Go module is independent of the Python package — no toolchain crossover. Python CI
+ignores it; a dedicated `agent.yml` workflow handles the Go build.
+
+### Component boundaries
+- **`gpu_windows.go`** knows PDH and engine math. It does **not** know about HTTP. It
+  exposes a function returning the engine map + gate decision, plus a **pure**
+  `aggregateEngineCounters([]pdhSample) map[string]float64` that is unit-testable without
+  Windows.
+- **`auth.go`** is a stdlib `http.Handler` middleware. Platform-agnostic, independently
+  testable.
+- **`main.go`** wires flags → server → middleware → handler. Owns the response schema and
+  the fail-closed/fail-open policy.
+
+### Request flow (`GET /gpu`)
+```
+request → auth middleware (constant-time bearer check)
+        → [401 if invalid, BEFORE any PDH work]
+        → mutex (serialize concurrent PDH collections, share one result)
+        → PDH on-demand query (see §4)
+        → aggregate engines, compute gaming = 3D > threshold
+        → write JSON response per error mode
+```
+
+Auth is checked **before** any PDH work, so an unauthenticated flood is rejected at
+constant-time-compare cost and never reaches the 1-second PDH sleep.
+
+---
+
+## 4. PDH Query (on-demand, per request)
+
+Ported from the validated `gpu_engine_capture.ps1` logic. Uses
+`golang.org/x/sys/windows` and **`windows.NewLazySystemDLL("pdh.dll")`** — the System-DLL
+variant forces the loader to `%SystemRoot%\System32`, closing the DLL-hijacking hole that
+plain `NewLazyDLL` leaves open (working-directory search).
+
+1. `PdhOpenQuery`
+2. `PdhAddEnglishCounterW` — `\GPU Engine(*)\Utilization Percentage`
+3. `PdhCollectQueryData` — **baseline** (establishes counter state; values discarded)
+4. `time.Sleep(1 * time.Second)` — required for the rate counter to compute a valid delta
+5. `PdhCollectQueryData` — actual reading
+6. `PdhGetFormattedCounterArrayW` — all instances as doubles
+7. Parse each instance name; sum `CookedValue` per engine type
+8. `PdhCloseQuery` (always, via `defer`)
+9. `gaming = engines["3D"] > threshold`
+
+### Instance-name parsing
+A typical instance looks like:
+`pid_4132_luid_0x00..._phys_0_gpu_0_engtype_3D`
+
+- Extract engine type after `engtype_` → buckets: `3D`, `Compute`, `Copy`, `VideoDecode`,
+  `VideoEncode`, anything else → `Other`.
+- **Retain** the `phys_N` / `gpu_N` discriminator in the parsed struct even though v1 sums
+  globally. This makes per-GPU isolation (multi-GPU nodes: iGPU + dGPU) a future
+  enhancement without reworking the parser. Documented known-limitation for v1: a node
+  gaming on GPU 0 and idle on GPU 1 reports a single global gaming=true.
+
+### Concurrency
+A package-level `sync.Mutex` serializes PDH collections so two overlapping requests share
+a single query rather than firing parallel PDH work. Correctness is not at stake (each
+query handle is independent) — this is contention insurance and avoids redundant driver work.
+
+---
+
+## 5. HTTP API
+
+### `GET /gpu`
+
+**Auth:** `Authorization: Bearer <token>` required.
+
+**Success (200):**
+```json
+{
+  "status": "ok",
+  "node_id": "fleet-node-20",
+  "gaming": true,
+  "gate_threshold_pct": 10.0,
+  "engines": {
+    "3D": 94.2,
+    "Compute": 1847.3,
+    "Copy": 1.1,
+    "VideoDecode": 0.0,
+    "VideoEncode": 0.0
+  },
+  "sampled_at": "2026-06-02T14:23:01Z"
+}
+```
+
+**PDH failure — `fail-closed` mode (200):** safe default — assume gaming so the fleet
+never dispatches into an unread signal.
+```json
+{
+  "status": "ok",
+  "node_id": "fleet-node-20",
+  "gaming": true,
+  "gate_threshold_pct": 10.0,
+  "engines": {},
+  "sampled_at": "2026-06-02T14:23:01Z",
+  "error": "pdh_query_failed",
+  "error_detail": "PdhCollectQueryData returned 0xC0000BC4"
+}
+```
+
+**PDH failure — `fail-open` mode (503):** caller decides what to do with a missing signal.
+```json
+{
+  "status": "error",
+  "node_id": "fleet-node-20",
+  "error": "pdh_query_failed",
+  "error_detail": "PdhCollectQueryData returned 0xC0000BC4",
+  "sampled_at": "2026-06-02T14:23:01Z"
+}
+```
+> **Datacenter-scale caveat:** at 2,000–100,000 nodes the 503 body may be stripped by
+> proxies/load balancers in the path. Not a concern on the direct-VLAN lab path. Tracked
+> in `backlog_hermia_agent_503_body`.
+
+**Auth failure (401):**
+```json
+{ "status": "error", "error": "unauthorized" }
+```
+
+### Design rationale: agent has no fleet policy
+The agent answers "is the owner gaming?" — it does **not** decide dispatch. Fail-closed vs
+fail-open is a per-environment knob, not a hardcoded opinion. The orchestration layer owns
+retry budgets, node priority, and run criticality; the sidecar must not. Local lab runs
+fail-closed (never accidentally dispatch into a gaming session); production uses the most
+secure variant of fail-open so the orchestrator can manage fleet-wide policy.
+
+---
+
+## 6. Rejected Alternative: Background Sampler
+
+A background goroutine polling PDH every ~2s with the handler returning a cached snapshot
+was considered (and was Gemini's headline recommendation). **Rejected** for two reasons:
+
+1. **Wrong scale model.** The agent runs on each node; 2,000 nodes = 2,000 agents each
+   handling **one** request per run — not one agent holding 2,000 connections. There is no
+   connection-pool exhaustion to design around. The 1-second hold is a single node
+   answering its own occasional query.
+2. **Passive-endpoint principle.** This runs on someone's personal gaming machine. A
+   process that wakes the GPU performance counters every second in perpetuity is exactly
+   the impolite background activity we are trying to avoid. The agent should do work
+   **only when a dispatch decision is actually pending** — checked once per run, not on a
+   perpetual timer.
+
+The on-demand model is correct for "check liveness/readiness/hardware once per run." The
+1-second PDH baseline cost is a non-issue at that call frequency.
+
+---
+
+## 7. Configuration
+
+| Flag | Default | Env override |
+|------|---------|--------------|
+| `--port` | `11435` | `HERMIA_AGENT_PORT` |
+| `--bind` | `0.0.0.0` | `HERMIA_AGENT_BIND` |
+| `--token-env` | `HERMIA_AGENT_TOKEN` | — |
+| `--threshold` | `10.0` | `HERMIA_AGENT_THRESHOLD` |
+| `--error-mode` | `fail-closed` | `HERMIA_AGENT_ERROR_MODE` |
+| `--node-id` | OS hostname | `HERMIA_AGENT_NODE_ID` |
+
+- `--token-env` names the env var holding the token — **never** the token value itself
+  (AGENTS.md rule #11). If that env var is unset at startup, the binary exits with a fatal
+  error rather than serving unauthenticated.
+- `--error-mode` accepts `fail-closed` | `fail-open`.
+- HTTP server: explicit `ReadTimeout` and a `WriteTimeout` set safely above the 1s PDH
+  sleep (e.g. 5s). Graceful shutdown on SIGINT/SIGTERM.
+
+---
+
+## 8. Security Posture (v1)
+
+- **Cleartext bearer over HTTP, isolated VLAN only.** The token is sniffable in transit.
+  Acceptable for local-lab hardware testing on `.20` and nothing else.
+- The binary prints a **prominent startup warning** when serving without TLS.
+- README and this spec carry an "isolated-VLAN-only — not for untrusted networks" banner.
+- **HARD GATE:** production transport security (TLS, without forcing Tailscale) must be
+  solved before any non-lab deployment. Tracked in `backlog_hermia_agent_tls`, including
+  the commander-as-CA deployment idea.
+- Constant-time token comparison via `crypto/subtle` — same cost regardless of where the
+  token first differs (timing-attack mitigation).
+- Auth evaluated before any PDH work (cheap rejection of unauthenticated requests).
+
+---
+
+## 9. Build
+
+```bash
+GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o hermia-agent.exe ./cmd/hermia-agent
+```
+
+- One external dependency: `golang.org/x/sys` — Go-team maintained, effectively extended
+  stdlib (the safe dependency per AGENTS.md rule #1). Everything else is stdlib.
+- `CGO_ENABLED=0` → fully static binary, `scp`-and-run, no runtime deps.
+
+---
+
+## 10. Testing
+
+### Unit (cross-platform, run in CI)
+- **`aggregateEngineCounters`** (pure): table-driven cases — gaming signal, inference
+  signal, idle, all-zeros, missing `3D` key, multi-instance same-engine sum, multi-GPU
+  instances, and the gate boundary at exactly `10.0%`.
+- **Instance-name parser:** real PDH instance strings → correct engine bucket and retained
+  `phys/gpu` discriminator; malformed names fall to `Other` without panicking.
+- **Auth middleware:** valid token passes; wrong token 401; missing header 401; verifies
+  constant-time path is used.
+- **Config:** flag/env precedence; fatal exit when the token env var is unset; error-mode
+  parsing.
+
+### Not unit-tested (deploy-and-verify on `.20`)
+The live `pdh.dll` syscalls require Windows. Exercised by deploying the binary to `.20`
+and running all three states (idle / inference / gaming), confirming the gate flips
+correctly at the 10% threshold against real hardware.
+
+### CI
+`agent.yml` on a `windows-latest` runner: `go vet` + `go build` to catch compile/vet
+errors on PRs. No live PDH tests in CI (no GPU on hosted runners) — that is the
+deploy-and-verify step.
+
+---
+
+## 11. Acceptance Criteria
+
+1. `go build` produces a static `hermia-agent.exe` with no CGO and only `golang.org/x/sys`
+   as an external dep.
+2. `GET /gpu` with a valid bearer token returns the §5 success schema with live per-engine
+   values from the box.
+3. On the `.20` box: idle and inference states report `gaming: false`; a running game/
+   benchmark reports `gaming: true`. The flip occurs at the configured threshold.
+4. Invalid/missing token → 401, no PDH work performed.
+5. Simulated PDH failure → fail-closed returns 200 + `gaming: true` + `error`; fail-open
+   returns 503 + structured error body.
+6. Unset token env var at startup → fatal exit, no server started.
+7. All unit tests pass; `agent.yml` CI build is green.
+8. Startup without TLS prints the security warning.
+
+---
+
+## 12. References
+- `project_gaming_gate_prototype` — three-state capture results and decision rule
+- `project_hermia_probe` — hermia-agent component overview, schema, graceful degradation
+- `hometech/gpu_engine_capture.ps1` — the validated PDH capture logic this ports
+- `backlog_hermia_agent_tls` — production TLS hard gate + commander-as-CA idea
+- `backlog_hermia_agent_503_body` — fail-open body-stripping at datacenter scale
+- Roadmap: `docs/roadmap.md` → v0.2 Workstream B


### PR DESCRIPTION
## Summary

- Static Windows amd64 Go binary (`CGO_ENABLED=0`) at `cmd/hermia-agent/`
- Single authenticated `GET /gpu` endpoint: PDH `\GPU Engine(*)\Utilization Percentage`, 1-second on-demand delta, `engtype_3D > 10%` → gaming gate
- Validated three-state signal (idle 0.1%, ROCm/HIP inference 0.1%, gaming benchmark 93.6%) — ROCm registers as Compute, leaving 3D flat
- Bearer token auth via `crypto/subtle.ConstantTimeCompare`, checked before any PDH work
- Fail-closed (200 + `gaming:true` on PDH failure) and fail-open (503 + structured error) modes
- Graceful SIGINT/SIGTERM shutdown; startup TLS warning; isolated-VLAN lab use only

## Code review fixes applied

- `pdhMu` released before 1-second inter-sample sleep (was serializing all concurrent requests)
- Empty counter set (no GPU engine instances) returns `Gaming:false` instead of spurious error
- `engtype` suffix delimited at next underscore (defensive against future Windows format extensions)
- `HERMIA_AGENT_THRESHOLD` parse failure now logs a warning

## Testing

- 23 cross-platform unit tests (pure aggregation functions + auth middleware) — all pass
- `go vet` clean; Windows amd64 cross-compile produces 8.6MB static exe
- CI: `agent.yml` — `windows-latest` go vet + go build; `ubuntu-latest` go test pure functions
- Live three-state deploy-and-verify on `.20` (Windows RX 7800 XT, ROCm) pending

## Known limitations (v1)

- Cleartext bearer over HTTP — **isolated VLAN only**, not for untrusted networks (`backlog_hermia_agent_tls`)
- `gpu_`/`eng_` segment in PDH instance name: spec-validated as `gpu_0` on the target hardware; needs confirmation on first deploy (`backlog` noted)
- v1 sums 3D globally across GPUs; per-GPU isolation deferred (parser retains `physIdx`/`gpuIdx` for future enhancement)

## Test plan

- [ ] CI passes (windows-latest build + ubuntu-latest unit tests)
- [ ] Deploy `hermia-agent.exe` to `.20`, set `HERMIA_AGENT_TOKEN`, run `--error-mode fail-closed`
- [ ] Verify idle state: `gaming: false`
- [ ] Verify ROCm inference state: `gaming: false`
- [ ] Verify gaming/benchmark state: `gaming: true`
- [ ] Verify invalid token → 401 with no PDH work
- [ ] Verify startup logs TLS warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)