### PR TITLE
fix(backend): strip YAML stack whitespace; add hermia_version index

### DIFF
--- a/scripts/add_backend_columns.sql
+++ b/scripts/add_backend_columns.sql
@@ -7,5 +7,7 @@ ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS runtime_version TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS backend_stack TEXT;
 
 -- Index for version-partition queries (WHERE hermia_version = '...').
-CREATE INDEX IF NOT EXISTS idx_hermia_results_hermia_version
+-- CONCURRENTLY avoids a write lock on hermia_results during index build.
+-- Note: cannot run inside a transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_hermia_results_hermia_version
     ON hermia_results (hermia_version);

--- a/scripts/add_backend_columns.sql
+++ b/scripts/add_backend_columns.sql
@@ -5,3 +5,7 @@ ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS hermia_version TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS gpu_arch TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS runtime_version TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS backend_stack TEXT;
+
+-- Index for version-partition queries (WHERE hermia_version = '...').
+CREATE INDEX IF NOT EXISTS idx_hermia_results_hermia_version
+    ON hermia_results (hermia_version);

--- a/scripts/add_backend_columns.sql
+++ b/scripts/add_backend_columns.sql
@@ -6,8 +6,11 @@ ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS gpu_arch TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS runtime_version TEXT;
 ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS backend_stack TEXT;
 
--- Index for version-partition queries (WHERE hermia_version = '...').
--- CONCURRENTLY avoids a write lock on hermia_results during index build.
--- Note: cannot run inside a transaction block.
+-- Partial index for version-partition queries (WHERE hermia_version = '...').
+-- Excludes NULL rows (historical data before PR #109) to keep the index small.
+-- CONCURRENTLY avoids a write lock during build; cannot run in a transaction.
+-- If CONCURRENTLY fails mid-build, drop the resulting invalid index manually
+-- before re-running (IF NOT EXISTS will otherwise silently skip recreation).
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_hermia_results_hermia_version
-    ON hermia_results (hermia_version);
+    ON hermia_results (hermia_version)
+    WHERE hermia_version IS NOT NULL;

--- a/src/hermia/backend.py
+++ b/src/hermia/backend.py
@@ -26,10 +26,10 @@ def resolve_stack(
         stack = {}
 
     raw_arch = stack.get("gpu_arch")
-    gpu_arch = raw_arch.strip() if isinstance(raw_arch, str) else None
+    gpu_arch = (raw_arch.strip() or None) if isinstance(raw_arch, str) else None
 
     raw_rt = stack.get("runtime_version")
-    runtime_version = raw_rt.strip() if isinstance(raw_rt, str) else None
+    runtime_version = (raw_rt.strip() or None) if isinstance(raw_rt, str) else None
 
     components = [orchestration_version, gpu_arch, runtime_version]
     non_none = [c for c in components if isinstance(c, str) and c.strip()]

--- a/src/hermia/backend.py
+++ b/src/hermia/backend.py
@@ -26,10 +26,10 @@ def resolve_stack(
         stack = {}
 
     raw_arch = stack.get("gpu_arch")
-    gpu_arch = raw_arch if isinstance(raw_arch, str) else None
+    gpu_arch = raw_arch.strip() if isinstance(raw_arch, str) else None
 
     raw_rt = stack.get("runtime_version")
-    runtime_version = raw_rt if isinstance(raw_rt, str) else None
+    runtime_version = raw_rt.strip() if isinstance(raw_rt, str) else None
 
     components = [orchestration_version, gpu_arch, runtime_version]
     non_none = [c for c in components if isinstance(c, str) and c.strip()]

--- a/src/hermia/backend.py
+++ b/src/hermia/backend.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 from typing import Any
 
 
+def _normalize_str(val: Any) -> str | None:
+    """Return stripped string, or None for non-strings and whitespace-only strings."""
+    return (val.strip() or None) if isinstance(val, str) else None
+
+
 def resolve_stack(
     entry: dict[str, Any],
     orchestration_version: str | None = None,
@@ -25,14 +30,11 @@ def resolve_stack(
     if not isinstance(stack, dict):
         stack = {}
 
-    raw_arch = stack.get("gpu_arch")
-    gpu_arch = (raw_arch.strip() or None) if isinstance(raw_arch, str) else None
+    gpu_arch = _normalize_str(stack.get("gpu_arch"))
+    runtime_version = _normalize_str(stack.get("runtime_version"))
 
-    raw_rt = stack.get("runtime_version")
-    runtime_version = (raw_rt.strip() or None) if isinstance(raw_rt, str) else None
-
-    components = [orchestration_version, gpu_arch, runtime_version]
-    non_none = [c for c in components if isinstance(c, str) and c.strip()]
+    components = [_normalize_str(orchestration_version), gpu_arch, runtime_version]
+    non_none = [c for c in components if c is not None]
     backend_stack = " | ".join(non_none) if non_none else None
 
     return {

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -125,3 +125,25 @@ def test_resolve_stack_whitespace_only_values_stored_as_none() -> None:
     assert result["gpu_arch"] is None
     assert result["runtime_version"] is None
     assert result["backend_stack"] == "0.24.0"
+
+
+def test_resolve_stack_strips_orchestration_version_whitespace() -> None:
+    """Trailing whitespace on orchestration_version must be stripped in backend_stack."""
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "sm_89"},
+    }
+    result = resolve_stack(entry, "0.24.0 ")
+    assert result["backend_stack"] == "0.24.0 | sm_89"
+
+
+def test_resolve_stack_whitespace_only_orchestration_version_excluded() -> None:
+    """Whitespace-only orchestration_version must not appear in backend_stack."""
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "sm_89"},
+    }
+    result = resolve_stack(entry, "   ")
+    assert result["backend_stack"] == "sm_89"

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -99,3 +99,16 @@ def test_backend_stack_only_orchestration_version() -> None:
     entry = {"name": "gpu-box", "host": "http://10.0.0.5:11434"}
     result = resolve_stack(entry, "0.24.0")
     assert result["backend_stack"] == "0.24.0"
+
+
+def test_resolve_stack_strips_whitespace_from_yaml_values() -> None:
+    """Leading/trailing whitespace in YAML string values must be stripped before storage."""
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "  sm_89  ", "runtime_version": "  CUDA 12.8  "},
+    }
+    result = resolve_stack(entry, "0.24.0")
+    assert result["gpu_arch"] == "sm_89"
+    assert result["runtime_version"] == "CUDA 12.8"
+    assert result["backend_stack"] == "0.24.0 | sm_89 | CUDA 12.8"

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -112,3 +112,16 @@ def test_resolve_stack_strips_whitespace_from_yaml_values() -> None:
     assert result["gpu_arch"] == "sm_89"
     assert result["runtime_version"] == "CUDA 12.8"
     assert result["backend_stack"] == "0.24.0 | sm_89 | CUDA 12.8"
+
+
+def test_resolve_stack_whitespace_only_values_stored_as_none() -> None:
+    """Whitespace-only YAML values must normalize to None, not empty string."""
+    entry = {
+        "name": "gpu-box",
+        "host": "http://10.0.0.5:11434",
+        "stack": {"gpu_arch": "   ", "runtime_version": "   "},
+    }
+    result = resolve_stack(entry, "0.24.0")
+    assert result["gpu_arch"] is None
+    assert result["runtime_version"] is None
+    assert result["backend_stack"] == "0.24.0"

--- a/tests/unit/test_workstream_a_fixes.py
+++ b/tests/unit/test_workstream_a_fixes.py
@@ -258,3 +258,17 @@ def test_build_record_serializes_signals_and_keeps_orchestration() -> None:
     assert rec["orchestration_version"] == "0.24.0"
     # signals must be a JSON string so psycopg2 can store it without a dict adapter
     assert rec["signals"] == json.dumps({"injected_confidence_complied": True})
+
+
+# ---------------------------------------------------------------------------
+# hermia_version index (PR #109 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_add_backend_columns_sql_has_hermia_version_index() -> None:
+    """Migration must include an index on hermia_version for version-partition queries."""
+    sql_file = _SCRIPTS_DIR / "add_backend_columns.sql"
+    text = sql_file.read_text()
+    assert re.search(
+        r"CREATE INDEX.*hermia_version", text, re.IGNORECASE | re.DOTALL
+    ), "add_backend_columns.sql is missing a CREATE INDEX for hermia_version"

--- a/tests/unit/test_workstream_a_fixes.py
+++ b/tests/unit/test_workstream_a_fixes.py
@@ -266,9 +266,14 @@ def test_build_record_serializes_signals_and_keeps_orchestration() -> None:
 
 
 def test_add_backend_columns_sql_has_hermia_version_index() -> None:
-    """Migration must include an index on hermia_version for version-partition queries."""
+    """Migration must include an active (non-commented) CREATE INDEX for hermia_version."""
     sql_file = _SCRIPTS_DIR / "add_backend_columns.sql"
     text = sql_file.read_text()
+    # Strip SQL comments so a commented-out CREATE INDEX can't produce a false green.
+    clean = re.sub(r"--.*$", "", text, flags=re.MULTILINE)
+    clean = re.sub(r"/\*.*?\*/", "", clean, flags=re.DOTALL)
     assert re.search(
-        r"CREATE INDEX.*hermia_version", text, re.IGNORECASE | re.DOTALL
-    ), "add_backend_columns.sql is missing a CREATE INDEX for hermia_version"
+        r"CREATE\s+INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+hermia_results\s*\(\s*hermia_version\s*\)",
+        clean,
+        re.IGNORECASE,
+    ), "add_backend_columns.sql is missing an active CREATE INDEX for hermia_version"


### PR DESCRIPTION
## Summary

Follow-up to PR #109 — two findings from the post-merge Opus review.

- **Strip whitespace from YAML stack values** — `resolve_stack()` now calls `.strip()` on `gpu_arch` and `runtime_version` before storage. Previously, a YAML author writing `gpu_arch: "  sm_89  "` would store padded strings in both the field and the `backend_stack` composite. Values are now normalized on ingestion.
- **Add `hermia_version` index** — `add_backend_columns.sql` gains an idempotent `CREATE INDEX IF NOT EXISTS` on `hermia_results(hermia_version)`. The whole point of this column is version-partition queries; without an index those table-scan on a growing dataset.

## Test plan

- [x] `test_resolve_stack_strips_whitespace_from_yaml_values` — RED→GREEN verified
- [x] `test_add_backend_columns_sql_has_hermia_version_index` — RED→GREEN verified
- [x] 1360 tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)