### PR TITLE
feat: hermia_version stamping + backend stack tagging

### DIFF
--- a/scripts/add_backend_columns.sql
+++ b/scripts/add_backend_columns.sql
@@ -1,0 +1,7 @@
+-- Add hermia_version and backend stack tagging columns.
+-- Idempotent — safe to run multiple times.
+
+ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS hermia_version TEXT;
+ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS gpu_arch TEXT;
+ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS runtime_version TEXT;
+ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS backend_stack TEXT;

--- a/src/hermia/backend.py
+++ b/src/hermia/backend.py
@@ -32,7 +32,7 @@ def resolve_stack(
     runtime_version = raw_rt if isinstance(raw_rt, str) else None
 
     components = [orchestration_version, gpu_arch, runtime_version]
-    non_none = [c for c in components if c is not None]
+    non_none = [c for c in components if isinstance(c, str) and c.strip()]
     backend_stack = " | ".join(non_none) if non_none else None
 
     return {

--- a/src/hermia/backend.py
+++ b/src/hermia/backend.py
@@ -1,0 +1,42 @@
+"""Backend stack metadata resolution for fleet eval runs.
+
+Merges fleet YAML ``stack:`` block metadata with live transport data
+to produce queryable per-result-row fields: ``gpu_arch``,
+``runtime_version``, and a composite ``backend_stack`` summary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_stack(
+    entry: dict[str, Any],
+    orchestration_version: str | None = None,
+) -> dict[str, str | None]:
+    """Merge fleet YAML stack metadata with live query data.
+
+    Returns dict with keys: ``gpu_arch``, ``runtime_version``,
+    ``backend_stack``.  ``orchestration`` / ``orchestration_version``
+    already exist on the result row — this function does NOT duplicate
+    them.
+    """
+    stack = entry.get("stack")
+    if not isinstance(stack, dict):
+        stack = {}
+
+    raw_arch = stack.get("gpu_arch")
+    gpu_arch = raw_arch if isinstance(raw_arch, str) else None
+
+    raw_rt = stack.get("runtime_version")
+    runtime_version = raw_rt if isinstance(raw_rt, str) else None
+
+    components = [orchestration_version, gpu_arch, runtime_version]
+    non_none = [c for c in components if c is not None]
+    backend_stack = " | ".join(non_none) if non_none else None
+
+    return {
+        "gpu_arch": gpu_arch,
+        "runtime_version": runtime_version,
+        "backend_stack": backend_stack,
+    }

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -53,6 +53,10 @@ _PG_COLUMNS = (
     "raw_system",
     "raw_prompt",
     "raw_response",
+    "hermia_version",
+    "gpu_arch",
+    "runtime_version",
+    "backend_stack",
 )
 
 _INSERT_SQL = (

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -40,6 +40,11 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
                 f"Fleet entry '{entry.get('name', '?')}': transport must be 'ollama' or "
                 f"'openai-compat', got '{transport}'"
             )
+        stack = entry.get("stack")
+        if stack is not None and not isinstance(stack, dict):
+            raise ValueError(
+                f"Fleet entry [{i}] 'stack' must be a mapping, got {type(stack).__name__}"
+            )
     return entries
 
 
@@ -103,6 +108,7 @@ def _run_host_eval(
     """
     from datetime import UTC, datetime
 
+    from hermia.backend import resolve_stack
     from hermia.metrics import MetricsSampler
     from hermia.results import append_result
     from hermia.robustness import score_rows
@@ -166,6 +172,9 @@ def _run_host_eval(
                 result["cold_warm_delta_tps"] = None
                 result["fleet_host_name"] = name
                 result["fleet_host_start"] = host_start
+                result.update(resolve_stack(
+                    entry, result.get("orchestration_version"),
+                ))
                 run_results.append(result)
 
             # Compute robustness aggregates across all repeat runs for this pair

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 import requests
 
+from hermia import __version__
 from hermia.metrics import MetricsSampler, get_gpu_stats
 from hermia.schemas import SCHEMA_CHECKS, SIGNAL_EXTRACTORS
 from hermia.transport.base import Response, TransportError
@@ -403,4 +404,5 @@ def run_test(
         "orchestration_version": orchestration_version,
         "turn_count": len(user_turns),
         "raw_turns": user_turns,
+        "hermia_version": __version__,
     }

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -1,0 +1,101 @@
+"""Tests for hermia.backend — backend stack metadata resolution."""
+
+from hermia.backend import resolve_stack
+
+
+def test_resolve_stack_full() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "sm_89", "runtime_version": "CUDA 12.8"},
+    }
+    result = resolve_stack(entry, "0.24.0")
+    assert result["gpu_arch"] == "sm_89"
+    assert result["runtime_version"] == "CUDA 12.8"
+    assert result["backend_stack"] == "0.24.0 | sm_89 | CUDA 12.8"
+
+
+def test_resolve_stack_no_stack_block() -> None:
+    entry = {"name": "gpu-box", "host": "http://10.0.0.5:11434"}
+    result = resolve_stack(entry)
+    assert result["gpu_arch"] is None
+    assert result["runtime_version"] is None
+    assert result["backend_stack"] is None
+
+
+def test_resolve_stack_partial_gpu_only() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "sm_89"},
+    }
+    result = resolve_stack(entry)
+    assert result["gpu_arch"] == "sm_89"
+    assert result["runtime_version"] is None
+    assert result["backend_stack"] == "sm_89"
+
+
+def test_resolve_stack_partial_runtime_only() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"runtime_version": "CUDA 12.8"},
+    }
+    result = resolve_stack(entry)
+    assert result["gpu_arch"] is None
+    assert result["runtime_version"] == "CUDA 12.8"
+    assert result["backend_stack"] == "CUDA 12.8"
+
+
+def test_resolve_stack_non_dict_stack() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": "not a dict",
+    }
+    result = resolve_stack(entry)
+    assert result["gpu_arch"] is None
+    assert result["runtime_version"] is None
+    assert result["backend_stack"] is None
+
+
+def test_resolve_stack_non_string_gpu_arch() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": 123},
+    }
+    result = resolve_stack(entry)
+    assert result["gpu_arch"] is None
+
+
+def test_resolve_stack_non_string_runtime_version() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"runtime_version": ["CUDA"]},
+    }
+    result = resolve_stack(entry)
+    assert result["runtime_version"] is None
+
+
+def test_backend_stack_string_format() -> None:
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "sm_89", "runtime_version": "CUDA 12.8"},
+    }
+    result = resolve_stack(entry, "0.24.0")
+    assert result["backend_stack"] == "0.24.0 | sm_89 | CUDA 12.8"
+
+
+def test_backend_stack_all_none() -> None:
+    entry = {"name": "gpu-box", "host": "http://10.0.0.5:11434"}
+    result = resolve_stack(entry)
+    assert result["backend_stack"] is None
+
+
+def test_backend_stack_only_orchestration_version() -> None:
+    entry = {"name": "gpu-box", "host": "http://10.0.0.5:11434"}
+    result = resolve_stack(entry, "0.24.0")
+    assert result["backend_stack"] == "0.24.0"

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -634,6 +634,61 @@ def test_pg_columns_includes_raw_response() -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# hermia_version + backend stack tagging columns
+# ---------------------------------------------------------------------------
+
+
+def test_pg_columns_includes_hermia_version() -> None:
+    assert "hermia_version" in _PG_COLUMNS
+
+
+def test_pg_columns_includes_backend_stack_fields() -> None:
+    assert "gpu_arch" in _PG_COLUMNS
+    assert "runtime_version" in _PG_COLUMNS
+    assert "backend_stack" in _PG_COLUMNS
+
+
+def test_pg_columns_no_duplicates() -> None:
+    assert len(_PG_COLUMNS) == len(set(_PG_COLUMNS))
+
+
+def test_build_record_projects_hermia_version() -> None:
+    from hermia.export import _build_record
+    row = {**_ROW, "hermia_version": "0.2.0"}
+    rec = _build_record(row)
+    assert rec["hermia_version"] == "0.2.0"
+
+
+def test_build_record_projects_backend_fields() -> None:
+    from hermia.export import _build_record
+    row = {
+        **_ROW,
+        "gpu_arch": "sm_89",
+        "runtime_version": "CUDA 12.8",
+        "backend_stack": "0.24.0 | sm_89 | CUDA 12.8",
+    }
+    rec = _build_record(row)
+    assert rec["gpu_arch"] == "sm_89"
+    assert rec["runtime_version"] == "CUDA 12.8"
+    assert rec["backend_stack"] == "0.24.0 | sm_89 | CUDA 12.8"
+
+
+def test_build_record_backend_fields_default_none() -> None:
+    """Legacy rows without backend fields must project to None."""
+    from hermia.export import _build_record
+    rec = _build_record(_ROW)
+    assert rec["hermia_version"] is None
+    assert rec["gpu_arch"] is None
+    assert rec["runtime_version"] is None
+    assert rec["backend_stack"] is None
+
+
+# ---------------------------------------------------------------------------
+# --version flag
+# ---------------------------------------------------------------------------
+
+
 def test_main_version_flag(monkeypatch, capsys) -> None:
     """--version should print the package version and exit 0."""
     import sys

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -540,6 +540,52 @@ def test_run_fleet_verbose_still_prints_saved_path(tmp_path: Path) -> None:
     assert any("Saved:" in ln for ln in lines)
 
 
+# ---------------------------------------------------------------------------
+# stack: block in fleet YAML
+# ---------------------------------------------------------------------------
+
+
+def test_load_fleet_config_with_stack(tmp_path: Path) -> None:
+    """Valid stack block is accepted and preserved on the entry."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: gpu-box\n"
+        "    host: http://host1:11434\n"
+        "    stack:\n"
+        "      gpu_arch: sm_89\n"
+        "      runtime_version: CUDA 12.8\n"
+    )
+    entries = load_fleet_config(cfg)
+    assert entries[0]["stack"]["gpu_arch"] == "sm_89"
+    assert entries[0]["stack"]["runtime_version"] == "CUDA 12.8"
+
+
+def test_load_fleet_config_invalid_stack_type(tmp_path: Path) -> None:
+    """stack: 'not a dict' must raise ValueError."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: gpu-box\n"
+        "    host: http://host1:11434\n"
+        "    stack: not-a-dict\n"
+    )
+    with pytest.raises(ValueError, match="stack"):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_stack_optional(tmp_path: Path) -> None:
+    """Missing stack block must not cause an error."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+    )
+    entries = load_fleet_config(cfg)
+    assert "stack" not in entries[0]
+
+
 def test_group_entries_by_host_serializes_same_host() -> None:
     from hermia.fleet import _group_entries_by_host
     entries = [

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -262,6 +262,21 @@ def test_run_test_generic_exception() -> None:
     assert result["json_valid"] is False
 
 
+def test_run_test_stamps_hermia_version() -> None:
+    """Every result row must carry hermia_version for data partitioning."""
+    payload = '{"action": "search_documentation", "params": {}}'
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+    assert "hermia_version" in result
+    assert isinstance(result["hermia_version"], str)
+    assert result["hermia_version"]  # non-empty
+
+
 def test_run_test_peak_metrics_in_result() -> None:
     transport = MagicMock()
     transport.generate.return_value = TransportResponse(


### PR DESCRIPTION
## Summary

- **hermia_version on every result row** — stamps `hermia.__version__` on every `run_test()` result so JSONL/CSV/Postgres data can be partitioned by tool version. Unblocks the v0.2 promotion gate.
- **Backend stack tagging** — new `backend.py` module with `resolve_stack()` that merges optional fleet YAML `stack:` metadata (gpu_arch, runtime_version) into per-row fields. Composite `backend_stack` field enables cross-version queries.
- **Fleet YAML extension** — optional `stack:` block per node; validated on load; graceful None when absent.
- **Postgres migration** — `scripts/add_backend_columns.sql` (idempotent `ADD COLUMN IF NOT EXISTS`)
- **20 new tests** across `test_backend.py` (new), `test_runner.py`, `test_export.py`, `test_fleet.py`

## Test plan

- [x] 1355 tests passing (0 failures)
- [x] mypy clean on new module
- [x] detect-secrets hooks pass
- [x] DDL backing test passes (test_every_pg_column_has_backing_ddl)
- [ ] Gemini review
- [ ] /code-review
- [ ] Opus /review

🤖 Generated with [Claude Code](https://claude.com/claude-code)