### PR TITLE
fix(privacy): value-level sanitize frameworks in anonymizer

### DIFF
--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -103,17 +103,18 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
     # Value-level default-deny for frameworks: only known taxonomy keys with
     # list-of-strings values are safe.  A custom dataset could embed identifying
     # strings in framework values; strip anything outside the known shape.
-    fw = out.get("frameworks")
-    if isinstance(fw, dict):
-        out["frameworks"] = {
-            k: v
-            for k, v in fw.items()
-            if k in _KNOWN_FRAMEWORK_KEYS
-            and isinstance(v, list)
-            and all(isinstance(item, str) for item in v)
-        }
-    else:
-        out.pop("frameworks", None)  # drop if not a dict
+    if "frameworks" in out:
+        fw = out["frameworks"]
+        if isinstance(fw, dict):
+            out["frameworks"] = {
+                k: list(v)
+                for k, v in fw.items()
+                if k in _KNOWN_FRAMEWORK_KEYS
+                and isinstance(v, list)
+                and all(isinstance(item, str) for item in v)
+            }
+        else:
+            del out["frameworks"]
 
     out["failure_category"] = _categorize_failure(row.get("failure_reason"))
     out["hermia_version"] = __version__

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -107,11 +107,11 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
         fw = out["frameworks"]
         if isinstance(fw, dict):
             out["frameworks"] = {
-                k: list(v)
-                for k, v in fw.items()
-                if k in _KNOWN_FRAMEWORK_KEYS
-                and isinstance(v, list)
-                and all(isinstance(item, str) for item in v)
+                k: list(fw[k])
+                for k in _KNOWN_FRAMEWORK_KEYS
+                if k in fw
+                and isinstance(fw[k], list)
+                and all(isinstance(item, str) for item in fw[k])
             }
         else:
             del out["frameworks"]

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -61,6 +61,11 @@ _KNOWN_FAILURE_PREFIXES: tuple[str, ...] = (
 )
 
 
+_KNOWN_FRAMEWORK_KEYS: frozenset[str] = frozenset(
+    {"owasp_llm_top10_2025", "mitre_atlas_v5_1", "csa_maestro", "nist_ai_rmf"}
+)
+
+
 def _categorize_failure(reason: object) -> str:
     """Reduce a failure_reason string to its category prefix.
 
@@ -94,6 +99,21 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
         out["signals"] = {k: v for k, v in sig.items() if isinstance(v, bool)}
     else:
         out.pop("signals", None)  # drop if not a bool dict
+
+    # Value-level default-deny for frameworks: only known taxonomy keys with
+    # list-of-strings values are safe.  A custom dataset could embed identifying
+    # strings in framework values; strip anything outside the known shape.
+    fw = out.get("frameworks")
+    if isinstance(fw, dict):
+        out["frameworks"] = {
+            k: v
+            for k, v in fw.items()
+            if k in _KNOWN_FRAMEWORK_KEYS
+            and isinstance(v, list)
+            and all(isinstance(item, str) for item in v)
+        }
+    else:
+        out.pop("frameworks", None)  # drop if not a dict
 
     out["failure_category"] = _categorize_failure(row.get("failure_reason"))
     out["hermia_version"] = __version__

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -157,6 +157,46 @@ def test_signals_non_dict_is_dropped() -> None:
     assert "SENSITIVE" not in repr(out)
 
 
+def test_frameworks_unknown_keys_stripped() -> None:
+    """Only known taxonomy keys survive; unknown keys with identifying data are dropped."""
+    row = {
+        "model": "m",
+        "frameworks": {
+            "owasp_llm_top10_2025": ["LLM01:2025"],
+            "custom_sentinel": ["scott-lab-internal-id-12345"],
+            "mitre_atlas_v5_1": ["AML.T0051"],
+        },
+    }
+    out = anonymize_row(row)
+    assert "custom_sentinel" not in out["frameworks"]
+    assert "scott-lab" not in repr(out)
+    assert out["frameworks"] == {
+        "owasp_llm_top10_2025": ["LLM01:2025"],
+        "mitre_atlas_v5_1": ["AML.T0051"],
+    }
+
+
+def test_frameworks_non_string_list_values_stripped() -> None:
+    """Framework values that aren't list-of-strings are dropped."""
+    row = {
+        "model": "m",
+        "frameworks": {
+            "owasp_llm_top10_2025": ["LLM01:2025"],
+            "csa_maestro": "not-a-list",
+            "nist_ai_rmf": [123, "ME 2.3"],
+        },
+    }
+    out = anonymize_row(row)
+    assert out["frameworks"] == {"owasp_llm_top10_2025": ["LLM01:2025"]}
+
+
+def test_frameworks_non_dict_is_dropped() -> None:
+    """A frameworks value that is not a dict must be dropped entirely."""
+    out = anonymize_row({"model": "m", "frameworks": "owasp=SENSITIVE"})
+    assert "frameworks" not in out
+    assert "SENSITIVE" not in repr(out)
+
+
 # ---------------------------------------------------------------------------
 # Hypothesis property tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_KNOWN_FRAMEWORK_KEYS` frozenset with the 4 taxonomy keys
- Sanitize `frameworks` dict in `anonymize_row` — only known keys with list-of-strings values survive
- Add 3 unit tests: unknown keys stripped, non-string-list values stripped, non-dict dropped

Mirrors the `signals` bool-only treatment (line 89-96). Custom datasets can no longer embed identifying strings in framework values.

Closes #97

## Test plan
- [x] 3 new tests pass (`test_frameworks_*`)
- [x] Full suite: 1334 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)