### PR TITLE
feat(v0.2): Workstream D — Sink + opt-in anonymized submission [WIP]

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -5,7 +5,7 @@
 > it and its PR/tag — making the loss obvious and recovery trivial. Keep it current:
 > add a row when a workstream branch is pushed; update status on merge.
 
-**Last updated:** 2026-06-03
+**Last updated:** 2026-06-03 (D updated)
 
 | WS | Title | Branch | PR | Protective tag | Status |
 |----|-------|--------|----|----------------|--------|
@@ -13,7 +13,7 @@
 | — | Recovery copy of A (pristine, do not edit) | `recover/workstream-a-transport` | — | `ws-a-reviewed-2026-06-03` | 🟢 Safety net — retain until A is confirmed stable on `dev` |
 | B | hermia-agent sidecar (Windows Go GPU gaming-gate) | merged | [#85](https://github.com/scottblydotcom/hermia/pull/85), [#86](https://github.com/scottblydotcom/hermia/pull/86) | — | ✅ Done — verified through to physical machine (ScottWin11 .20) |
 | C | Concurrent fleet runner (ThreadPoolExecutor, VRAM-aware) | `feat/workstream-c-concurrent-runner` | [#93](https://github.com/scottblydotcom/hermia/pull/93) | — | 🔵 In review — `_ps_cache` + `append_result` thread-safe; `run_fleet` concurrent via `ThreadPoolExecutor`; `--max-concurrency N` flag; VRAM-safe host grouping; all 852 tests green |
-| D | Submission API + partial Sink | _planned_ | — | — | ⚪ Planned — independent of A |
+| D | Submission API + partial Sink | `feat/workstream-d-sink` | [#95](https://github.com/scottblydotcom/hermia/pull/95) | — | 🔵 In review — `Sink` Protocol + `JsonlCsvSink`/`PostgresSink` adapters; default-deny anonymizer (property-tested); `SubmissionSink` opt-in POST/dry-run; `--submit` / `--submit-dry-run` CLI flags; 650 tests green |
 | E | Deterministic multi-turn | _planned_ | — | — | ⚪ Planned — depends on A (message-list) |
 | F | Test quality + framework coverage | _planned_ | — | — | ⚪ Planned — independent of A |
 

--- a/docs/superpowers/plans/2026-06-03-workstream-d-sink.md
+++ b/docs/superpowers/plans/2026-06-03-workstream-d-sink.md
@@ -1,0 +1,150 @@
+# Workstream D — Submission API + partial Sink (lean plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Generation is delegated to the fleet (`coder-biggest-5090`); the Sonnet implementer integrates, runs gates, commits. Steps use `- [ ]`.
+
+**Goal:** Introduce a pluggable `Sink` output seam (mirroring the v0.2 `Transport` pattern), port the existing JSONL/CSV and Postgres outputs behind thin adapters, and add an **opt-in, anonymized** community-submission Sink — with a default-deny anonymizer that can never leak identifying data.
+
+**Architecture:** New `src/hermia/sink/` package. `Sink` is a `Protocol` with `write(rows: list[dict]) -> None`. Concrete sinks: `JsonlCsvSink` and `PostgresSink` are **thin adapters over the existing `results.append_result` / `export.push`** (establish the seam without ripping out current call sites — full migration is deferred). `SubmissionSink` is the new capability: it runs each row through a **whitelist-based anonymizer** and POSTs the safe subset to a configured endpoint (opt-in; dry-run prints the payload and sends nothing). The anonymizer is the privacy-critical core and gets property tests proving no stripped field or sensitive value ever appears in output.
+
+**Tech Stack:** Python 3.11+, `typing.Protocol`, `requests`, `hypothesis`, `pytest`.
+
+**Privacy model (default-deny):** a row is anonymized by copying ONLY an explicit whitelist of safe fields. Everything else is dropped. `failure_reason` is reduced to a category (it can contain `ERROR: ...<host/IP>...`). Auth tokens, hostnames, IPs, raw prompt/response text, local-client hardware metrics, run ids/timestamps are never included.
+
+## Fleet delegation protocol (every task)
+The Sonnet implementer delegates GENERATION to the fleet's `coder-biggest-5090` lane via the LiteLLM gateway (dispatch helper/endpoint/credentials live in the **ailab ops repo**, never here), then critically reviews, adapts, verifies, and commits. Never commit fleet output unread. **For Task D2 (privacy core), favor your own careful authorship over fleet output** — fleet code is a starting point only.
+
+## File Map
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| CREATE | `src/hermia/sink/__init__.py` | exports |
+| CREATE | `src/hermia/sink/base.py` | `Sink` protocol |
+| CREATE | `src/hermia/sink/local.py` | `JsonlCsvSink`, `PostgresSink` adapters |
+| CREATE | `src/hermia/sink/anonymize.py` | whitelist anonymizer + failure categorizer |
+| CREATE | `src/hermia/sink/submission.py` | `SubmissionSink` (opt-in POST, dry-run) |
+| CREATE | `tests/unit/test_sink_base.py`, `test_sink_local.py`, `test_anonymize.py`, `test_submission.py` | tests |
+| MODIFY | `src/hermia/app.py` | `--submit` / `--submit-dry-run` flag wiring |
+| MODIFY | `tests/unit/test_app.py` | flag test |
+
+---
+
+## Task D1: Sink protocol + local adapters
+**Files:** `src/hermia/sink/{__init__,base,local}.py`, `tests/unit/test_sink_base.py`, `tests/unit/test_sink_local.py`
+
+- [ ] **D1.1** Write `tests/unit/test_sink_base.py`: a trivial object with `write(self, rows)` satisfies `isinstance(obj, Sink)` (runtime-checkable Protocol); the protocol exposes `write`.
+- [ ] **D1.2** Implement `base.py`:
+```python
+from __future__ import annotations
+from typing import Any, Protocol, runtime_checkable
+
+@runtime_checkable
+class Sink(Protocol):
+    def write(self, rows: list[dict[str, Any]]) -> None: ...
+```
+- [ ] **D1.3** Write `tests/unit/test_sink_local.py` (fleet-generate, then verify): `JsonlCsvSink(jsonl_path, csv_path).write(rows)` appends each row via the existing writer (assert rows land via `load_jsonl`); `PostgresSink(dsn, dry_run=True).write(rows)` calls `export.push(rows, dsn, dry_run=True)` (patch `export.push` and assert called with those args).
+- [ ] **D1.4** Implement `local.py`: `JsonlCsvSink` wraps `results.append_result` (loop rows); `PostgresSink` wraps `export.push`. Thin adapters — no new behavior. `__init__.py` exports `Sink, JsonlCsvSink, PostgresSink`.
+- [ ] **D1.5** `pytest tests/unit/test_sink_base.py tests/unit/test_sink_local.py -q`, ruff, mypy → green. Commit: `feat(sink): Sink protocol + JsonlCsvSink/PostgresSink adapters`
+
+## Task D2: Anonymizer (privacy-critical — author carefully, property-test hard)
+**Files:** `src/hermia/sink/anonymize.py`, `tests/unit/test_anonymize.py`
+
+- [ ] **D2.1** Write `tests/unit/test_anonymize.py` FIRST. Define the whitelist and forbidden sets in the test and assert the implementation honors them:
+```python
+from hermia.sink.anonymize import anonymize_row, SUBMIT_WHITELIST
+
+FORBIDDEN_KEYS = {
+    "host", "fleet_host_name", "fleet_host_start", "raw_prompt", "raw_response",
+    "raw_system", "output_preview", "run_id", "run_timestamp",
+    "peak_cpu_pct", "peak_ram_used_gb", "peak_gpu_pct", "peak_vram_used_gb",
+}
+
+def test_anonymize_drops_all_forbidden_keys():
+    row = {k: "SENSITIVE" for k in FORBIDDEN_KEYS}
+    row.update({"model": "qwen2.5:32b", "tokens": 10})
+    out = anonymize_row(row)
+    assert FORBIDDEN_KEYS.isdisjoint(out.keys())
+
+def test_anonymize_only_whitelisted_keys_plus_derived():
+    row = {k: 1 for k in list(SUBMIT_WHITELIST) + ["host", "raw_response", "surprise_new_field"]}
+    out = anonymize_row(row)
+    allowed = SUBMIT_WHITELIST | {"failure_category", "hermia_version"}
+    assert set(out).issubset(allowed)   # default-deny: unknown future fields never leak
+
+def test_failure_reason_reduced_to_category():
+    out = anonymize_row({"failure_reason": "ERROR: HTTPConnectionPool(host='192.168.1.5', port=11434)"})
+    assert out["failure_category"] == "ERROR"
+    assert "192.168" not in str(out)     # no host/IP detail survives
+    assert "failure_reason" not in out
+
+def test_no_sensitive_value_survives():
+    sentinel = "host-marker-9f3a2c"
+    row = {"host": sentinel, "raw_response": sentinel, "output_preview": sentinel,
+           "model": "m", "tokens": 1}
+    out = anonymize_row(row)
+    assert sentinel not in repr(out)
+```
+Also add a hypothesis property test: for an arbitrary dict that includes random FORBIDDEN_KEYS with random string values, `set(out).issubset(allowed)` AND none of the forbidden values appear in `repr(out)`.
+- [ ] **D2.2** Run the tests → fail (module missing).
+- [ ] **D2.3** Implement `anonymize.py` (YOU author this; fleet output is reference only):
+```python
+from __future__ import annotations
+from typing import Any
+from hermia import __version__
+
+SUBMIT_WHITELIST = frozenset({
+    "model", "dimension", "test_id", "frameworks",
+    "json_valid", "schema_compliant", "had_markdown_fence",
+    "tokens", "elapsed_sec", "tokens_per_sec",
+    "mode", "orchestration", "orchestration_version", "execution_path",
+    "vram_server_gb", "model_size_server_gb",
+    "score", "consistency_pct", "pass_count", "robustness_n",
+    "run_index", "is_cold", "cold_warm_delta_tps", "signals",
+})
+_KNOWN_FAILURE_PREFIXES = ("SCHEMA_FAIL", "JSON_PARSE_ERROR", "EMPTY_RESPONSE",
+                           "TIMEOUT", "OLLAMA_ERROR", "API_ERROR", "ERROR")
+
+def _categorize_failure(reason: object) -> str:
+    if not reason or not isinstance(reason, str):
+        return "none"
+    for p in _KNOWN_FAILURE_PREFIXES:
+        if reason.startswith(p):
+            return p
+    return "other"
+
+def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Default-deny: copy only whitelisted fields; reduce failure_reason to a
+    category; stamp the Hermia version. Never emits host identity, raw text,
+    client hardware metrics, run ids/timestamps, or any non-whitelisted field."""
+    out: dict[str, Any] = {k: row[k] for k in SUBMIT_WHITELIST if k in row}
+    out["failure_category"] = _categorize_failure(row.get("failure_reason"))
+    out["hermia_version"] = __version__
+    return out
+```
+- [ ] **D2.4** Tests green; ruff + mypy clean. Commit: `feat(sink): default-deny anonymizer for community submission (privacy core)`
+
+## Task D3: SubmissionSink (opt-in POST, dry-run)
+**Files:** `src/hermia/sink/submission.py`, `tests/unit/test_submission.py`
+
+- [ ] **D3.1** Write `tests/unit/test_submission.py` (fleet-generate, then verify):
+  - dry-run: `SubmissionSink(endpoint=None, dry_run=True).write(rows)` does NOT call `requests.post` and prints/returns the anonymized payload; every emitted row is `anonymize_row` of an input.
+  - live: `SubmissionSink(endpoint="https://example.test/submit", token_env="X", dry_run=False)` with `requests.post` patched POSTs the anonymized payload; the Authorization header is built from the env var only (never logged); on non-2xx it does not raise (best-effort, logs a warning).
+  - **Privacy guard test:** a row with `host`/`raw_response` set to a sentinel → the JSON body passed to `requests.post` does NOT contain the sentinel.
+- [ ] **D3.2** Implement `submission.py`: `SubmissionSink.write` maps rows through `anonymize_row`, builds the payload, and either prints (dry-run) or POSTs with a short timeout; auth token sourced from `os.environ[token_env]` only; never logs the token or body at error level. No endpoint or `dry_run=True` ⇒ dry-run.
+- [ ] **D3.3** Tests green; ruff + mypy clean. Commit: `feat(sink): SubmissionSink — opt-in anonymized POST with dry-run`
+
+## Task D4: CLI wiring (`--submit` / `--submit-dry-run`)
+**Files:** `src/hermia/app.py`, `tests/unit/test_app.py`. READ app.py's fleet branch first.
+
+- [ ] **D4.1** Test: `--submit-dry-run` causes a `SubmissionSink` dry-run over the run's results after a fleet eval (patch `SubmissionSink` and assert `.write` called; assert no network). `--submit` (with endpoint env configured) constructs a live `SubmissionSink`. Default: neither flag ⇒ no submission.
+- [ ] **D4.2** Add `--submit` and `--submit-dry-run` args; after `run_fleet` returns, if set, load the run's rows (`results.load_jsonl`) and call the sink. Endpoint + token come from env vars (e.g. `HERMIA_SUBMIT_URL`, `HERMIA_SUBMIT_TOKEN`); document that nothing is sent without `--submit`.
+- [ ] **D4.3** Tests green; full suite green; ruff + mypy. Commit: `feat(cli): --submit / --submit-dry-run opt-in community submission`
+
+## Task D5: Docs + manifest + gates
+- [ ] Full suite, ruff, mypy green. Document the Sink seam + the opt-in/anonymized submission (README + docs/usage.md), emphasizing default-deny + what is/isn't sent. Update `docs/WORKSTREAMS.md` D row → in review + PR #. Commit: `docs: document Sink + opt-in anonymized submission`
+
+## Self-review
+- Spec coverage: Sink protocol ✓ (D1), port existing outputs behind adapters ✓ (D1), anonymizer ✓ (D2), SubmissionSink opt-in/dry-run ✓ (D3), CLI ✓ (D4). Server/auth/other sinks explicitly DEFERRED.
+- Privacy: whitelist default-deny + property test that unknown future fields and forbidden values never leak (D2) — the load-bearing guarantee.
+- Type consistency: `anonymize_row(row) -> dict`, `SUBMIT_WHITELIST` frozenset, `Sink.write(rows)` used identically across D1/D3/D4.
+
+## Coordination
+D is independent of C/E/F (new package + thin adapters; does not modify runner/fleet logic). Safe to run in parallel.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -317,6 +317,70 @@ hermia-push --results-dir /path/to/results
 
 ---
 
+## Opt-in community submission (`--submit`)
+
+After a fleet run you can contribute anonymized results to the Hermia community
+dataset.  **Nothing is sent unless you pass `--submit` explicitly.**
+
+### What is shared
+
+A strict default-deny whitelist determines what leaves your machine.  Only
+aggregate performance fields are included:
+
+| Field | Example |
+|---|---|
+| `model` | `qwen2.5:32b` |
+| `dimension` / `test_id` | `security` / `security-direct-injection` |
+| `json_valid` / `schema_compliant` / `had_markdown_fence` | `true` |
+| `tokens` / `elapsed_sec` / `tokens_per_sec` | `142` / `1.4` / `101.4` |
+| `mode` / `orchestration` / `orchestration_version` | `fleet` / `ollama` / `0.9.0` |
+| `execution_path` / `vram_server_gb` / `model_size_server_gb` | `gpu` / `18.0` / `4.7` |
+| `score` / `consistency_pct` / `pass_count` / `robustness_n` | `100` / `95.0` / `9` / `10` |
+| `run_index` / `is_cold` / `cold_warm_delta_tps` | `1` / `false` / `12.3` |
+| `failure_category` (derived from `failure_reason`) | `SCHEMA_FAIL` |
+
+### What is never shared
+
+The anonymizer unconditionally drops:
+
+- Host names, IP addresses, fleet host metadata
+- Raw prompt, raw response, raw system prompt
+- Output preview (may contain model-verbatim sensitive text)
+- Run ID and timestamp (would allow cross-run correlation)
+- Client hardware metrics (CPU%, RAM, GPU%, VRAM — client-side only)
+
+`failure_reason` is reduced to a category prefix only (`ERROR`, `SCHEMA_FAIL`,
+`TIMEOUT`, etc.) — the detail that can contain host names or paths is stripped.
+
+### Dry-run (inspect the payload first)
+
+Print the payload to stdout without sending anything:
+
+```bash
+hermia --fleet hermia-fleet.yaml --submit-dry-run
+```
+
+### Live submission
+
+Set the endpoint URL and opt in:
+
+```bash
+export HERMIA_SUBMIT_URL="https://submit.hermia.dev/v1/results"
+hermia --fleet hermia-fleet.yaml --submit
+```
+
+The bearer token (if the endpoint requires one) comes from `HERMIA_SUBMIT_TOKEN`:
+
+```bash
+export HERMIA_SUBMIT_TOKEN="..."
+hermia --fleet hermia-fleet.yaml --submit
+```
+
+Submission is best-effort: a non-2xx response or network failure logs a warning
+and does not abort the run.
+
+---
+
 ## What's next
 
 - **Grafana dashboards** — if you have Grafana running, point it at the `hermia_results`

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -87,6 +87,21 @@ def main() -> None:
         dest="audit_format",
         help="Audit output format: jsonl (default), html, or spill (fleet health table)",
     )
+    submit_group = parser.add_mutually_exclusive_group()
+    submit_group.add_argument(
+        "--submit",
+        action="store_true",
+        help=(
+            "After a fleet run, anonymize results and POST to HERMIA_SUBMIT_URL "
+            "(opt-in community submission; nothing is sent without this flag)"
+        ),
+    )
+    submit_group.add_argument(
+        "--submit-dry-run",
+        action="store_true",
+        dest="submit_dry_run",
+        help="Print the anonymized submission payload without sending it",
+    )
     args = parser.parse_args()
 
     if (args.verbose or args.quiet) and not args.fleet:
@@ -109,16 +124,33 @@ def main() -> None:
 
     if args.fleet:
         from hermia.fleet import load_fleet_config, run_fleet
+        from hermia.results import load_jsonl
         from hermia.screens import RESULTS_DIR
+        from hermia.sink.submission import SubmissionSink
 
         verbosity = 1 if args.verbose else (-1 if args.quiet else 0)
         try:
             entries = load_fleet_config(Path(args.fleet))
-            run_fleet(entries, repeat=args.repeat, results_dir=RESULTS_DIR, verbosity=verbosity,
-                      max_concurrency=args.max_concurrency)
+            jsonl_path = run_fleet(
+                entries,
+                repeat=args.repeat,
+                results_dir=RESULTS_DIR,
+                verbosity=verbosity,
+                max_concurrency=args.max_concurrency,
+            )
         except (ValueError, RuntimeError, OSError) as exc:
             print(f"hermia: {exc}", file=sys.stderr)
             sys.exit(1)
+
+        if args.submit_dry_run:
+            SubmissionSink(endpoint=None, dry_run=True).write(load_jsonl(jsonl_path))
+        elif args.submit:
+            SubmissionSink(
+                endpoint=os.environ.get("HERMIA_SUBMIT_URL"),
+                token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
+                dry_run=False,
+            ).write(load_jsonl(jsonl_path))
+
         sys.exit(0)
 
     os.environ["HERMIA_HOST"] = args.host.rstrip("/")

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -145,11 +145,22 @@ def main() -> None:
         if args.submit_dry_run:
             SubmissionSink(endpoint=None, dry_run=True).write(load_jsonl(jsonl_path))
         elif args.submit:
-            SubmissionSink(
-                endpoint=os.environ.get("HERMIA_SUBMIT_URL"),
-                token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
-                dry_run=False,
-            ).write(load_jsonl(jsonl_path))
+            submit_url = os.environ.get("HERMIA_SUBMIT_URL", "").strip()
+            if not submit_url:
+                print(
+                    "hermia: --submit requires HERMIA_SUBMIT_URL environment variable to be set",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            try:
+                SubmissionSink(
+                    endpoint=submit_url,
+                    token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
+                    dry_run=False,
+                ).write(load_jsonl(jsonl_path))
+            except OSError as exc:
+                print(f"hermia: {exc}", file=sys.stderr)
+                sys.exit(1)
 
         sys.exit(0)
 

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -142,22 +142,27 @@ def main() -> None:
             print(f"hermia: {exc}", file=sys.stderr)
             sys.exit(1)
 
-        if args.submit_dry_run:
-            SubmissionSink(endpoint=None, dry_run=True).write(load_jsonl(jsonl_path))
-        elif args.submit:
-            submit_url = os.environ.get("HERMIA_SUBMIT_URL", "").strip()
-            if not submit_url:
-                print(
-                    "hermia: --submit requires HERMIA_SUBMIT_URL environment variable to be set",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+        if args.submit_dry_run or args.submit:
+            submit_url = ""
+            if args.submit:
+                submit_url = os.environ.get("HERMIA_SUBMIT_URL", "").strip()
+                if not submit_url:
+                    print(
+                        "hermia: --submit requires HERMIA_SUBMIT_URL"
+                        " environment variable to be set",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
             try:
-                SubmissionSink(
-                    endpoint=submit_url,
-                    token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
-                    dry_run=False,
-                ).write(load_jsonl(jsonl_path))
+                rows = load_jsonl(jsonl_path)
+                if args.submit_dry_run:
+                    SubmissionSink(endpoint=None, dry_run=True).write(rows)
+                else:
+                    SubmissionSink(
+                        endpoint=submit_url,
+                        token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
+                        dry_run=False,
+                    ).write(rows)
             except OSError as exc:
                 print(f"hermia: {exc}", file=sys.stderr)
                 sys.exit(1)

--- a/src/hermia/sink/__init__.py
+++ b/src/hermia/sink/__init__.py
@@ -1,0 +1,5 @@
+"""Hermia Sink — pluggable output seam."""
+from hermia.sink.base import Sink
+from hermia.sink.local import JsonlCsvSink, PostgresSink
+
+__all__ = ["Sink", "JsonlCsvSink", "PostgresSink"]

--- a/src/hermia/sink/__init__.py
+++ b/src/hermia/sink/__init__.py
@@ -1,5 +1,6 @@
 """Hermia Sink — pluggable output seam."""
+from hermia.sink.anonymize import SUBMIT_WHITELIST, anonymize_row
 from hermia.sink.base import Sink
 from hermia.sink.local import JsonlCsvSink, PostgresSink
 
-__all__ = ["Sink", "JsonlCsvSink", "PostgresSink"]
+__all__ = ["Sink", "JsonlCsvSink", "PostgresSink", "SUBMIT_WHITELIST", "anonymize_row"]

--- a/src/hermia/sink/__init__.py
+++ b/src/hermia/sink/__init__.py
@@ -2,5 +2,13 @@
 from hermia.sink.anonymize import SUBMIT_WHITELIST, anonymize_row
 from hermia.sink.base import Sink
 from hermia.sink.local import JsonlCsvSink, PostgresSink
+from hermia.sink.submission import SubmissionSink
 
-__all__ = ["Sink", "JsonlCsvSink", "PostgresSink", "SUBMIT_WHITELIST", "anonymize_row"]
+__all__ = [
+    "Sink",
+    "JsonlCsvSink",
+    "PostgresSink",
+    "SubmissionSink",
+    "SUBMIT_WHITELIST",
+    "anonymize_row",
+]

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -85,6 +85,16 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
     metrics, run ids, or timestamps are ever emitted.
     """
     out: dict[str, Any] = {k: row[k] for k in SUBMIT_WHITELIST if k in row}
+
+    # Value-level default-deny for signals: only bool values are safe to share.
+    # A probe could embed host/IP strings or other sensitive content in non-bool
+    # signal values; strip anything that is not strictly bool.
+    sig = out.get("signals")
+    if isinstance(sig, dict):
+        out["signals"] = {k: v for k, v in sig.items() if isinstance(v, bool)}
+    else:
+        out.pop("signals", None)  # drop if not a bool dict
+
     out["failure_category"] = _categorize_failure(row.get("failure_reason"))
     out["hermia_version"] = __version__
     return out

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -1,0 +1,90 @@
+"""Default-deny anonymizer for community submission.
+
+A row is anonymized by copying ONLY an explicit whitelist of safe fields.
+Everything else is dropped. ``failure_reason`` is reduced to a category
+prefix (it can contain ``ERROR: ...<host/IP>...`` detail that must not be
+shared). Auth tokens, hostnames, IPs, raw prompt/response text,
+local-client hardware metrics, and run ids/timestamps are never emitted.
+
+The privacy guarantee is enforced by the default-deny whitelist: any field
+not in SUBMIT_WHITELIST is unconditionally excluded. Unknown fields added
+to result rows in future versions of hermia are therefore also excluded
+automatically — they cannot leak.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from hermia import __version__
+
+# Explicit whitelist of fields safe to share.  Default-deny: anything NOT
+# listed here is dropped, including future fields not yet imagined.
+SUBMIT_WHITELIST: frozenset[str] = frozenset(
+    {
+        "model",
+        "dimension",
+        "test_id",
+        "frameworks",
+        "json_valid",
+        "schema_compliant",
+        "had_markdown_fence",
+        "tokens",
+        "elapsed_sec",
+        "tokens_per_sec",
+        "mode",
+        "orchestration",
+        "orchestration_version",
+        "execution_path",
+        "vram_server_gb",
+        "model_size_server_gb",
+        "score",
+        "consistency_pct",
+        "pass_count",
+        "robustness_n",
+        "run_index",
+        "is_cold",
+        "cold_warm_delta_tps",
+        "signals",
+    }
+)
+
+# Category prefixes for failure_reason reduction.  Longest matches first to
+# avoid SCHEMA_FAIL being incorrectly categorised as the shorter "ERROR".
+_KNOWN_FAILURE_PREFIXES: tuple[str, ...] = (
+    "SCHEMA_FAIL",
+    "JSON_PARSE_ERROR",
+    "EMPTY_RESPONSE",
+    "TIMEOUT",
+    "OLLAMA_ERROR",
+    "API_ERROR",
+    "ERROR",
+)
+
+
+def _categorize_failure(reason: object) -> str:
+    """Reduce a failure_reason string to its category prefix.
+
+    Strips all detail that might contain host names, IPs, or other
+    identifying information.  Returns ``"none"`` when reason is absent
+    or empty, and ``"other"`` for unrecognised prefixes.
+    """
+    if not reason or not isinstance(reason, str):
+        return "none"
+    for prefix in _KNOWN_FAILURE_PREFIXES:
+        if reason.startswith(prefix):
+            return prefix
+    return "other"
+
+
+def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Return an anonymized copy of *row* safe for community submission.
+
+    Only whitelisted fields are copied.  ``failure_reason`` is replaced by
+    ``failure_category`` (the prefix only).  The Hermia version is stamped
+    in ``hermia_version``.  No host identity, raw text, client hardware
+    metrics, run ids, or timestamps are ever emitted.
+    """
+    out: dict[str, Any] = {k: row[k] for k in SUBMIT_WHITELIST if k in row}
+    out["failure_category"] = _categorize_failure(row.get("failure_reason"))
+    out["hermia_version"] = __version__
+    return out

--- a/src/hermia/sink/base.py
+++ b/src/hermia/sink/base.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Sink(Protocol):
+    def write(self, rows: list[dict[str, Any]]) -> None: ...

--- a/src/hermia/sink/local.py
+++ b/src/hermia/sink/local.py
@@ -1,0 +1,31 @@
+"""Local sink adapters — thin wrappers over existing results/export writers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hermia.export import push
+from hermia.results import append_result
+
+
+class JsonlCsvSink:
+    """Writes each row via the existing ``append_result`` writer."""
+
+    def __init__(self, jsonl_path: Path, csv_path: Path) -> None:
+        self.jsonl_path = jsonl_path
+        self.csv_path = csv_path
+
+    def write(self, rows: list[dict[str, Any]]) -> None:
+        for row in rows:
+            append_result(row, self.jsonl_path, self.csv_path)
+
+
+class PostgresSink:
+    """Pushes a batch of rows to Postgres via the existing ``push`` writer."""
+
+    def __init__(self, dsn: str, dry_run: bool = False) -> None:
+        self.dsn = dsn
+        self.dry_run = dry_run
+
+    def write(self, rows: list[dict[str, Any]]) -> None:
+        push(rows, self.dsn, dry_run=self.dry_run)

--- a/src/hermia/sink/submission.py
+++ b/src/hermia/sink/submission.py
@@ -50,6 +50,9 @@ class SubmissionSink:
 
     def write(self, rows: list[dict[str, Any]]) -> None:
         """Anonymize *rows* and submit (or dry-print) the safe subset."""
+        if not rows:
+            return
+
         payload = [anonymize_row(row) for row in rows]
 
         if self.dry_run or self.endpoint is None:
@@ -58,7 +61,9 @@ class SubmissionSink:
 
         # Live submission — read token from env at call time; never log it.
         bearer = os.environ.get(self.token_env, "")
-        headers = {"Authorization": f"Bearer {bearer}"}
+        headers: dict[str, str] = {}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
 
         try:
             response = requests.post(
@@ -68,6 +73,10 @@ class SubmissionSink:
                 timeout=5,
             )
             if not response.ok:
-                logger.warning("hermia submit: server returned %s", response.status_code)
+                logger.warning(
+                    "hermia submit: server returned %s: %s",
+                    response.status_code,
+                    response.text[:200],
+                )
         except requests.exceptions.RequestException as exc:
             logger.warning("hermia submit: request failed (%s)", type(exc).__name__)

--- a/src/hermia/sink/submission.py
+++ b/src/hermia/sink/submission.py
@@ -55,7 +55,7 @@ class SubmissionSink:
 
         payload = [anonymize_row(row) for row in rows]
 
-        if self.dry_run or self.endpoint is None:
+        if self.dry_run or not self.endpoint:
             print(json.dumps(payload, indent=2))
             return
 

--- a/src/hermia/sink/submission.py
+++ b/src/hermia/sink/submission.py
@@ -68,10 +68,6 @@ class SubmissionSink:
                 timeout=5,
             )
             if not response.ok:
-                logger.warning(
-                    "hermia submit: server returned %s for %s",
-                    response.status_code,
-                    self.endpoint,
-                )
+                logger.warning("hermia submit: server returned %s", response.status_code)
         except requests.exceptions.RequestException as exc:
             logger.warning("hermia submit: request failed (%s)", type(exc).__name__)

--- a/src/hermia/sink/submission.py
+++ b/src/hermia/sink/submission.py
@@ -1,0 +1,77 @@
+"""SubmissionSink — opt-in, anonymized community submission.
+
+Rows are passed through the default-deny anonymizer before any POST is made.
+No identifying data (host, raw text, hardware metrics) can reach the server.
+
+Opt-in design: nothing is sent unless ``--submit`` is explicitly passed on
+the CLI.  Dry-run mode prints the payload and exits without any network I/O.
+
+Auth token is read from an environment variable at call time and is never
+logged, even at DEBUG level.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+
+from hermia.sink.anonymize import anonymize_row
+
+logger = logging.getLogger(__name__)
+
+
+class SubmissionSink:
+    """Anonymize and POST rows to a community submission endpoint.
+
+    Parameters
+    ----------
+    endpoint:
+        Full URL to POST to.  ``None`` forces dry-run behaviour.
+    token_env:
+        Name of the environment variable that holds the bearer token.
+        The token is read at write-time and never stored or logged.
+    dry_run:
+        When ``True`` (or when ``endpoint`` is ``None``), print the
+        anonymized payload to stdout and make no network request.
+    """
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        token_env: str = "HERMIA_SUBMIT_TOKEN",  # noqa: S107
+        dry_run: bool = False,
+    ) -> None:
+        self.endpoint = endpoint
+        self.token_env = token_env
+        self.dry_run = dry_run
+
+    def write(self, rows: list[dict[str, Any]]) -> None:
+        """Anonymize *rows* and submit (or dry-print) the safe subset."""
+        payload = [anonymize_row(row) for row in rows]
+
+        if self.dry_run or self.endpoint is None:
+            print(json.dumps(payload, indent=2))
+            return
+
+        # Live submission — read token from env at call time; never log it.
+        bearer = os.environ.get(self.token_env, "")
+        headers = {"Authorization": f"Bearer {bearer}"}
+
+        try:
+            response = requests.post(
+                self.endpoint,
+                json=payload,
+                headers=headers,
+                timeout=5,
+            )
+            if not response.ok:
+                logger.warning(
+                    "hermia submit: server returned %s for %s",
+                    response.status_code,
+                    self.endpoint,
+                )
+        except requests.exceptions.RequestException as exc:
+            logger.warning("hermia submit: request failed (%s)", type(exc).__name__)

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -1,0 +1,194 @@
+"""Tests for the default-deny anonymizer — privacy core.
+
+The critical invariants:
+1. All FORBIDDEN_KEYS are dropped unconditionally.
+2. Only SUBMIT_WHITELIST + {"failure_category", "hermia_version"} keys appear in output.
+3. failure_reason is reduced to a category prefix — no host/IP detail survives.
+4. No forbidden VALUE appears anywhere in repr(output).
+5. Unknown future fields never leak (default-deny).
+
+A passthrough implementation would fail tests 2 and 5.
+"""
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from hermia.sink.anonymize import SUBMIT_WHITELIST, anonymize_row
+
+FORBIDDEN_KEYS = {
+    "host",
+    "fleet_host_name",
+    "fleet_host_start",
+    "raw_prompt",
+    "raw_response",
+    "raw_system",
+    "output_preview",
+    "run_id",
+    "run_timestamp",
+    "peak_cpu_pct",
+    "peak_ram_used_gb",
+    "peak_gpu_pct",
+    "peak_vram_used_gb",
+}
+
+# The complete set of keys the anonymizer is ever allowed to emit.
+_ALLOWED_OUTPUT_KEYS = SUBMIT_WHITELIST | {"failure_category", "hermia_version"}
+
+
+# ---------------------------------------------------------------------------
+# Deterministic unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_drops_all_forbidden_keys() -> None:
+    """Every forbidden key must be absent from the output."""
+    row: dict[str, object] = {k: "SENSITIVE" for k in FORBIDDEN_KEYS}
+    row.update({"model": "qwen2.5:32b", "tokens": 10})
+    out = anonymize_row(row)
+    assert FORBIDDEN_KEYS.isdisjoint(out.keys())
+
+
+def test_anonymize_only_whitelisted_keys_plus_derived() -> None:
+    """Default-deny: unknown future fields (not in whitelist) never leak."""
+    row: dict[str, object] = {
+        **{k: 1 for k in SUBMIT_WHITELIST},
+        "host": "server-01",
+        "raw_response": "some text",
+        "surprise_new_field": "should_not_appear",
+    }
+    out = anonymize_row(row)
+    # Only whitelisted + derived keys allowed — future unknown fields must NOT appear.
+    assert set(out).issubset(_ALLOWED_OUTPUT_KEYS)
+    assert "surprise_new_field" not in out
+
+
+def test_failure_reason_reduced_to_category() -> None:
+    """failure_reason is reduced to a category; host/IP detail must not survive."""
+    out = anonymize_row(
+        {"failure_reason": "ERROR: HTTPConnectionPool(host='192.168.1.5', port=11434)"}
+    )
+    assert out["failure_category"] == "ERROR"
+    assert "192.168" not in str(out)
+    assert "failure_reason" not in out
+
+
+def test_failure_reason_schema_fail_category() -> None:
+    out = anonymize_row({"failure_reason": "SCHEMA_FAIL: missing required field"})
+    assert out["failure_category"] == "SCHEMA_FAIL"
+    assert "missing required field" not in str(out)
+
+
+def test_failure_reason_none_gives_none_category() -> None:
+    out = anonymize_row({"failure_reason": None})
+    assert out["failure_category"] == "none"
+
+
+def test_failure_reason_absent_gives_none_category() -> None:
+    out = anonymize_row({"model": "x"})
+    assert out["failure_category"] == "none"
+
+
+def test_failure_reason_unknown_gives_other_category() -> None:
+    out = anonymize_row({"failure_reason": "completely_unknown_prefix: detail"})
+    assert out["failure_category"] == "other"
+
+
+def test_no_sensitive_value_survives() -> None:
+    """The actual sentinel VALUE must not appear anywhere in the output repr."""
+    sentinel = "host-marker-9f3a2c"
+    row: dict[str, object] = {
+        "host": sentinel,
+        "raw_response": sentinel,
+        "output_preview": sentinel,
+        "model": "m",
+        "tokens": 1,
+    }
+    out = anonymize_row(row)
+    assert sentinel not in repr(out)
+
+
+def test_hermia_version_stamped() -> None:
+    """The output must always carry hermia_version."""
+    out = anonymize_row({"model": "x"})
+    assert "hermia_version" in out
+    assert out["hermia_version"]  # non-empty
+
+
+def test_whitelist_fields_pass_through() -> None:
+    """Whitelisted fields that are present must appear in the output unchanged."""
+    row: dict[str, object] = {"model": "qwen2.5:32b", "tokens": 42, "score": 0.9}
+    out = anonymize_row(row)
+    assert out["model"] == "qwen2.5:32b"
+    assert out["tokens"] == 42
+    assert out["score"] == 0.9
+
+
+def test_passthrough_would_fail() -> None:
+    """Verify the test would catch a naive passthrough implementation.
+
+    If anonymize_row were a no-op passthrough (returning the input dict), the
+    forbidden key "host" would appear in the output — which our other tests
+    already forbid. This test exists as explicit documentation of that contract.
+    """
+    row: dict[str, object] = {"host": "LEAKS", "model": "x"}
+    out = anonymize_row(row)
+    # A passthrough would have "host" here — we verify it does NOT.
+    assert "host" not in out
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests
+# ---------------------------------------------------------------------------
+
+
+@given(
+    # Use a fixed prefix that cannot appear in legitimate output fields
+    # (version strings, model names, etc.) so value-leak checks are reliable.
+    forbidden_suffixes=st.text(
+        alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")),
+        min_size=6,
+        max_size=14,
+    ),
+    extra_keys=st.lists(
+        st.text(min_size=1, max_size=12).filter(
+            lambda k: k not in FORBIDDEN_KEYS and k not in SUBMIT_WHITELIST
+        ),
+        max_size=3,
+    ),
+)
+@settings(max_examples=200)
+def test_property_no_forbidden_key_or_value_leaks(
+    forbidden_suffixes: str,
+    extra_keys: list[str],
+) -> None:
+    """For any dict that includes forbidden keys with sentinel values:
+    1. None of those forbidden keys appear in the output.
+    2. None of the sentinel values appear in repr(output).
+    3. Any extra unknown keys are also dropped.
+    """
+    # Build sentinel values with a guaranteed-unique prefix that cannot
+    # appear naturally in version strings, model names, or other output.
+    _SENTINEL_PREFIX = "TESTLEAK_XZQJ_"
+    forbidden_vals = {
+        k: _SENTINEL_PREFIX + forbidden_suffixes
+        for k in FORBIDDEN_KEYS
+    }
+    extra = {k: _SENTINEL_PREFIX + "extra" for k in extra_keys}
+    row: dict[str, object] = {**forbidden_vals, **extra, "model": "test-model"}
+    out = anonymize_row(row)
+
+    # No forbidden key in output
+    assert FORBIDDEN_KEYS.isdisjoint(out.keys()), (
+        f"Forbidden key leaked: {FORBIDDEN_KEYS & set(out.keys())}"
+    )
+
+    # No sentinel value in repr(out) — verifies value-level privacy
+    out_repr = repr(out)
+    for val in forbidden_vals.values():
+        assert val not in out_repr, f"Forbidden value leaked: {val!r}"
+
+    # Only allowed keys in output
+    assert set(out).issubset(_ALLOWED_OUTPUT_KEYS), (
+        f"Non-whitelisted key in output: {set(out) - _ALLOWED_OUTPUT_KEYS}"
+    )

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -137,6 +137,26 @@ def test_passthrough_would_fail() -> None:
     assert "host" not in out
 
 
+def test_signals_non_bool_values_are_stripped() -> None:
+    """Non-bool values in signals (e.g. leaked host strings) must be stripped."""
+    row = {
+        "model": "m",
+        "signals": {"flag": True, "leaked_host": "192.168.1.5", "detail": "raw text"},
+    }
+    out = anonymize_row(row)
+    assert out["signals"] == {"flag": True}
+    assert "192.168" not in repr(out)
+    assert "raw text" not in repr(out)
+
+
+def test_signals_non_dict_is_dropped() -> None:
+    """A signals value that is not a dict must be dropped entirely."""
+    out = anonymize_row({"model": "m", "signals": "host=192.168.1.5 raw=SENSITIVE"})
+    assert "signals" not in out
+    assert "192.168" not in repr(out)
+    assert "SENSITIVE" not in repr(out)
+
+
 # ---------------------------------------------------------------------------
 # Hypothesis property tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_app_submit.py
+++ b/tests/unit/test_app_submit.py
@@ -1,0 +1,134 @@
+"""Tests for --submit / --submit-dry-run CLI flags in app.py."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_fleet_file(tmp_path: Path) -> Path:
+    f = tmp_path / "fleet.yaml"
+    f.write_text("hosts:\n  - name: local\n    host: http://localhost:11434\n")
+    return f
+
+
+def _make_jsonl(tmp_path: Path, rows: list[dict[str, object]]) -> Path:
+    p = tmp_path / "eval.jsonl"
+    with p.open("w") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# --submit-dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_submit_dry_run_calls_submission_sink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--submit-dry-run must construct a dry-run SubmissionSink and call .write."""
+    fleet_file = _make_fleet_file(tmp_path)
+    rows = [{"model": "m", "score": 1.0}]
+    jsonl_path = _make_jsonl(tmp_path, rows)
+
+    monkeypatch.setattr(sys, "argv", ["hermia", "--fleet", str(fleet_file), "--submit-dry-run"])
+
+    mock_load = MagicMock(return_value=[{"name": "local", "host": "http://localhost:11434"}])
+    mock_run = MagicMock(return_value=jsonl_path)
+    mock_sink_instance = MagicMock()
+    mock_sink_class = MagicMock(return_value=mock_sink_instance)
+
+    with (
+        patch("hermia.fleet.load_fleet_config", mock_load),
+        patch("hermia.fleet.run_fleet", mock_run),
+        patch("hermia.sink.submission.SubmissionSink", mock_sink_class),
+        patch("requests.post") as mock_post,
+        pytest.raises(SystemExit) as exc,
+    ):
+        from hermia.app import main
+        main()
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    # Must construct a dry-run sink (no endpoint)
+    mock_sink_class.assert_called_once_with(endpoint=None, dry_run=True)
+    # Must call write with the loaded rows
+    mock_sink_instance.write.assert_called_once_with(rows)
+    # No network call
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# --submit
+# ---------------------------------------------------------------------------
+
+
+def test_submit_live_calls_submission_sink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--submit must construct a live SubmissionSink with endpoint from env."""
+    fleet_file = _make_fleet_file(tmp_path)
+    rows = [{"model": "m", "score": 1.0}]
+    jsonl_path = _make_jsonl(tmp_path, rows)
+    submit_url = "https://example.test/submit"
+
+    monkeypatch.setattr(sys, "argv", ["hermia", "--fleet", str(fleet_file), "--submit"])
+    monkeypatch.setenv("HERMIA_SUBMIT_URL", submit_url)
+
+    mock_load = MagicMock(return_value=[{"name": "local", "host": "http://localhost:11434"}])
+    mock_run = MagicMock(return_value=jsonl_path)
+    mock_sink_instance = MagicMock()
+    mock_sink_class = MagicMock(return_value=mock_sink_instance)
+
+    with (
+        patch("hermia.fleet.load_fleet_config", mock_load),
+        patch("hermia.fleet.run_fleet", mock_run),
+        patch("hermia.sink.submission.SubmissionSink", mock_sink_class),
+        pytest.raises(SystemExit) as exc,
+    ):
+        from hermia.app import main
+        main()
+
+    assert exc.value.code == 0
+    mock_run.assert_called_once()
+    mock_sink_class.assert_called_once_with(
+        endpoint=submit_url,
+        token_env="HERMIA_SUBMIT_TOKEN",  # noqa: S106
+        dry_run=False,
+    )
+    mock_sink_instance.write.assert_called_once_with(rows)
+
+
+# ---------------------------------------------------------------------------
+# No flags — no SubmissionSink
+# ---------------------------------------------------------------------------
+
+
+def test_no_submit_flags_no_submission_sink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --submit or --submit-dry-run, SubmissionSink must not be created."""
+    fleet_file = _make_fleet_file(tmp_path)
+    jsonl_path = tmp_path / "eval.jsonl"
+    jsonl_path.write_text("")  # empty but exists
+
+    monkeypatch.setattr(sys, "argv", ["hermia", "--fleet", str(fleet_file)])
+
+    mock_load = MagicMock(return_value=[{"name": "local", "host": "http://localhost:11434"}])
+    mock_run = MagicMock(return_value=jsonl_path)
+    mock_sink_class = MagicMock()
+
+    with (
+        patch("hermia.fleet.load_fleet_config", mock_load),
+        patch("hermia.fleet.run_fleet", mock_run),
+        patch("hermia.sink.submission.SubmissionSink", mock_sink_class),
+        pytest.raises(SystemExit) as exc,
+    ):
+        from hermia.app import main
+        main()
+
+    assert exc.value.code == 0
+    mock_sink_class.assert_not_called()

--- a/tests/unit/test_app_submit.py
+++ b/tests/unit/test_app_submit.py
@@ -140,6 +140,40 @@ def test_submit_exits_nonzero_when_url_unset(
 
 
 # ---------------------------------------------------------------------------
+# load_jsonl OSError in submit path → clean exit(1), no traceback
+# ---------------------------------------------------------------------------
+
+
+def test_submit_oserror_exits_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An OSError from load_jsonl in the submit path must exit(1) cleanly, not raise."""
+    fleet_file = _make_fleet_file(tmp_path)
+    # Point to a non-existent jsonl path so load_jsonl raises OSError
+    missing_jsonl = tmp_path / "nonexistent.jsonl"
+    submit_url = "https://example.test/submit"
+
+    monkeypatch.setattr(sys, "argv", ["hermia", "--fleet", str(fleet_file), "--submit"])
+    monkeypatch.setenv("HERMIA_SUBMIT_URL", submit_url)
+
+    mock_load = MagicMock(return_value=[{"name": "local", "host": "http://localhost:11434"}])
+    mock_run = MagicMock(return_value=missing_jsonl)
+
+    with (
+        patch("hermia.fleet.load_fleet_config", mock_load),
+        patch("hermia.fleet.run_fleet", mock_run),
+        patch("hermia.results.load_jsonl", side_effect=OSError("file not found")),
+        pytest.raises(SystemExit) as exc,
+    ):
+        from hermia.app import main
+        main()
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "hermia:" in captured.err
+
+
+# ---------------------------------------------------------------------------
 # No flags — no SubmissionSink
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_app_submit.py
+++ b/tests/unit/test_app_submit.py
@@ -103,6 +103,43 @@ def test_submit_live_calls_submission_sink(tmp_path: Path, monkeypatch: pytest.M
 
 
 # ---------------------------------------------------------------------------
+# --submit with HERMIA_SUBMIT_URL unset → non-zero exit, no write
+# ---------------------------------------------------------------------------
+
+
+def test_submit_exits_nonzero_when_url_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--submit without HERMIA_SUBMIT_URL must exit(1) with a clear message; no write."""
+    fleet_file = _make_fleet_file(tmp_path)
+    rows = [{"model": "m", "score": 1.0}]
+    jsonl_path = _make_jsonl(tmp_path, rows)
+
+    monkeypatch.setattr(sys, "argv", ["hermia", "--fleet", str(fleet_file), "--submit"])
+    monkeypatch.delenv("HERMIA_SUBMIT_URL", raising=False)
+
+    mock_load = MagicMock(return_value=[{"name": "local", "host": "http://localhost:11434"}])
+    mock_run = MagicMock(return_value=jsonl_path)
+    mock_sink_instance = MagicMock()
+    mock_sink_class = MagicMock(return_value=mock_sink_instance)
+
+    with (
+        patch("hermia.fleet.load_fleet_config", mock_load),
+        patch("hermia.fleet.run_fleet", mock_run),
+        patch("hermia.sink.submission.SubmissionSink", mock_sink_class),
+        pytest.raises(SystemExit) as exc,
+    ):
+        from hermia.app import main
+        main()
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "HERMIA_SUBMIT_URL" in captured.err
+    # SubmissionSink.write must NOT have been called
+    mock_sink_instance.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # No flags — no SubmissionSink
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_sink_base.py
+++ b/tests/unit/test_sink_base.py
@@ -1,0 +1,29 @@
+"""Tests for the Sink protocol (runtime-checkable)."""
+from __future__ import annotations
+
+from typing import Any
+
+from hermia.sink.base import Sink
+
+
+class _ValidSink:
+    def write(self, rows: list[dict[str, Any]]) -> None:
+        pass
+
+
+class _NoWrite:
+    def other_method(self) -> None:
+        pass
+
+
+def test_sink_protocol_satisfied() -> None:
+    assert isinstance(_ValidSink(), Sink)
+
+
+def test_sink_protocol_not_satisfied() -> None:
+    assert not isinstance(_NoWrite(), Sink)
+
+
+def test_sink_has_write_attribute() -> None:
+    assert hasattr(Sink, "write")
+    assert callable(Sink.write)

--- a/tests/unit/test_sink_local.py
+++ b/tests/unit/test_sink_local.py
@@ -1,0 +1,63 @@
+"""Tests for JsonlCsvSink and PostgresSink local adapters."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from hermia.sink.local import JsonlCsvSink, PostgresSink
+
+# ---------------------------------------------------------------------------
+# JsonlCsvSink
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_csv_sink_calls_append_result_per_row(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "test.jsonl"
+    csv_path = tmp_path / "test.csv"
+    rows = [{"model": "a", "score": 1}, {"model": "b", "score": 2}]
+
+    with patch("hermia.sink.local.append_result") as mock_append:
+        JsonlCsvSink(jsonl_path, csv_path).write(rows)
+
+    assert mock_append.call_count == 2
+    mock_append.assert_any_call(rows[0], jsonl_path, csv_path)
+    mock_append.assert_any_call(rows[1], jsonl_path, csv_path)
+
+
+def test_jsonl_csv_sink_rows_persist(tmp_path: Path) -> None:
+    """Integration: rows actually land in the JSONL file via the real writer."""
+    from hermia.results import load_jsonl
+
+    jsonl_path = tmp_path / "test.jsonl"
+    csv_path = tmp_path / "test.csv"
+    rows = [{"model": "a", "score": 1}, {"model": "b", "score": 2}]
+
+    JsonlCsvSink(jsonl_path, csv_path).write(rows)
+
+    loaded = load_jsonl(jsonl_path)
+    assert loaded == rows
+
+
+# ---------------------------------------------------------------------------
+# PostgresSink
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_sink_dry_run_true() -> None:
+    dsn = "postgresql://localhost/testdb"
+    rows = [{"model": "a", "score": 1}]
+
+    with patch("hermia.sink.local.push") as mock_push:
+        PostgresSink(dsn, dry_run=True).write(rows)
+
+    mock_push.assert_called_once_with(rows, dsn, dry_run=True)
+
+
+def test_postgres_sink_default_dry_run_false() -> None:
+    dsn = "postgresql://localhost/testdb"
+    rows = [{"model": "a", "score": 1}]
+
+    with patch("hermia.sink.local.push") as mock_push:
+        PostgresSink(dsn).write(rows)
+
+    mock_push.assert_called_once_with(rows, dsn, dry_run=False)

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -1,0 +1,171 @@
+"""Tests for SubmissionSink — opt-in anonymized POST with dry-run."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from hermia.sink.submission import SubmissionSink
+
+# ---------------------------------------------------------------------------
+# Dry-run mode — no network call
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_no_endpoint_no_network_call(capsys: pytest.CaptureFixture[str]) -> None:
+    """endpoint=None with any dry_run value must never call requests.post."""
+    rows = [{"host": "example.com", "raw_response": "raw text", "model": "m"}]
+    with patch("requests.post") as mock_post:
+        SubmissionSink(endpoint=None, dry_run=True).write(rows)
+    mock_post.assert_not_called()
+
+
+def test_dry_run_true_with_endpoint_no_network_call() -> None:
+    """dry_run=True must never call requests.post even when endpoint is set."""
+    rows = [{"host": "example.com", "raw_response": "raw text", "model": "m"}]
+    with patch("requests.post") as mock_post:
+        SubmissionSink(endpoint="https://example.test/submit", dry_run=True).write(rows)
+    mock_post.assert_not_called()
+
+
+def test_dry_run_output_contains_anonymized_rows(capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry-run should print the anonymized payload to stdout."""
+    rows = [{"model": "qwen2.5:32b", "tokens": 42, "host": "private-host"}]
+    SubmissionSink(endpoint=None, dry_run=True).write(rows)
+    captured = capsys.readouterr().out
+    assert "qwen2.5:32b" in captured  # whitelisted field present
+    assert "private-host" not in captured  # host must NOT appear
+
+
+# ---------------------------------------------------------------------------
+# Live mode — posts anonymized payload
+# ---------------------------------------------------------------------------
+
+
+def test_live_posts_anonymized_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Live mode POSTs the anonymized payload to the endpoint."""
+    rows = [{"host": "example.com", "raw_response": "raw text", "model": "m", "tokens": 5}]
+    monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="TEST_SUBMIT_MARKER",  # noqa: S106
+            dry_run=False,
+        ).write(rows)
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://example.test/submit"
+    assert "json" in kwargs
+    payload = kwargs["json"]
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    row = payload[0]
+    # Whitelisted field passes through
+    assert row.get("model") == "m"
+    assert row.get("tokens") == 5
+    # Forbidden fields are stripped
+    assert "host" not in row
+    assert "raw_response" not in row
+
+
+def test_live_authorization_header_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auth header must be built from the env var value."""
+    marker = "bearer-marker-xyz789"
+    monkeypatch.setenv("MY_MARKER_ENV", marker)
+    rows = [{"model": "m"}]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="MY_MARKER_ENV",  # noqa: S106
+            dry_run=False,
+        ).write(rows)
+
+    _, kwargs = mock_post.call_args
+    headers = kwargs.get("headers", {})
+    assert headers.get("Authorization") == f"Bearer {marker}"
+
+
+def test_live_non_2xx_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-2xx response must not raise; a warning should be logged."""
+    monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.ok = False
+
+    with (
+        patch("requests.post", return_value=mock_response),
+        patch("hermia.sink.submission.logger") as mock_logger,
+    ):
+        # Must not raise
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="TEST_SUBMIT_MARKER",  # noqa: S106
+            dry_run=False,
+        ).write([{"model": "m"}])
+
+    mock_logger.warning.assert_called()
+
+
+def test_live_request_exception_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Network errors must be caught and logged, not raised."""
+    monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
+
+    with (
+        patch("requests.post", side_effect=requests.exceptions.RequestException("timeout")),
+        patch("hermia.sink.submission.logger") as mock_logger,
+    ):
+        # Must not raise
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="TEST_SUBMIT_MARKER",  # noqa: S106
+            dry_run=False,
+        ).write([{"model": "m"}])
+
+    mock_logger.warning.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Privacy guard — sentinel value must never appear in the POST body
+# ---------------------------------------------------------------------------
+
+
+def test_privacy_guard_sentinel_not_in_post_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Forbidden field values must not appear in the JSON body posted to the server."""
+    sentinel = "SENTINEL_XZQJ_abc123"
+    rows = [
+        {
+            "host": sentinel,
+            "raw_response": sentinel,
+            "output_preview": sentinel,
+            "model": "m",
+            "tokens": 1,
+        }
+    ]
+    monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="TEST_SUBMIT_MARKER",  # noqa: S106
+            dry_run=False,
+        ).write(rows)
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    payload_str = json.dumps(kwargs["json"])
+    assert sentinel not in payload_str, (
+        "Privacy violation: sentinel value appeared in POST body"
+    )

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -96,12 +96,35 @@ def test_live_authorization_header_from_env(monkeypatch: pytest.MonkeyPatch) -> 
     assert headers.get("Authorization") == f"Bearer {marker}"
 
 
+def test_live_empty_token_omits_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the token env var is unset/empty, no Authorization header must be sent."""
+    monkeypatch.delenv("MY_MISSING_TOKEN_ENV", raising=False)
+    rows = [{"model": "m"}]
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="MY_MISSING_TOKEN_ENV",  # noqa: S106
+            dry_run=False,
+        ).write(rows)
+
+    _, kwargs = mock_post.call_args
+    headers = kwargs.get("headers", {})
+    assert "Authorization" not in headers, (
+        "Authorization header must be absent when token env var is unset"
+    )
+
+
 def test_live_non_2xx_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-2xx response must not raise; a warning should be logged."""
     monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
     mock_response = MagicMock()
     mock_response.status_code = 503
     mock_response.ok = False
+    mock_response.text = "Service Unavailable"
 
     with (
         patch("requests.post", return_value=mock_response),
@@ -115,6 +138,56 @@ def test_live_non_2xx_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
         ).write([{"model": "m"}])
 
     mock_logger.warning.assert_called()
+
+
+def test_live_non_2xx_logs_truncated_response_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-2xx warning must include a truncated response body for diagnosis."""
+    monkeypatch.setenv("TEST_SUBMIT_MARKER", "marker-value-abc")
+    body = "x" * 300  # longer than the 200-char truncation limit
+    mock_response = MagicMock()
+    mock_response.status_code = 422
+    mock_response.ok = False
+    mock_response.text = body
+
+    with (
+        patch("requests.post", return_value=mock_response),
+        patch("hermia.sink.submission.logger") as mock_logger,
+    ):
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            token_env="TEST_SUBMIT_MARKER",  # noqa: S106
+            dry_run=False,
+        ).write([{"model": "m"}])
+
+    mock_logger.warning.assert_called_once()
+    call_args = mock_logger.warning.call_args
+    # The warning format string references %s, %s — check positional args
+    pos_args = call_args[0]
+    assert 422 in pos_args
+    # Truncated body (first 200 chars) must appear somewhere in the positional args
+    assert body[:200] in pos_args
+
+
+def test_empty_rows_no_network_call() -> None:
+    """When rows is empty, no anonymization, no print, no network call must occur."""
+    with (
+        patch("requests.post") as mock_post,
+        patch("hermia.sink.anonymize.anonymize_row") as mock_anon,
+    ):
+        SubmissionSink(
+            endpoint="https://example.test/submit",
+            dry_run=False,
+        ).write([])
+
+    mock_post.assert_not_called()
+    mock_anon.assert_not_called()
+
+
+def test_empty_rows_dry_run_no_print(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty rows with dry_run=True must not print anything."""
+    SubmissionSink(endpoint=None, dry_run=True).write([])
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 def test_live_request_exception_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_submission.py
+++ b/tests/unit/test_submission.py
@@ -22,6 +22,16 @@ def test_dry_run_no_endpoint_no_network_call(capsys: pytest.CaptureFixture[str])
     mock_post.assert_not_called()
 
 
+def test_empty_string_endpoint_dry_runs_no_network_call(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """endpoint='' with dry_run=False must behave as dry-run (not POST to empty URL)."""
+    rows = [{"host": "example.com", "raw_response": "raw text", "model": "m"}]
+    with patch("requests.post") as mock_post:
+        SubmissionSink(endpoint="", dry_run=False).write(rows)
+    mock_post.assert_not_called()
+
+
 def test_dry_run_true_with_endpoint_no_network_call() -> None:
     """dry_run=True must never call requests.post even when endpoint is set."""
     rows = [{"host": "example.com", "raw_response": "raw text", "model": "m"}]


### PR DESCRIPTION
Draft (governance: PR on first push). Lean plan in docs/superpowers/plans/. Sink protocol + JsonlCsv/Postgres adapters + default-deny anonymizer (privacy core, property-tested) + opt-in SubmissionSink (dry-run). Server/auth deferred to v0.3. Generation delegated to coder-biggest-5090; Sonnet integrates/reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)