### PR TITLE
chore: sign off on 10 capability test policies

### DIFF
--- a/catalog-meta/compound-sequencing.json
+++ b/catalog-meta/compound-sequencing.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/context-retention.json
+++ b/catalog-meta/context-retention.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/error-recovery.json
+++ b/catalog-meta/error-recovery.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/home-automation-agent.json
+++ b/catalog-meta/home-automation-agent.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/multiturn-context-carry.json
+++ b/catalog-meta/multiturn-context-carry.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/partial-failure-handling.json
+++ b/catalog-meta/partial-failure-handling.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/strict-constraint-adherence.json
+++ b/catalog-meta/strict-constraint-adherence.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/structured-data-extraction.json
+++ b/catalog-meta/structured-data-extraction.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/tool-calling-basic.json
+++ b/catalog-meta/tool-calling-basic.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }

--- a/catalog-meta/tool-selection.json
+++ b/catalog-meta/tool-selection.json
@@ -23,5 +23,5 @@
   "known_limitations": [
     "Capability test: structure-only grading (no semantic verification of the reasoning/calculation prose beyond the checked fields)."
   ],
-  "policy_signed_off": false
+  "policy_signed_off": true
 }


### PR DESCRIPTION
## Summary
- Flips `policy_signed_off: true` on 10 capability tests after Gate-2 review
- Each carries the consistent known-limitation: structural-only grading (no semantic verification of reasoning/calculation prose beyond the checked fields)
- Sign-off confirms the grader policy is sound for what it measures, not that the test is a semantic oracle

## Tests signed off
- tool-calling-basic
- error-recovery
- strict-constraint-adherence (just clarified in PR #102)
- context-retention
- home-automation-agent
- structured-data-extraction
- tool-selection
- multiturn-context-carry
- compound-sequencing
- partial-failure-handling

## Still deferred (NOT in this PR)
- multi-step-reasoning — adversarial framing upgrade batched with GUARDS normalization
- numeric-reasoning — same reason

## Test plan
- [x] 115 unit tests passing (corpus audit + dataset format)
- [x] Catalog regenerated (no public diff — `policy_signed_off` is internal metadata)
- [x] Per-test review documented in `next_session_corpus_audit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)