### PR TITLE
chore(security): SHA-pin pypa/gh-action-pypi-publish (Aikido HIGH)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,6 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        # SHA pinning not supported: pypa/gh-action-pypi-publish is a Docker container action;
-        # GHCR does not publish images tagged by commit SHA. release/v1 is the pypa-maintained stable ref.
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to the release/v1 HEAD commit (GitHub builds Docker actions from the pinned
+        # ref). Dependabot (github-actions ecosystem) bumps this SHA as PyPA ships updates.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1


### PR DESCRIPTION
Pins the PyPI publish action to release/v1 HEAD (`cef2210`), closing the last unpinned-action finding. The publish job holds `id-token: write` for trusted publishing, so its supply chain is the highest-value to lock. Dependabot (github-actions) keeps the SHA current. Corrects a stale comment that wrongly claimed SHA-pinning is unsupported for Docker actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)