### PR TITLE
feat(submit): add hermia-submit CLI for community dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ hermia = "hermia.app:main"
 hermia-regression = "hermia.regression:main"
 hermia-push = "hermia.export:main"
 hermia-analyze = "hermia.analyze:main"
+hermia-submit = "hermia.submit:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hermia"]

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -37,11 +38,15 @@ RESULTS_DIR = Path("results")
 CORPUS_VERSION = "v0.2"
 SUBMIT_URL = "https://hermia.scottbly.com/v1/submit"
 
-_INSTALL_ID_RE = re.compile(r'install_id\s*=\s*"([^"]+)"')
-
 # Value-level anonymization patterns (mirror lambda/anonymization.py)
 _URL_PATTERN = re.compile(r"https?://|://")
 _PATH_PREFIXES = ("/Users/", "/home/", "C:\\")
+# Redact the user-home dir INCLUDING the username segment. Redacting the prefix
+# alone leaves the username exposed (e.g. "scott" in "/Users/scott/...") — a
+# privacy leak in a community dataset.
+_PATH_USER_PATTERN = re.compile(
+    r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)([^/\\\s]+)", re.IGNORECASE
+)
 _TILDE_PATTERN = re.compile(r"(?:^|(?<=\s))~/")
 _HOSTNAME_PATTERN = re.compile(
     r"\b\w[\w.-]*\.(?:local|internal|lan|home|localdomain)\b",
@@ -57,10 +62,14 @@ _HOSTNAME_PATTERN = re.compile(
 def load_or_create_install_id(config_path: Path | None = None) -> str:
     """Load install_id from config or create and persist a new one.
 
-    The config file is plain TOML written by hand (no tomllib/tomli_w dep):
+    The config file is TOML:
 
         [hermia]
         install_id = "<uuid4>"
+
+    Parsed with the stdlib ``tomllib`` (Python 3.11+) so a hand-edited file
+    with comments or reordered keys is read correctly. A malformed file is
+    treated as absent and regenerated.
 
     Parameters
     ----------
@@ -71,12 +80,15 @@ def load_or_create_install_id(config_path: Path | None = None) -> str:
         config_path = CONFIG_PATH
 
     try:
-        content = config_path.read_text(encoding="utf-8")
-        match = _INSTALL_ID_RE.search(content)
-        if match:
-            return match.group(1)
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        existing = data.get("hermia", {}).get("install_id")
+        if isinstance(existing, str) and existing:
+            return existing
     except FileNotFoundError:
         pass
+    except tomllib.TOMLDecodeError:
+        pass  # malformed/hand-broken config — fall through and regenerate
 
     install_id = str(uuid4())
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -92,7 +104,7 @@ _NVIDIA_MATCHERS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"RTX\s+5090"), "local:cuda/rtx-5090"),
     (re.compile(r"RTX\s+4090"), "local:cuda/rtx-4090"),
     (re.compile(r"RTX\s+3090"), "local:cuda/rtx-3090"),
-    (re.compile(r"RTX\s+30[678][05]"), "local:cuda/rtx-30xx"),
+    (re.compile(r"RTX\s+30[5678]0"), "local:cuda/rtx-30xx"),
     (re.compile(r"RTX\s+A\d"), "local:cuda/rtx-a-series"),
     (re.compile(r"GTX\s+(?:9|10)\d\d"), "local:cuda/gtx-legacy"),
 ]
@@ -161,10 +173,16 @@ def compute_unified_memory_gb(gpu_info: dict[str, Any]) -> float | None:
     vram: float = gpu_info.get("vram_total_gb", 0.0)
 
     try:
-        if vendor in ("apple", "nvidia", "amd"):
-            if vram > 0.0:
-                return float(vram)
-            # Fall through to psutil if vram is unknown
+        if vendor in ("nvidia", "amd"):
+            # Discrete GPUs do NOT share system RAM. If VRAM detection failed
+            # (vram == 0.0), report None rather than a misleading system-RAM
+            # figure — let the server decide how to handle the missing value.
+            return float(vram) if vram > 0.0 else None
+        if vendor == "apple" and vram > 0.0:
+            # Apple Silicon: unified memory == measured VRAM when available.
+            return float(vram)
+        # Apple w/o measured VRAM, Intel iGPU, and CPU-only systems: total
+        # system RAM is the meaningful figure.
         return float(psutil.virtual_memory().total) / (1024 ** 3)
     except Exception:  # noqa: BLE001
         return None
@@ -195,6 +213,9 @@ def _redact_string(value: str, field_path: str = "") -> str:
     if not is_attribution_url and _URL_PATTERN.search(value):
         value = _URL_PATTERN.sub("[REDACTED]", value)
 
+    # Redact home dir + username first (prefix-only redaction would leak the
+    # username), then collapse any remaining bare prefixes (e.g. non-user C:\ paths).
+    value = _PATH_USER_PATTERN.sub("[REDACTED]", value)
     if any(prefix in value for prefix in _PATH_PREFIXES):
         for prefix in _PATH_PREFIXES:
             value = value.replace(prefix, "[REDACTED]")

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -39,17 +39,20 @@ CORPUS_VERSION = "v0.2"
 SUBMIT_URL = "https://hermia.scottbly.com/v1/submit"
 
 # Value-level anonymization patterns (mirror lambda/anonymization.py)
-_URL_PATTERN = re.compile(r"https?://|://")
-_PATH_PREFIXES = ("/Users/", "/home/", "C:\\")
+# Redact the FULL URL, not just the scheme. Matching only "https://" left the
+# host/path/query exposed (e.g. "example.com/secret" after redacting the prefix).
+_URL_PATTERN = re.compile(r"\w*://\S+")
 # Redact the user-home dir INCLUDING the username segment. Redacting the prefix
 # alone leaves the username exposed (e.g. "scott" in "/Users/scott/...") — a
-# privacy leak in a community dataset.
-# Match the whole user-dir segment up to the next path separator (NOT stopping
-# at whitespace) so usernames with spaces (e.g. "C:\Users\Scott Bly") are fully
-# redacted. Bias is intentionally toward over-redaction for a privacy tool.
+# privacy leak in a community dataset. Match the whole user-dir segment up to the
+# next path separator (NOT stopping at whitespace) so usernames with spaces
+# (e.g. "C:\Users\Scott Bly") are fully redacted. Bias toward over-redaction.
 _PATH_USER_PATTERN = re.compile(
     r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)([^/\\]+)", re.IGNORECASE
 )
+# Bare home/drive prefixes — case-insensitive so "/users/" and "c:\" are caught
+# too. Applied after _PATH_USER_PATTERN (which removes the username segment).
+_BARE_PREFIX_PATTERN = re.compile(r"(?:/Users/|/home/|[A-Za-z]:\\)", re.IGNORECASE)
 _TILDE_PATTERN = re.compile(r"(?:^|(?<=\s))~/")
 _HOSTNAME_PATTERN = re.compile(
     r"\b\w[\w.-]*\.(?:local|internal|lan|home|localdomain)\b",
@@ -85,7 +88,10 @@ def load_or_create_install_id(config_path: Path | None = None) -> str:
     try:
         with config_path.open("rb") as f:
             data = tomllib.load(f)
-        existing = data.get("hermia", {}).get("install_id")
+        # `[hermia]` may be absent or (in a hand-broken file) not a table —
+        # guard isinstance before .get() so a non-dict section can't crash.
+        section = data.get("hermia")
+        existing = section.get("install_id") if isinstance(section, dict) else None
         if isinstance(existing, str) and existing:
             return existing
     except FileNotFoundError:
@@ -227,9 +233,7 @@ def _redact_string(value: str, field_path: str = "") -> str:
     # Redact home dir + username first (prefix-only redaction would leak the
     # username), then collapse any remaining bare prefixes (e.g. non-user C:\ paths).
     value = _PATH_USER_PATTERN.sub("[REDACTED]", value)
-    if any(prefix in value for prefix in _PATH_PREFIXES):
-        for prefix in _PATH_PREFIXES:
-            value = value.replace(prefix, "[REDACTED]")
+    value = _BARE_PREFIX_PATTERN.sub("[REDACTED]", value)
 
     value = _TILDE_PATTERN.sub("[REDACTED]", value)
 
@@ -367,7 +371,7 @@ def submit_command(
             answer = input()
         except EOFError:
             answer = ""
-        if answer.strip() != "y":
+        if answer.strip().lower() != "y":
             print("Aborted.")
             sys.exit(0)
 

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -1,0 +1,420 @@
+"""hermia submit — anonymize and POST results to the community dataset.
+
+Opt-in: nothing is sent unless the user explicitly runs ``hermia-submit``.
+A confirmation prompt is shown before every live submission unless ``--yes``
+is passed.  ``--dry-run`` prints the payload to stdout without any network I/O.
+
+Auth: v0.2 uses no client auth (Pattern A).  The endpoint is open; defense is
+handled server-side via Reserved Concurrency, per-IP throttle, kill switch, and
+budget alarms.  The ``install_id`` field is a stable per-install UUID stored at
+``~/.hermia/config.toml`` so the server can associate submissions without any PII.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import psutil
+import requests
+
+from hermia import __version__
+from hermia.metrics import detect_gpu
+from hermia.results import load_jsonl
+from hermia.sink.anonymize import anonymize_row
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CONFIG_DIR = Path.home() / ".hermia"
+CONFIG_PATH = CONFIG_DIR / "config.toml"
+RESULTS_DIR = Path("results")
+CORPUS_VERSION = "v0.2"
+SUBMIT_URL = "https://hermia.scottbly.com/v1/submit"
+
+_INSTALL_ID_RE = re.compile(r'install_id\s*=\s*"([^"]+)"')
+
+# Value-level anonymization patterns (mirror lambda/anonymization.py)
+_URL_PATTERN = re.compile(r"https?://|://")
+_PATH_PREFIXES = ("/Users/", "/home/", "C:\\")
+_TILDE_PATTERN = re.compile(r"(?:^|(?<=\s))~/")
+_HOSTNAME_PATTERN = re.compile(
+    r"\b\w[\w.-]*\.(?:local|internal|lan|home|localdomain)\b",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# install_id management
+# ---------------------------------------------------------------------------
+
+
+def load_or_create_install_id(config_path: Path | None = None) -> str:
+    """Load install_id from config or create and persist a new one.
+
+    The config file is plain TOML written by hand (no tomllib/tomli_w dep):
+
+        [hermia]
+        install_id = "<uuid4>"
+
+    Parameters
+    ----------
+    config_path:
+        Override path for testing.  Defaults to ``~/.hermia/config.toml``.
+    """
+    if config_path is None:
+        config_path = CONFIG_PATH
+
+    try:
+        content = config_path.read_text(encoding="utf-8")
+        match = _INSTALL_ID_RE.search(content)
+        if match:
+            return match.group(1)
+    except FileNotFoundError:
+        pass
+
+    install_id = str(uuid4())
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(f'[hermia]\ninstall_id = "{install_id}"\n', encoding="utf-8")
+    return install_id
+
+
+# ---------------------------------------------------------------------------
+# host_class mapping
+# ---------------------------------------------------------------------------
+
+_NVIDIA_MATCHERS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"RTX\s+5090"), "local:cuda/rtx-5090"),
+    (re.compile(r"RTX\s+4090"), "local:cuda/rtx-4090"),
+    (re.compile(r"RTX\s+3090"), "local:cuda/rtx-3090"),
+    (re.compile(r"RTX\s+30[678][05]"), "local:cuda/rtx-30xx"),
+    (re.compile(r"RTX\s+A\d"), "local:cuda/rtx-a-series"),
+    (re.compile(r"GTX\s+(?:9|10)\d\d"), "local:cuda/gtx-legacy"),
+]
+
+_APPLE_MATCHERS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bM1\b"), "local:metal/m1"),
+    (re.compile(r"\bM2\b"), "local:metal/m2"),
+    (re.compile(r"\bM3\b"), "local:metal/m3"),
+    (re.compile(r"\bM4\b"), "local:metal/m4"),
+]
+
+
+def compute_host_class(gpu_info: dict[str, Any]) -> str:
+    """Map detect_gpu() result to the 17-value host_class vocabulary.
+
+    Falls back to ``local:other`` whenever no rule matches — the server
+    accepts this value and surfaces it for manual taxonomy expansion.
+    """
+    vendor: str = gpu_info.get("vendor", "none")
+    card: str = gpu_info.get("card", "")
+
+    if vendor == "nvidia":
+        for pattern, cls in _NVIDIA_MATCHERS:
+            if pattern.search(card):
+                return cls
+        return "local:other"
+
+    if vendor == "apple":
+        for pattern, cls in _APPLE_MATCHERS:
+            if pattern.search(card):
+                return cls
+        return "local:other"
+
+    if vendor == "amd":
+        card_upper = card.upper()
+        if any(x in card_upper for x in ("7900", "7800", "7700")):
+            return "local:rocm/rdna3"
+        if any(x in card_upper for x in ("6900", "6800", "6700", "6600", "6500", "6400")):
+            return "local:rocm/rdna2"
+        if card_upper.startswith("MI"):
+            return "local:rocm/instinct"
+        return "local:vulkan/amd"
+
+    if vendor == "intel":
+        return "local:vulkan/intel-igpu"
+
+    if vendor == "none":
+        return "local:cpu"
+
+    return "local:other"
+
+
+# ---------------------------------------------------------------------------
+# unified_memory_gb
+# ---------------------------------------------------------------------------
+
+
+def compute_unified_memory_gb(gpu_info: dict[str, Any]) -> float | None:
+    """Return unified memory (Apple) or discrete VRAM in GB, or None on failure.
+
+    For Intel iGPU and CPU-only systems, falls back to total system RAM via
+    psutil.  Returns None if all attempts fail so the server can decide whether
+    to reject the submission.
+    """
+    vendor: str = gpu_info.get("vendor", "none")
+    vram: float = gpu_info.get("vram_total_gb", 0.0)
+
+    try:
+        if vendor in ("apple", "nvidia", "amd"):
+            if vram > 0.0:
+                return float(vram)
+            # Fall through to psutil if vram is unknown
+        return float(psutil.virtual_memory().total) / (1024 ** 3)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Client-side anonymization (mirrors lambda/anonymization.py rule set)
+# ---------------------------------------------------------------------------
+
+
+def _redact_string(value: str, field_path: str = "") -> str:
+    """Replace forbidden URL/path/hostname patterns with ``[REDACTED]``.
+
+    Parameters
+    ----------
+    value:
+        The string to sanitize.
+    field_path:
+        Dot-separated path used for exemption checks:
+        - ``'extras_json'`` or paths ending in ``'.extras_json'``: fully exempt.
+        - ``'attribution.url'``: URL patterns are exempt (URLs are valid there).
+    """
+    if field_path == "extras_json" or field_path.endswith(".extras_json"):
+        return value
+
+    is_attribution_url = field_path == "attribution.url"
+
+    if not is_attribution_url and _URL_PATTERN.search(value):
+        value = _URL_PATTERN.sub("[REDACTED]", value)
+
+    if any(prefix in value for prefix in _PATH_PREFIXES):
+        for prefix in _PATH_PREFIXES:
+            value = value.replace(prefix, "[REDACTED]")
+
+    value = _TILDE_PATTERN.sub("[REDACTED]", value)
+
+    if _HOSTNAME_PATTERN.search(value):
+        value = _HOSTNAME_PATTERN.sub("[REDACTED]", value)
+
+    return value
+
+
+def _redact_node(node: Any, path: str) -> Any:
+    """Recursively redact a value at the given dot-path."""
+    if isinstance(node, str):
+        return _redact_string(node, path)
+    if isinstance(node, dict):
+        return {
+            k: _redact_node(v, f"{path}.{k}" if path else k)
+            for k, v in node.items()
+        }
+    if isinstance(node, list):
+        return [_redact_node(item, f"{path}[{i}]") for i, item in enumerate(node)]
+    return node
+
+
+def anonymize_for_submit(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Apply anonymize_row (whitelist + key-stripping) then redact value patterns.
+
+    Two passes:
+    1. ``anonymize_row`` enforces the default-deny whitelist and strips forbidden
+       keys (host, fleet_host_name, output_preview, raw_response).
+    2. ``_redact_node`` replaces URL/path/hostname patterns in any remaining strings.
+    """
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        clean = anonymize_row(row)
+        result.append({k: _redact_node(v, k) for k, v in clean.items()})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+
+def build_payload(
+    install_id: str,
+    host_class: str,
+    unified_memory_gb: float | None,
+    rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Assemble the v0.2 submission JSON envelope.
+
+    The shape is forward-compatible with v0.3 (Pattern B token auth is purely
+    additive — ``install_id`` is never renamed, the envelope is never restructured).
+    """
+    return {
+        "install_id": install_id,
+        "hermia_version": __version__,
+        "corpus_version": CORPUS_VERSION,
+        "host_class": host_class,
+        "unified_memory_gb": unified_memory_gb,
+        "attribution": None,
+        "rows": rows,
+        "extras_json": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main submit logic
+# ---------------------------------------------------------------------------
+
+
+def _find_latest_results() -> Path | None:
+    """Return the most recently modified JSONL file in RESULTS_DIR, or None."""
+    candidates = list(RESULTS_DIR.glob("*.jsonl"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def submit_command(
+    results_path: Path | None,
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """Main entry point for ``hermia-submit``.
+
+    Loads results, anonymizes them, assembles the payload, and either prints it
+    (dry-run) or POSTs to the submission endpoint with a confirmation prompt.
+    Calls ``sys.exit(1)`` on any unrecoverable error.
+    """
+    # Resolve results path
+    if results_path is None:
+        results_path = _find_latest_results()
+        if results_path is None:
+            print("hermia submit: no results found in results/ directory", file=sys.stderr)
+            sys.exit(1)
+
+    # Load rows
+    try:
+        rows = load_jsonl(results_path)
+    except OSError as exc:
+        print(f"hermia submit: cannot read results: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not rows:
+        print(f"hermia submit: no rows in {results_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Detect hardware
+    gpu_info = detect_gpu()
+    host_class = compute_host_class(gpu_info)
+    unified_memory_gb = compute_unified_memory_gb(gpu_info)
+
+    # Anonymize
+    anonymized_rows = anonymize_for_submit(rows)
+
+    # Resolve install_id
+    install_id = load_or_create_install_id()
+
+    # Build payload
+    payload = build_payload(install_id, host_class, unified_memory_gb, anonymized_rows)
+
+    if dry_run:
+        print(json.dumps(payload, indent=2))
+        return
+
+    # Confirmation prompt
+    if not yes:
+        print(
+            f"About to submit {len(rows)} test results "
+            f"(host_class={host_class}, {len(anonymized_rows)} rows)"
+        )
+        print("Type 'y' to proceed: ", end="", flush=True)
+        try:
+            answer = input()
+        except EOFError:
+            answer = ""
+        if answer.strip() != "y":
+            print("Aborted.")
+            sys.exit(0)
+
+    # POST
+    try:
+        resp = requests.post(SUBMIT_URL, json=payload, timeout=30)
+    except requests.exceptions.RequestException as exc:
+        print(f"hermia submit: network error: {type(exc).__name__}", file=sys.stderr)
+        sys.exit(1)
+
+    if resp.status_code == 503:
+        print(
+            "hermia submit: submissions are temporarily disabled — try again later.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if resp.status_code == 429:
+        print("hermia submit: rate limited — wait a few minutes.", file=sys.stderr)
+        sys.exit(1)
+
+    if resp.status_code >= 400:
+        body_snippet = resp.text[:200]
+        print(
+            f"hermia submit: server rejected submission: {body_snippet}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if resp.status_code == 201:
+        try:
+            data = resp.json()
+            public_url = data.get("public_url", "(no URL returned)")
+        except (ValueError, KeyError):
+            public_url = "(could not parse response)"
+        print(f"Submitted. Public URL: {public_url}")
+    else:
+        print(
+            f"hermia submit: unexpected response status {resp.status_code}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Parse CLI arguments and call submit_command."""
+    parser = argparse.ArgumentParser(
+        prog="hermia-submit",
+        description="Anonymize and submit hermia results to the community dataset.",
+    )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        metavar="FILE",
+        default=None,
+        help="Path to a JSONL results file (default: most recent in results/)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the anonymized payload without sending it",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt",
+    )
+    args = parser.parse_args()
+    submit_command(
+        results_path=args.results,
+        dry_run=args.dry_run,
+        yes=args.yes,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -44,8 +44,11 @@ _PATH_PREFIXES = ("/Users/", "/home/", "C:\\")
 # Redact the user-home dir INCLUDING the username segment. Redacting the prefix
 # alone leaves the username exposed (e.g. "scott" in "/Users/scott/...") — a
 # privacy leak in a community dataset.
+# Match the whole user-dir segment up to the next path separator (NOT stopping
+# at whitespace) so usernames with spaces (e.g. "C:\Users\Scott Bly") are fully
+# redacted. Bias is intentionally toward over-redaction for a privacy tool.
 _PATH_USER_PATTERN = re.compile(
-    r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)([^/\\\s]+)", re.IGNORECASE
+    r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)([^/\\]+)", re.IGNORECASE
 )
 _TILDE_PATTERN = re.compile(r"(?:^|(?<=\s))~/")
 _HOSTNAME_PATTERN = re.compile(
@@ -91,8 +94,16 @@ def load_or_create_install_id(config_path: Path | None = None) -> str:
         pass  # malformed/hand-broken config — fall through and regenerate
 
     install_id = str(uuid4())
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(f'[hermia]\ninstall_id = "{install_id}"\n', encoding="utf-8")
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            f'[hermia]\ninstall_id = "{install_id}"\n', encoding="utf-8"
+        )
+    except OSError:
+        # Read-only / permission-restricted home (e.g. locked-down container):
+        # use the id for this run without persisting. It won't be stable across
+        # runs, but the CLI still works instead of crashing.
+        pass
     return install_id
 
 
@@ -389,9 +400,14 @@ def submit_command(
     if resp.status_code == 201:
         try:
             data = resp.json()
-            public_url = data.get("public_url", "(no URL returned)")
-        except (ValueError, KeyError):
-            public_url = "(could not parse response)"
+        except ValueError:
+            data = None
+        # A valid-but-non-dict JSON body (list/string/bool) must not crash on .get().
+        public_url = (
+            data.get("public_url", "(no URL returned)")
+            if isinstance(data, dict)
+            else "(could not parse response)"
+        )
         print(f"Submitted. Public URL: {public_url}")
     else:
         print(

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -85,6 +85,15 @@ def test_load_or_create_install_id_read_only_does_not_crash(
     assert not config_path.exists()  # but nothing was persisted
 
 
+def test_load_or_create_install_id_non_dict_section_regenerates(tmp_path: Path) -> None:
+    """A valid TOML where [hermia] isn't a table must not crash — it regenerates."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('hermia = "not-a-table"\n', encoding="utf-8")
+    install_id = load_or_create_install_id(config_path)
+    assert install_id
+    assert load_or_create_install_id(config_path) == install_id
+
+
 def test_load_or_create_install_id_creates_parent_dir(tmp_path: Path) -> None:
     """Parent directory is created if it does not exist."""
     config_path = tmp_path / "subdir" / "config.toml"
@@ -258,6 +267,25 @@ def test_redact_string_url_replaced() -> None:
     result = _redact_string("connect to https://server.example/api")
     assert "https://" not in result
     assert "[REDACTED]" in result
+    # The host/path must be redacted too, not just the scheme.
+    assert "server.example" not in result
+    assert "/api" not in result
+
+
+def test_redact_string_public_domain_url_fully_redacted() -> None:
+    """A non-.local URL must be fully redacted (host wouldn't be caught by the
+    hostname rule)."""
+    result = _redact_string("see https://example.com/secret?token=abc")
+    assert "example.com" not in result
+    assert "secret" not in result
+
+
+def test_redact_string_bare_prefix_case_insensitive() -> None:
+    """Lowercase home/drive prefixes must still be redacted."""
+    for path in ("/users/data", "c:\\temp\\x"):
+        result = _redact_string(path)
+        assert "[REDACTED]" in result, path
+        assert result.startswith("[REDACTED]"), path
 
 
 def test_redact_string_file_path_users() -> None:
@@ -493,6 +521,25 @@ def test_submit_command_success_201(
     captured = capsys.readouterr()
     assert "Submitted. Public URL:" in captured.out
     assert "hermia.scottbly.com" in captured.out
+
+
+def test_submit_command_confirm_prompt_accepts_uppercase_y(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Typing 'Y' at the confirmation prompt must proceed (case-insensitive)."""
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 201
+    mock_resp.json.return_value = {"public_url": "https://hermia.scottbly.com/v1/r/x"}
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-ok"),
+        patch("requests.post", return_value=mock_resp),
+        patch("builtins.input", return_value="Y"),
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=False)
+    assert "Submitted." in capsys.readouterr().out
 
 
 def test_submit_command_non_dict_json_response_does_not_crash(

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -69,6 +69,22 @@ def test_load_or_create_install_id_regenerates_on_malformed(tmp_path: Path) -> N
     assert load_or_create_install_id(config_path) == install_id
 
 
+def test_load_or_create_install_id_read_only_does_not_crash(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A read-only/permission-restricted home must not crash the CLI — the id is
+    returned for this run even though it can't be persisted."""
+
+    def _boom(*args, **kwargs):
+        raise PermissionError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+    config_path = tmp_path / "config.toml"
+    install_id = load_or_create_install_id(config_path)
+    assert install_id  # a usable id was still produced
+    assert not config_path.exists()  # but nothing was persisted
+
+
 def test_load_or_create_install_id_creates_parent_dir(tmp_path: Path) -> None:
     """Parent directory is created if it does not exist."""
     config_path = tmp_path / "subdir" / "config.toml"
@@ -258,6 +274,16 @@ def test_redact_string_redacts_username_across_platforms() -> None:
     for path in ("/Users/scott/x", "/home/scott/x", "C:\\Users\\scott\\x"):
         result = _redact_string(path)
         assert "scott" not in result, path
+        assert "[REDACTED]" in result
+
+
+def test_redact_string_redacts_username_with_spaces() -> None:
+    """A username containing spaces must be fully redacted, not truncated at the
+    first space."""
+    for path in ("/Users/Scott Bly/x", "C:\\Users\\Scott Bly\\x"):
+        result = _redact_string(path)
+        assert "Scott" not in result, path
+        assert "Bly" not in result, path
         assert "[REDACTED]" in result
 
 
@@ -467,6 +493,27 @@ def test_submit_command_success_201(
     captured = capsys.readouterr()
     assert "Submitted. Public URL:" in captured.out
     assert "hermia.scottbly.com" in captured.out
+
+
+def test_submit_command_non_dict_json_response_does_not_crash(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A valid-but-non-dict 201 JSON body (e.g. a list) must not raise on .get()."""
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 201
+    mock_resp.json.return_value = ["unexpected", "list"]
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-ok"),
+        patch("requests.post", return_value=mock_resp),
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    captured = capsys.readouterr()
+    assert "Submitted." in captured.out
+    assert "could not parse response" in captured.out
 
 
 def test_submit_command_503_exits_1(

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -49,6 +49,26 @@ def test_load_or_create_install_id_stable(tmp_path: Path) -> None:
     assert len(set(ids)) == 1
 
 
+def test_load_or_create_install_id_parses_handedited_toml(tmp_path: Path) -> None:
+    """tomllib reads a hand-edited config with comments and extra keys."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '# hermia config\n[hermia]\nother = 1\ninstall_id = "abc-123"\n',
+        encoding="utf-8",
+    )
+    assert load_or_create_install_id(config_path) == "abc-123"
+
+
+def test_load_or_create_install_id_regenerates_on_malformed(tmp_path: Path) -> None:
+    """A malformed config is treated as absent and regenerated (not crashed on)."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("this is not valid toml ===", encoding="utf-8")
+    install_id = load_or_create_install_id(config_path)
+    assert install_id
+    # The regenerated file is now valid TOML and reads back stably.
+    assert load_or_create_install_id(config_path) == install_id
+
+
 def test_load_or_create_install_id_creates_parent_dir(tmp_path: Path) -> None:
     """Parent directory is created if it does not exist."""
     config_path = tmp_path / "subdir" / "config.toml"
@@ -79,8 +99,20 @@ def test_compute_host_class_nvidia_rtx3090() -> None:
 
 
 def test_compute_host_class_nvidia_rtx30xx() -> None:
-    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 3080"}
-    assert compute_host_class(gpu) == "local:cuda/rtx-30xx"
+    # 3050/3060/3070/3080 and Ti variants all map to rtx-30xx (3090 is separate).
+    for card in (
+        "NVIDIA GeForce RTX 3050",
+        "NVIDIA GeForce RTX 3060 Ti",
+        "NVIDIA GeForce RTX 3070",
+        "NVIDIA GeForce RTX 3080 Ti",
+    ):
+        gpu = {"vendor": "nvidia", "card": card}
+        assert compute_host_class(gpu) == "local:cuda/rtx-30xx", card
+
+
+def test_compute_host_class_nvidia_rtx3090_is_distinct() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 3090"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-3090"
 
 
 def test_compute_host_class_nvidia_rtx_a_series() -> None:
@@ -171,8 +203,18 @@ def test_compute_unified_memory_gb_apple() -> None:
     assert result == pytest.approx(36.0)
 
 
-def test_compute_unified_memory_gb_zero_vram_falls_back_to_psutil() -> None:
-    gpu = {"vendor": "nvidia", "card": "RTX 3090", "vram_total_gb": 0.0}
+def test_compute_unified_memory_gb_discrete_zero_vram_returns_none() -> None:
+    # Discrete GPUs don't share system RAM — vram=0 must yield None, not a
+    # misleading system-RAM figure. (No psutil patch: psutil must NOT be called.)
+    for vendor in ("nvidia", "amd"):
+        gpu = {"vendor": vendor, "card": "RTX 3090", "vram_total_gb": 0.0}
+        assert compute_unified_memory_gb(gpu) is None, vendor
+
+
+def test_compute_unified_memory_gb_apple_zero_vram_uses_psutil() -> None:
+    # Apple Silicon unified memory == system RAM, so a 0.0 vram reading still
+    # falls back to total RAM.
+    gpu = {"vendor": "apple", "card": "M3", "vram_total_gb": 0.0}
     with patch("hermia.submit.psutil") as mock_psutil:
         mock_vm = MagicMock()
         mock_vm.total = 32 * (1024 ** 3)  # 32 GiB
@@ -206,6 +248,23 @@ def test_redact_string_file_path_users() -> None:
     result = _redact_string("path is /Users/scott/data")
     assert "/Users/" not in result
     assert "[REDACTED]" in result
+    # The username segment must also be redacted, not just the prefix (privacy leak).
+    assert "scott" not in result
+
+
+def test_redact_string_redacts_username_across_platforms() -> None:
+    """Username in the home-dir segment must be redacted on macOS, Linux, and
+    Windows — redacting only the prefix would ship the username."""
+    for path in ("/Users/scott/x", "/home/scott/x", "C:\\Users\\scott\\x"):
+        result = _redact_string(path)
+        assert "scott" not in result, path
+        assert "[REDACTED]" in result
+
+
+def test_redact_string_non_user_windows_path_still_redacted() -> None:
+    """A non-user C:\\ path keeps its prefix redacted (no regression)."""
+    result = _redact_string("C:\\Windows\\System32")
+    assert result.startswith("[REDACTED]")
 
 
 def test_redact_string_file_path_home() -> None:

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -1,0 +1,543 @@
+"""Tests for hermia.submit — install_id, host_class, anonymization, payload, CLI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from hermia.submit import (
+    _redact_string,
+    anonymize_for_submit,
+    build_payload,
+    compute_host_class,
+    compute_unified_memory_gb,
+    load_or_create_install_id,
+    submit_command,
+)
+
+# ---------------------------------------------------------------------------
+# install_id management
+# ---------------------------------------------------------------------------
+
+
+def test_load_or_create_install_id_creates_new_config(tmp_path: Path) -> None:
+    """When config_path does not exist, creates the file and returns a UUID string."""
+    config_path = tmp_path / "config.toml"
+    install_id = load_or_create_install_id(config_path)
+    assert isinstance(install_id, str)
+    assert len(install_id) == 36  # UUID4 string length
+    assert config_path.exists()
+    content = config_path.read_text()
+    assert f'install_id = "{install_id}"' in content
+
+
+def test_load_or_create_install_id_reuses_existing(tmp_path: Path) -> None:
+    """Calling twice returns the same install_id without rewriting."""
+    config_path = tmp_path / "config.toml"
+    first = load_or_create_install_id(config_path)
+    second = load_or_create_install_id(config_path)
+    assert first == second
+
+
+def test_load_or_create_install_id_stable(tmp_path: Path) -> None:
+    """install_id is idempotent across repeated calls."""
+    config_path = tmp_path / "config.toml"
+    ids = [load_or_create_install_id(config_path) for _ in range(3)]
+    assert len(set(ids)) == 1
+
+
+def test_load_or_create_install_id_creates_parent_dir(tmp_path: Path) -> None:
+    """Parent directory is created if it does not exist."""
+    config_path = tmp_path / "subdir" / "config.toml"
+    assert not (tmp_path / "subdir").exists()
+    install_id = load_or_create_install_id(config_path)
+    assert isinstance(install_id, str)
+    assert config_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# host_class mapping
+# ---------------------------------------------------------------------------
+
+
+def test_compute_host_class_nvidia_rtx5090() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 5090"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-5090"
+
+
+def test_compute_host_class_nvidia_rtx4090() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 4090"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-4090"
+
+
+def test_compute_host_class_nvidia_rtx3090() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 3090"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-3090"
+
+
+def test_compute_host_class_nvidia_rtx30xx() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 3080"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-30xx"
+
+
+def test_compute_host_class_nvidia_rtx_a_series() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA RTX A4000"}
+    assert compute_host_class(gpu) == "local:cuda/rtx-a-series"
+
+
+def test_compute_host_class_nvidia_gtx_legacy() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA GeForce GTX 1080"}
+    assert compute_host_class(gpu) == "local:cuda/gtx-legacy"
+
+
+def test_compute_host_class_nvidia_unrecognized_falls_back() -> None:
+    gpu = {"vendor": "nvidia", "card": "NVIDIA Quadro T1000"}
+    assert compute_host_class(gpu) == "local:other"
+
+
+def test_compute_host_class_apple_m1() -> None:
+    gpu = {"vendor": "apple", "card": "Apple M1 Pro"}
+    assert compute_host_class(gpu) == "local:metal/m1"
+
+
+def test_compute_host_class_apple_m2() -> None:
+    gpu = {"vendor": "apple", "card": "Apple M2 Max"}
+    assert compute_host_class(gpu) == "local:metal/m2"
+
+
+def test_compute_host_class_apple_m3() -> None:
+    gpu = {"vendor": "apple", "card": "Apple M3"}
+    assert compute_host_class(gpu) == "local:metal/m3"
+
+
+def test_compute_host_class_apple_m4() -> None:
+    gpu = {"vendor": "apple", "card": "Apple M4 Pro"}
+    assert compute_host_class(gpu) == "local:metal/m4"
+
+
+def test_compute_host_class_amd_rdna3() -> None:
+    gpu = {"vendor": "amd", "card": "AMD Radeon RX 7800 XT"}
+    assert compute_host_class(gpu) == "local:rocm/rdna3"
+
+
+def test_compute_host_class_amd_rdna2() -> None:
+    gpu = {"vendor": "amd", "card": "AMD Radeon RX 6800 XT"}
+    assert compute_host_class(gpu) == "local:rocm/rdna2"
+
+
+def test_compute_host_class_amd_mi_instinct() -> None:
+    gpu = {"vendor": "amd", "card": "MI250X"}
+    assert compute_host_class(gpu) == "local:rocm/instinct"
+
+
+def test_compute_host_class_amd_vulkan() -> None:
+    # RX 5700 doesn't match any RDNA2/RDNA3 or MI pattern — falls back to vulkan
+    gpu = {"vendor": "amd", "card": "AMD Radeon RX 5700"}
+    assert compute_host_class(gpu) == "local:vulkan/amd"
+
+
+def test_compute_host_class_intel_igpu() -> None:
+    gpu = {"vendor": "intel", "card": "Intel UHD Graphics 630"}
+    assert compute_host_class(gpu) == "local:vulkan/intel-igpu"
+
+
+def test_compute_host_class_cpu_only() -> None:
+    gpu = {"vendor": "none", "card": ""}
+    assert compute_host_class(gpu) == "local:cpu"
+
+
+def test_compute_host_class_unknown_vendor_falls_back() -> None:
+    gpu = {"vendor": "unknown", "card": "Exotic GPU"}
+    assert compute_host_class(gpu) == "local:other"
+
+
+# ---------------------------------------------------------------------------
+# compute_unified_memory_gb
+# ---------------------------------------------------------------------------
+
+
+def test_compute_unified_memory_gb_nvidia() -> None:
+    gpu = {"vendor": "nvidia", "card": "RTX 3090", "vram_total_gb": 24.0}
+    result = compute_unified_memory_gb(gpu)
+    assert result == pytest.approx(24.0)
+
+
+def test_compute_unified_memory_gb_apple() -> None:
+    gpu = {"vendor": "apple", "card": "M3 Pro", "vram_total_gb": 36.0}
+    result = compute_unified_memory_gb(gpu)
+    assert result == pytest.approx(36.0)
+
+
+def test_compute_unified_memory_gb_zero_vram_falls_back_to_psutil() -> None:
+    gpu = {"vendor": "nvidia", "card": "RTX 3090", "vram_total_gb": 0.0}
+    with patch("hermia.submit.psutil") as mock_psutil:
+        mock_vm = MagicMock()
+        mock_vm.total = 32 * (1024 ** 3)  # 32 GiB
+        mock_psutil.virtual_memory.return_value = mock_vm
+        result = compute_unified_memory_gb(gpu)
+    assert result == pytest.approx(32.0)
+
+
+def test_compute_unified_memory_gb_cpu_uses_psutil() -> None:
+    gpu = {"vendor": "none", "card": "", "vram_total_gb": 0.0}
+    with patch("hermia.submit.psutil") as mock_psutil:
+        mock_vm = MagicMock()
+        mock_vm.total = 16 * (1024 ** 3)
+        mock_psutil.virtual_memory.return_value = mock_vm
+        result = compute_unified_memory_gb(gpu)
+    assert result == pytest.approx(16.0)
+
+
+# ---------------------------------------------------------------------------
+# _redact_string — value-level anonymization
+# ---------------------------------------------------------------------------
+
+
+def test_redact_string_url_replaced() -> None:
+    result = _redact_string("connect to https://server.example/api")
+    assert "https://" not in result
+    assert "[REDACTED]" in result
+
+
+def test_redact_string_file_path_users() -> None:
+    result = _redact_string("path is /Users/scott/data")
+    assert "/Users/" not in result
+    assert "[REDACTED]" in result
+
+
+def test_redact_string_file_path_home() -> None:
+    result = _redact_string("path is /home/scott/data")
+    assert "/home/" not in result
+    assert "[REDACTED]" in result
+
+
+def test_redact_string_hostname_local() -> None:
+    result = _redact_string("host is server.local")
+    assert "server.local" not in result
+    assert "[REDACTED]" in result
+
+
+def test_redact_string_attribution_url_exempt() -> None:
+    """attribution.url field is exempt from URL redaction."""
+    value = "https://example.com/profile"
+    result = _redact_string(value, "attribution.url")
+    assert result == value
+
+
+def test_redact_string_extras_json_fully_exempt() -> None:
+    """extras_json is fully exempt from all redaction."""
+    value = "https://secret.internal/path /Users/data server.local"
+    result = _redact_string(value, "extras_json")
+    assert result == value
+
+
+def test_redact_string_normal_text_unchanged() -> None:
+    result = _redact_string("hello world, model passed")
+    assert result == "hello world, model passed"
+
+
+# ---------------------------------------------------------------------------
+# anonymize_for_submit — integration of whitelist + redaction
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_strips_forbidden_keys() -> None:
+    rows: list[dict[str, object]] = [
+        {
+            "host": "http://localhost:11434",
+            "fleet_host_name": "gateway",
+            "output_preview": "some output",
+            "raw_response": "raw text",
+            "model": "qwen2.5:32b",
+            "test_id": "guards_001",
+            "score": 1.0,
+        }
+    ]
+    result = anonymize_for_submit(rows)
+    row = result[0]
+    assert "host" not in row
+    assert "fleet_host_name" not in row
+    assert "output_preview" not in row
+    assert "raw_response" not in row
+    assert row["model"] == "qwen2.5:32b"
+    assert row["test_id"] == "guards_001"
+
+
+def test_anonymize_redacts_url_in_whitelisted_string_field() -> None:
+    """A URL pattern in a string value gets redacted by _redact_string."""
+    # hermia_version is stamped by anonymize_row — we test _redact_string directly
+    # since whitelisted string fields like 'model' wouldn't normally contain URLs.
+    result = _redact_string("check https://internal.server/api")
+    assert "https://" not in result
+    assert "[REDACTED]" in result
+
+
+def test_anonymize_redacts_file_path_in_string() -> None:
+    result = _redact_string("/Users/scott/data")
+    assert "[REDACTED]" in result
+    assert "/Users/" not in result
+
+
+def test_anonymize_redacts_home_path_in_string() -> None:
+    result = _redact_string("/home/scott/data")
+    assert "[REDACTED]" in result
+    assert "/home/" not in result
+
+
+def test_anonymize_redacts_hostname_in_string() -> None:
+    result = _redact_string("connection to server.local failed")
+    assert "server.local" not in result
+    assert "[REDACTED]" in result
+
+
+def test_anonymize_for_submit_produces_list() -> None:
+    rows: list[dict[str, object]] = [{"model": "m", "test_id": "t", "score": 0.0}]
+    result = anonymize_for_submit(rows)
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_payload — envelope structure
+# ---------------------------------------------------------------------------
+
+
+def test_build_payload_structure() -> None:
+    rows: list[dict[str, object]] = [{"model": "test"}]
+    payload = build_payload("uuid-1234", "local:cuda/rtx-4090", 24.0, rows)
+    assert payload["install_id"] == "uuid-1234"
+    assert payload["host_class"] == "local:cuda/rtx-4090"
+    assert payload["unified_memory_gb"] == 24.0
+    assert payload["corpus_version"] == "v0.2"
+    assert payload["attribution"] is None
+    assert payload["extras_json"] is None
+    assert payload["rows"] == rows
+
+
+def test_build_payload_hermia_version_present() -> None:
+    payload = build_payload("uuid-1234", "local:cpu", None, [])
+    assert isinstance(payload["hermia_version"], str)
+    assert len(payload["hermia_version"]) > 0
+
+
+def test_build_payload_none_unified_memory_allowed() -> None:
+    payload = build_payload("uuid-1234", "local:other", None, [])
+    assert payload["unified_memory_gb"] is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for submit_command tests
+# ---------------------------------------------------------------------------
+
+
+def _make_jsonl(tmp_path: Path, rows: list[dict[str, object]] | None = None) -> Path:
+    if rows is None:
+        rows = [{"model": "test-model", "test_id": "guards_001", "score": 1.0}]
+    p = tmp_path / "eval_test.jsonl"
+    with p.open("w") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+    return p
+
+
+_GPU_INFO = {"vendor": "nvidia", "card": "NVIDIA GeForce RTX 4090", "vram_total_gb": 24.0}
+
+
+# ---------------------------------------------------------------------------
+# --dry-run behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_submit_command_dry_run_prints_payload(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """dry_run=True prints the JSON payload to stdout."""
+    jf = _make_jsonl(tmp_path)
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="test-uuid-dry"),
+        patch("requests.post") as mock_post,
+    ):
+        submit_command(results_path=jf, dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    assert "install_id" in captured.out
+    assert "test-uuid-dry" in captured.out
+    mock_post.assert_not_called()
+
+
+def test_submit_command_dry_run_no_network(tmp_path: Path) -> None:
+    """dry_run=True must never call requests.post."""
+    jf = _make_jsonl(tmp_path)
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-dry"),
+        patch("requests.post") as mock_post,
+    ):
+        submit_command(results_path=jf, dry_run=True, yes=True)
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HTTP response handling
+# ---------------------------------------------------------------------------
+
+
+def test_submit_command_success_201(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 201
+    mock_resp.json.return_value = {
+        "submission_id": "sub-xyz",
+        "public_url": "https://hermia.scottbly.com/v1/r/v0.2/sub-xyz",
+    }
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-ok"),
+        patch("requests.post", return_value=mock_resp),
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    captured = capsys.readouterr()
+    assert "Submitted. Public URL:" in captured.out
+    assert "hermia.scottbly.com" in captured.out
+
+
+def test_submit_command_503_exits_1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 503
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-503"),
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(SystemExit) as exc,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    assert exc.value.code == 1
+    assert "temporarily disabled" in capsys.readouterr().err
+
+
+def test_submit_command_429_exits_1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 429
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-429"),
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(SystemExit) as exc,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    assert exc.value.code == 1
+    assert "rate limited" in capsys.readouterr().err
+
+
+def test_submit_command_400_exits_1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.text = "bad field: install_id"
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-400"),
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(SystemExit) as exc,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    assert exc.value.code == 1
+    assert "server rejected submission" in capsys.readouterr().err
+
+
+def test_submit_command_network_error_exits_1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    jf = _make_jsonl(tmp_path)
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-net"),
+        patch(
+            "requests.post",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    assert exc.value.code == 1
+    assert "network error" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt
+# ---------------------------------------------------------------------------
+
+
+def test_submit_command_yes_flag_skips_prompt(tmp_path: Path) -> None:
+    """yes=True must call requests.post without calling input()."""
+    jf = _make_jsonl(tmp_path)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 201
+    mock_resp.json.return_value = {"submission_id": "x", "public_url": "https://example.com"}
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-yes"),
+        patch("requests.post", return_value=mock_resp) as mock_post,
+        patch("builtins.input") as mock_input,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=True)
+
+    mock_post.assert_called_once()
+    mock_input.assert_not_called()
+
+
+def test_submit_command_abort_on_non_y(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Entering 'n' at the confirmation prompt must abort without POSTing."""
+    jf = _make_jsonl(tmp_path)
+    with (
+        patch("hermia.submit.detect_gpu", return_value=_GPU_INFO),
+        patch("hermia.submit.load_or_create_install_id", return_value="uuid-abort"),
+        patch("requests.post") as mock_post,
+        patch("builtins.input", return_value="n"),
+        pytest.raises(SystemExit) as exc,
+    ):
+        submit_command(results_path=jf, dry_run=False, yes=False)
+
+    assert exc.value.code == 0
+    mock_post.assert_not_called()
+    assert "Aborted" in capsys.readouterr().out
+
+
+def test_submit_command_no_results_file_exits_1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When results/ has no JSONL files and no --results given, exit(1)."""
+    # Redirect RESULTS_DIR to an empty tmp_path
+    monkeypatch.setattr("hermia.submit.RESULTS_DIR", tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        submit_command(results_path=None, dry_run=False, yes=True)
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary

Adds a new `hermia-submit` console script that produces the v0.2 community submission wire format. Pairs with `scottblydotcom/hermia-infra#2` (the AWS-hosted submission API).

- New module `src/hermia/submit.py` (420 lines):
  - Generates / persists `install_id` UUID at `~/.hermia/config.toml`
  - Detects `host_class` (17-value controlled vocabulary + `local:other` fallback)
  - Detects `unified_memory_gb` (Apple Silicon: system RAM; discrete: VRAM)
  - Client-side anonymization (mirrors `hermia-infra/lambda/anonymization.py`)
  - Confirmation prompt by default; `--yes` to skip; `--dry-run` to print payload
  - HTTP success / 503 / 429 / 400 / network failure error paths
- New tests: `tests/unit/test_submit.py` (52 tests, all green)
- `pyproject.toml`: one line added for `hermia-submit = "hermia.submit:main"` console script

## Scope

In: client CLI + tests.
Not in: changes to `app.py` TUI, fleet mode, or any existing module.

## Test plan

- [x] 52 new unit tests green
- [x] 1415 total tests pass (0 regressions)
- [x] `ruff check` clean
- [x] `mypy --strict src/` clean
- [x] Pre-commit hooks (gitleaks, trufflehog, detect-private-key) clean
- [ ] CI required checks (lint-and-test, gitleaks, trufflehog, trivy, bandit, pip-audit) — pending
- [ ] Sonnet `/code-review` run in-window — pending
- [ ] Opus `/review` run in-window — pending
- [ ] `/gemini review` posted as comment — pending

## Deploy impact

None to the existing tool. Adds a new console script that's opt-in.

## Reviewer focus

- RTX 30xx regex pattern `RTX\s+30[678][05]` — known to miss Ti variants (3080 Ti, 3070 Ti, 3060 Ti). Worth fixing before merge.
- `compute_unified_memory_gb` fallback to psutil when VRAM is 0 — for NVIDIA/AMD discrete cards with offline state this returns system RAM, which is wrong. Should return None instead.
- Anonymization rule parity with server (`hermia-infra/lambda/anonymization.py`)
- Confirmation flow: does the diff render cleanly enough for a Kwaai user to read?

## Linked PR

`scottblydotcom/hermia-infra#2` — the server this CLI submits to. Both must merge together.

🤖 Generated overnight by Claude Opus 4.7 with Claude Sonnet 4.7 dispatchers + local qwen3-coder fleet (5090).