### PR TITLE
feat(v0.2): reproducibility / self-divergence floor (item #2)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-reproducibility-floor.md
+++ b/docs/superpowers/plans/2026-06-15-reproducibility-floor.md
@@ -1,0 +1,662 @@
+# Reproducibility / Self-Divergence Floor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-trial-group `reproducibility` block to every fleet result row, computed over the existing `--repeat N` runs, measuring how consistently a fixed (model, stack, test) reproduces its output and how reliably it passes.
+
+**Architecture:** Extract the grader's fence-stripping into a shared `hermia/normalize.py` so canonical comparison uses the exact same transform the grader uses. Add `compute_reproducibility(run_results) -> ReproducibilityResult` next to `score_rows` in `robustness.py`. Wire it into `fleet.py:_run_host_eval` right after the existing `score_rows` call, stamping `row["reproducibility"] = asdict(repro)` on every row in the trial group. Purely additive to the result schema.
+
+**Tech Stack:** Python 3.14, pytest, `unittest.mock`, stdlib `statistics.pstdev` / `collections.Counter`. No new dependencies.
+
+---
+
+## Terminology
+
+- **trial** — one execution (one prompt → one response → one grade) = one JSONL result row.
+- **trial group** — all trials sharing the same `(model, test)` on one host; `--repeat N` produces one group of N trials. Reproducibility is measured over the group.
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/hermia/normalize.py` | **Create.** Pure `strip_fences(text)` moved verbatim from `runner._strip_fences` (renamed public). |
+| `src/hermia/runner.py` | Remove `def _strip_fences` + `import re`; import `strip_fences` from `normalize`; update the one internal call site (line ~352). |
+| `src/hermia/corpus_audit/mining.py` | Re-point import: `from hermia.normalize import strip_fences`; update call site. |
+| `src/hermia/corpus_audit/confusion.py` | Re-point import: `from hermia.normalize import strip_fences`; update call site. |
+| `src/hermia/robustness.py` | Add `ReproducibilityResult` dataclass + `compute_reproducibility()` + `_modal_match_rate()` helper; import `strip_fences`, `pstdev`. |
+| `src/hermia/fleet.py` | In `_run_host_eval`: import `compute_reproducibility` + `asdict`; call after `score_rows`; stamp `row["reproducibility"]`. |
+| `tests/unit/test_normalize.py` | **Create.** The 6 fence-stripping tests moved from `test_runner.py` (renamed to `strip_fences`). |
+| `tests/unit/test_runner.py` | Remove the 6 `_strip_fences` tests + the `_strip_fences` import (now in `test_normalize.py`). |
+| `tests/unit/test_robustness.py` | Add the `compute_reproducibility` test section. |
+| `tests/unit/test_fleet.py` | Add a repeat-loop test asserting the stamped `reproducibility` block. |
+
+## Spec correction (note for reviewers)
+
+The spec ([2026-06-15-reproducibility-floor-design.md](../specs/2026-06-15-reproducibility-floor-design.md)) said the `_strip_fences` extraction touches "one import site in runner.py." Reality: **three** production importers (`runner`, `corpus_audit/mining`, `corpus_audit/confusion`) plus 6 tests. Still low-risk (a pure function move), just more sites. This plan updates all of them. The design is unchanged.
+
+## The "valid trial" predicate (locked)
+
+From `run_test`, `raw_response` is `""` exactly when the trial produced no output — `TIMEOUT`, `OLLAMA_ERROR`/`API_ERROR`/`ERROR`, or `EMPTY_RESPONSE`. Rows that produced output but failed grading (`SCHEMA_FAIL`, `JSON_PARSE_ERROR`) keep their (bad) output in `raw_response`. So:
+
+- **valid trial** (counts toward exact-match) ⟺ `bool(row.get("raw_response"))` is truthy.
+- **pass** (counts toward pass-rate) ⟺ `row.get("schema_compliant") is True and not row.get("failure_reason")`, over **all** N.
+
+---
+
+## Task 1: Extract `strip_fences` into a shared `normalize.py`
+
+**Files:**
+- Create: `src/hermia/normalize.py`
+- Create: `tests/unit/test_normalize.py`
+- Modify: `src/hermia/runner.py`, `src/hermia/corpus_audit/mining.py`, `src/hermia/corpus_audit/confusion.py`, `tests/unit/test_runner.py`
+
+This is a behavior-preserving refactor. The existing tests are the safety net; no new behavior is added.
+
+- [ ] **Step 1: Create `src/hermia/normalize.py`**
+
+```python
+"""Output normalization shared by the grader and reproducibility scoring.
+
+`strip_fences` MUST stay the single source of truth: the eval grader uses it
+to extract JSON before checking schema, and reproducibility scoring uses it to
+compute canonical-output equality. They must apply the identical transform or
+`exact_match_rate_canonical` would diverge from what the grader actually saw.
+"""
+
+import re
+
+
+def strip_fences(text: str) -> str:
+    """Extract content from markdown code fences, ignoring surrounding prose."""
+    text = text.strip()
+    match = re.search(r'```(?:json)?\s*\n?(.*?)\n?\s*```', text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text
+```
+
+- [ ] **Step 2: Create `tests/unit/test_normalize.py` with the moved tests**
+
+```python
+"""Unit tests for hermia.normalize — shared output normalization."""
+
+from hermia.normalize import strip_fences
+
+
+def test_strip_fences_json_block() -> None:
+    assert strip_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_plain_block() -> None:
+    assert strip_fences('```\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_no_fences() -> None:
+    raw = '{"a": 1}'
+    assert strip_fences(raw) == raw
+
+
+def test_strip_fences_whitespace_only() -> None:
+    assert strip_fences("   ") == ""
+
+
+def test_strip_fences_prose_before_block() -> None:
+    assert strip_fences('Here is the JSON:\n```json\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_prose_after_block() -> None:
+    assert strip_fences('```json\n{"a": 1}\n```\nHope that helps!') == '{"a": 1}'
+```
+
+- [ ] **Step 3: Run the new normalize tests (verify they pass against the new module)**
+
+```bash
+cd ~/Git/hermia && source .venv/bin/activate
+pytest tests/unit/test_normalize.py -v -p no:cacheprovider --no-cov
+```
+
+Expected: 6 PASS.
+
+- [ ] **Step 4: Update `src/hermia/runner.py`**
+
+Remove `import re` (line 5) — it is used *only* by `_strip_fences`. Remove the `def _strip_fences` block (lines 33–39). Add to the import block (after `from hermia.metrics import ...`):
+
+```python
+from hermia.normalize import strip_fences
+```
+
+Change the one internal call site (≈ line 352) from:
+
+```python
+        cleaned = _strip_fences(output)
+```
+
+to:
+
+```python
+        cleaned = strip_fences(output)
+```
+
+- [ ] **Step 5: Update the two corpus_audit importers**
+
+In `src/hermia/corpus_audit/mining.py`, change `from hermia.runner import _strip_fences` to:
+
+```python
+from hermia.normalize import strip_fences
+```
+
+and the call site `parsed = json.loads(_strip_fences(raw))` to:
+
+```python
+        parsed = json.loads(strip_fences(raw))
+```
+
+In `src/hermia/corpus_audit/confusion.py`, change `from hermia.runner import _strip_fences` to:
+
+```python
+from hermia.normalize import strip_fences
+```
+
+and the call site `parsed = json.loads(_strip_fences(response))` to:
+
+```python
+            parsed = json.loads(strip_fences(response))
+```
+
+- [ ] **Step 6: Remove the moved tests from `tests/unit/test_runner.py`**
+
+Remove `_strip_fences` from the `from hermia.runner import (...)` block (line ~13). Delete the 6 `test_strip_fences_*` functions (lines ~766–788) and their section comment (line ~762 `# hermia-qc: _strip_fences, ...`) — they now live in `test_normalize.py`.
+
+- [ ] **Step 7: Run the full suite to prove the refactor is behavior-preserving**
+
+```bash
+pytest -p no:cacheprovider --no-cov -q
+```
+
+Expected: all pass (same count as before, the 6 strip-fences tests just relocated). If `ruff` flags an unused `import re` in runner, it means Step 4 missed the removal — fix it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/hermia/normalize.py tests/unit/test_normalize.py src/hermia/runner.py \
+        src/hermia/corpus_audit/mining.py src/hermia/corpus_audit/confusion.py \
+        tests/unit/test_runner.py
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit -m "refactor: extract strip_fences into shared hermia/normalize.py
+
+Single source of truth for fence-stripping, shared by the grader and the
+upcoming reproducibility canonical-match. Behavior-preserving move; updates
+all 3 production importers (runner, corpus_audit/mining, corpus_audit/confusion)
+and relocates the 6 tests to test_normalize.py."
+```
+
+---
+
+## Task 2: `compute_reproducibility` in `robustness.py`
+
+**Files:**
+- Modify: `src/hermia/robustness.py`
+- Test: `tests/unit/test_robustness.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_robustness.py` (after the `score_rows` section). Note the import addition at the top of the file: extend the existing `from hermia.robustness import (...)` block to include `ReproducibilityResult` and `compute_reproducibility`.
+
+```python
+# ---------------------------------------------------------------------------
+# compute_reproducibility
+# ---------------------------------------------------------------------------
+
+def _trial(
+    raw_response: str = '{"action":"read"}',
+    schema_compliant: bool = True,
+    failure_reason: str = "",
+) -> dict:
+    return {
+        "raw_response": raw_response,
+        "schema_compliant": schema_compliant,
+        "failure_reason": failure_reason,
+    }
+
+
+def test_compute_reproducibility_empty() -> None:
+    r = compute_reproducibility([])
+    assert r.n_repeats == 0
+    assert r.n_valid == 0
+    assert r.exact_match_rate_raw is None
+    assert r.exact_match_rate_canonical is None
+    assert r.pass_rate_mean == 0.0
+    assert r.pass_rate_stddev == 0.0
+
+
+def test_compute_reproducibility_all_identical_pass() -> None:
+    rows = [_trial() for _ in range(10)]
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 10
+    assert r.n_valid == 10
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.exact_match_rate_canonical == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(1.0)
+    assert r.pass_rate_stddev == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_modal_raw_rate() -> None:
+    # 7 identical, 3 different → modal raw rate = 0.7
+    rows = [_trial('{"x":1}') for _ in range(7)] + [_trial('{"x":2}') for _ in range(3)]
+    r = compute_reproducibility(rows)
+    assert r.exact_match_rate_raw == pytest.approx(0.7)
+
+
+def test_compute_reproducibility_canonical_ignores_fences_and_whitespace() -> None:
+    # Same JSON, one fenced one bare, one with surrounding whitespace.
+    # raw differs (fences/whitespace) but canonical is identical.
+    rows = [
+        _trial('{"x":1}'),
+        _trial('```json\n{"x":1}\n```'),
+        _trial('   {"x":1}   '),
+    ]
+    r = compute_reproducibility(rows)
+    assert r.exact_match_rate_raw == pytest.approx(1 / 3)   # all three raw strings differ
+    assert r.exact_match_rate_canonical == pytest.approx(1.0)  # all canonicalize equal
+
+
+def test_compute_reproducibility_all_errored_is_null_not_one() -> None:
+    """The poison case: all trials timed out (raw_response=''). Exact-match must be
+    null (not 1.0 from empty strings matching), n_valid=0, pass_rate=0."""
+    rows = [_trial(raw_response="", schema_compliant=False, failure_reason="TIMEOUT: 90s")
+            for _ in range(5)]
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 5
+    assert r.n_valid == 0
+    assert r.exact_match_rate_raw is None
+    assert r.exact_match_rate_canonical is None
+    assert r.pass_rate_mean == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_partial_error_excludes_invalid_from_exact_match() -> None:
+    """3 valid identical + 2 timeouts: exact-match over the 3 valid (=1.0); n_valid=3;
+    pass_rate over all 5 (=0.6)."""
+    rows = (
+        [_trial('{"x":1}') for _ in range(3)]
+        + [_trial(raw_response="", schema_compliant=False, failure_reason="TIMEOUT: 90s")
+           for _ in range(2)]
+    )
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 5
+    assert r.n_valid == 3
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(0.6)
+
+
+def test_compute_reproducibility_schema_fail_row_is_valid_for_exact_match() -> None:
+    """A SCHEMA_FAIL trial produced output (bad but present) → counts as valid for
+    exact-match, but NOT as a pass."""
+    rows = [_trial('{"wrong":1}', schema_compliant=False, failure_reason="SCHEMA_FAIL")
+            for _ in range(4)]
+    r = compute_reproducibility(rows)
+    assert r.n_valid == 4
+    assert r.exact_match_rate_raw == pytest.approx(1.0)  # all 4 bad outputs identical
+    assert r.pass_rate_mean == pytest.approx(0.0)        # none passed
+
+
+def test_compute_reproducibility_pass_stddev_matches_formula() -> None:
+    # 6 pass, 4 fail (fails still produced output) → mean 0.6, pstdev = sqrt(.6*.4)
+    import math
+    rows = (
+        [_trial('{"x":1}') for _ in range(6)]
+        + [_trial('{"x":1}', schema_compliant=False, failure_reason="SCHEMA_FAIL")
+           for _ in range(4)]
+    )
+    r = compute_reproducibility(rows)
+    assert r.pass_rate_mean == pytest.approx(0.6)
+    assert r.pass_rate_stddev == pytest.approx(math.sqrt(0.6 * 0.4))
+
+
+def test_compute_reproducibility_single_trial() -> None:
+    r = compute_reproducibility([_trial('{"x":1}')])
+    assert r.n_repeats == 1
+    assert r.n_valid == 1
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(1.0)
+    assert r.pass_rate_stddev == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_asdict_matches_schema() -> None:
+    """asdict() of the result must equal the documented 6-field schema exactly."""
+    from dataclasses import asdict
+    r = compute_reproducibility([_trial('{"x":1}') for _ in range(3)])
+    d = asdict(r)
+    assert set(d.keys()) == {
+        "n_repeats", "n_valid",
+        "exact_match_rate_raw", "exact_match_rate_canonical",
+        "pass_rate_mean", "pass_rate_stddev",
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/test_robustness.py -k compute_reproducibility -v -p no:cacheprovider --no-cov
+```
+
+Expected: ImportError / all FAIL (`compute_reproducibility` not defined).
+
+- [ ] **Step 3: Implement in `src/hermia/robustness.py`**
+
+Extend the imports at the top of the file:
+
+```python
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass
+from statistics import pstdev
+from typing import Any
+
+from hermia.normalize import strip_fences
+from hermia.schemas import _is_refusal
+```
+
+Add, after the `RobustnessResult` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ReproducibilityResult:
+    n_repeats: int
+    n_valid: int
+    exact_match_rate_raw: float | None
+    exact_match_rate_canonical: float | None
+    pass_rate_mean: float
+    pass_rate_stddev: float
+
+
+def _modal_match_rate(values: list[str]) -> float:
+    """Fraction of values equal to the single most common value.
+
+    `values` must be non-empty. This is the self-divergence floor: how reliably
+    the group reproduces its dominant output (O(n), vs O(n^2) all-pairs).
+    """
+    _, modal_count = Counter(values).most_common(1)[0]
+    return modal_count / len(values)
+
+
+def compute_reproducibility(run_results: list[dict[str, Any]]) -> ReproducibilityResult:
+    """Self-divergence floor over one trial group (the N repeats of a model+test).
+
+    Exact-match rates are computed over VALID trials only (those that produced
+    output, i.e. raw_response is non-empty); a group where everything errored
+    yields None, never a spurious 1.0 from empty strings matching. Pass-rate is
+    over ALL N trials, because a timeout is an end-to-end failure.
+    """
+    n_repeats = len(run_results)
+    if n_repeats == 0:
+        return ReproducibilityResult(
+            n_repeats=0, n_valid=0,
+            exact_match_rate_raw=None, exact_match_rate_canonical=None,
+            pass_rate_mean=0.0, pass_rate_stddev=0.0,
+        )
+
+    # A trial is valid for exact-match if it produced output. TIMEOUT /
+    # transport-error / EMPTY_RESPONSE rows carry raw_response="".
+    valid_raw = [str(r.get("raw_response", "")) for r in run_results if r.get("raw_response")]
+    n_valid = len(valid_raw)
+
+    if n_valid > 0:
+        exact_raw: float | None = _modal_match_rate(valid_raw)
+        exact_canonical: float | None = _modal_match_rate([strip_fences(v) for v in valid_raw])
+    else:
+        exact_raw = None
+        exact_canonical = None
+
+    # Pass = compliant output, over ALL trials (timeout counts as a failure).
+    passes = [
+        1.0 if (r.get("schema_compliant") is True and not r.get("failure_reason")) else 0.0
+        for r in run_results
+    ]
+    pass_rate_mean = sum(passes) / n_repeats
+    pass_rate_stddev = pstdev(passes)  # pstdev([x]) == 0.0; n_repeats >= 1 guaranteed here
+
+    return ReproducibilityResult(
+        n_repeats=n_repeats,
+        n_valid=n_valid,
+        exact_match_rate_raw=exact_raw,
+        exact_match_rate_canonical=exact_canonical,
+        pass_rate_mean=pass_rate_mean,
+        pass_rate_stddev=pass_rate_stddev,
+    )
+```
+
+- [ ] **Step 4: Run the compute_reproducibility tests**
+
+```bash
+pytest tests/unit/test_robustness.py -k compute_reproducibility -v -p no:cacheprovider --no-cov
+```
+
+Expected: all PASS (10 tests).
+
+- [ ] **Step 5: Run the full robustness suite (regression)**
+
+```bash
+pytest tests/unit/test_robustness.py -v -p no:cacheprovider --no-cov
+```
+
+Expected: all pass (existing `run_n_times` / `score_rows` untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hermia/robustness.py tests/unit/test_robustness.py
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit -m "feat(robustness): add compute_reproducibility self-divergence floor
+
+Per-trial-group block: n_repeats, n_valid, exact_match_rate_raw/canonical
+(modal-match over valid trials, null if all errored), pass_rate_mean/stddev
+(over all N). Canonical match reuses the grader's strip_fences for parity."
+```
+
+---
+
+## Task 3: Wire `compute_reproducibility` into the fleet repeat loop
+
+**Files:**
+- Modify: `src/hermia/fleet.py`
+- Test: `tests/unit/test_fleet.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_fleet.py`, in the repeat-loop section (after `test_run_host_eval_aggregates_are_per_cell_not_global`):
+
+```python
+def test_run_host_eval_stamps_reproducibility_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every row in a trial group carries an identical reproducibility block;
+    3 identical passing trials → exact_match_rate_raw=1.0, n_valid=3, pass=1.0."""
+    import hermia.fleet as fleet
+    from hermia.results import load_jsonl, open_run
+
+    def fake_run(model, test, sampler, **kw):
+        return {
+            "model": model, "test_id": test["id"],
+            "schema_compliant": True, "failure_reason": "",
+            "raw_response": '{"action":"read"}',
+            "elapsed_sec": 0.1, "tokens_per_sec": 1.0,
+        }
+
+    monkeypatch.setattr("hermia.runner.run_test", fake_run, raising=False)
+    monkeypatch.setattr("hermia.runner.load_tests_all", lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr(
+        "hermia.runner.get_available_models",
+        lambda host=None, headers=None: [{"name": "m1"}],
+        raising=False,
+    )
+
+    jsonl, csv = open_run(tmp_path)
+    fleet._run_host_eval(
+        {"name": "node1", "host": "http://h1:11434"},
+        repeat=3, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+    rows = load_jsonl(jsonl)
+
+    assert len(rows) == 3
+    for row in rows:
+        repro = row["reproducibility"]
+        assert repro["n_repeats"] == 3
+        assert repro["n_valid"] == 3
+        assert repro["exact_match_rate_raw"] == 1.0
+        assert repro["exact_match_rate_canonical"] == 1.0
+        assert repro["pass_rate_mean"] == 1.0
+        assert repro["pass_rate_stddev"] == 0.0
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pytest tests/unit/test_fleet.py::test_run_host_eval_stamps_reproducibility_block \
+       -v -p no:cacheprovider --no-cov
+```
+
+Expected: FAIL with `KeyError: 'reproducibility'`.
+
+- [ ] **Step 3: Update the import line in `_run_host_eval`**
+
+In `src/hermia/fleet.py`, change the local import (line ~126) from:
+
+```python
+    from hermia.robustness import score_rows
+```
+
+to:
+
+```python
+    from dataclasses import asdict
+
+    from hermia.robustness import compute_reproducibility, score_rows
+```
+
+- [ ] **Step 4: Add the compute + stamp in the repeat loop**
+
+In `_run_host_eval`, the block that currently reads (lines ~231–237):
+
+```python
+            # Compute robustness aggregates across all repeat runs for this pair
+            rob = score_rows(run_results)
+            for result in run_results:
+                result["consistency_pct"] = rob.consistency_pct
+                result["pass_count"] = rob.pass_count
+                result["robustness_n"] = rob.n
+                append_result(result, jsonl_path, csv_path)
+```
+
+becomes:
+
+```python
+            # Compute robustness + reproducibility aggregates across all repeat
+            # runs for this (model, test) trial group, then stamp on every row.
+            rob = score_rows(run_results)
+            repro = compute_reproducibility(run_results)
+            for result in run_results:
+                result["consistency_pct"] = rob.consistency_pct
+                result["pass_count"] = rob.pass_count
+                result["robustness_n"] = rob.n
+                result["reproducibility"] = asdict(repro)
+                append_result(result, jsonl_path, csv_path)
+```
+
+- [ ] **Step 5: Run the new fleet test**
+
+```bash
+pytest tests/unit/test_fleet.py::test_run_host_eval_stamps_reproducibility_block \
+       -v -p no:cacheprovider --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full fleet suite (regression)**
+
+```bash
+pytest tests/unit/test_fleet.py -v -p no:cacheprovider --no-cov
+```
+
+Expected: all pass. The pre-existing repeat-loop tests still pass — they don't assert absence of `reproducibility`, and rows lacking `raw_response` simply yield `n_valid=0` / null rates without error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hermia/fleet.py tests/unit/test_fleet.py
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit -m "feat(fleet): stamp reproducibility block on every trial-group row
+
+After the existing score_rows pass, compute_reproducibility over the same N
+repeats and denormalize asdict(repro) onto each row so every row is
+self-describing for downstream JSONL consumers."
+```
+
+---
+
+## Task 4: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+```bash
+cd ~/Git/hermia && source .venv/bin/activate
+pytest -p no:cacheprovider --no-cov -q
+```
+
+Expected: all pass. Baseline before this slice was 1469 (1464 + 5 coverage tests already committed); this slice adds 6 (normalize, relocated) + 10 (reproducibility) + 1 (fleet) and removes 6 from test_runner → net +11, so ~1480. Confirm zero failures.
+
+- [ ] **Step 2: Lint/type check (matches CI gates)**
+
+```bash
+ruff check src/ tests/
+mypy src/hermia/normalize.py src/hermia/robustness.py src/hermia/fleet.py src/hermia/runner.py
+```
+
+Expected: clean. Watch for: unused `import re` in `runner.py` (Task 1 Step 4), and `float | None` handling in `ReproducibilityResult` (mypy must see the None branches).
+
+- [ ] **Step 3: Confirm no stray `_strip_fences` references remain**
+
+```bash
+grep -rn "_strip_fences" src/ tests/ --include="*.py" | grep -v __pycache__
+```
+
+Expected: **no output** (every reference re-pointed to `strip_fences`).
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Spec requirement | Task |
+|---|---|
+| `reproducibility` block with 6 fields | Task 2 (`ReproducibilityResult` + `compute_reproducibility`) |
+| Exact-match over valid trials only; null if `n_valid==0` | Task 2 (Step 3 logic + poison-case test) |
+| Pass-rate over all N (timeout = fail) | Task 2 (Step 3 `passes` over all rows) |
+| Canonical match uses the grader's exact transform | Task 1 (shared `normalize.strip_fences`) + Task 2 import |
+| Denormalize block onto every trial-group row | Task 3 (`asdict(repro)` stamped per row) |
+| N = existing `--repeat` flag (no new knob) | Inherent — no CLI/YAML change in any task |
+| `_strip_fences` extraction (the one production refactor) | Task 1 (all 3 importers + tests) |
+| Per-trial `failure_reason`/`raw_response` preserved | Inherent — rows are unmodified except the added key |
+| Backward compatibility: purely additive key | Task 3 + Task 4 Step 1 (suite green) |
+
+### Out of scope (recorded in spec, not implemented here)
+
+- Semantic/functional-equivalence rung (`8 = 7+1`) — divergence-ladder future work.
+- The A/B cross-stack proof experiment (scope item #5) that consumes this floor.
+- Optional precomputed end-to-end "overall identical-output rate" field.
+- TUI/screens.py reproducibility display — fleet path only; the TUI repeat loop (`screens.py:363`) is a separate surface not in this slice.
+
+### Placeholder scan
+
+None. Every code step shows complete code; every command shows expected output.
+
+### Type consistency
+
+- `ReproducibilityResult.exact_match_rate_raw: float | None` — set to `_modal_match_rate(...)` (float) or `None`; both branches present in Task 2 Step 3. ✓
+- `compute_reproducibility(run_results: list[dict[str, Any]])` — matches how `score_rows` is called in `fleet.py` (same `run_results` list). ✓
+- `_modal_match_rate(values: list[str]) -> float` — called only inside the `n_valid > 0` guard, so `values` is non-empty as its docstring requires. ✓
+- `asdict(repro)` in `fleet.py` — `repro` is a `@dataclass`, so `asdict` yields the 6-field dict asserted by `test_compute_reproducibility_asdict_matches_schema`. ✓
+- `strip_fences` signature identical pre/post move (`(text: str) -> str`) — all 4 call sites unchanged in arity. ✓
+- `pstdev(passes)` — `passes` is `list[float]`, non-empty when reached (n_repeats ≥ 1). ✓
+```

--- a/docs/superpowers/specs/2026-06-15-reproducibility-floor-design.md
+++ b/docs/superpowers/specs/2026-06-15-reproducibility-floor-design.md
@@ -1,0 +1,172 @@
+# Reproducibility / Self-Divergence Floor — Design
+
+**Date:** 2026-06-15
+**Status:** Draft — ready for writing-plans
+**Scope:** v0.2.0 scope item #2 (follows the merged determinism slice, PR #113)
+**Parent spec:** `docs/superpowers/specs/2026-06-14-stack-fingerprint-design.md` (Round-2 §B defines the `reproducibility` block; §C the divergence ladder; §G the MVP confound controls)
+**Related memory:** [[project_hermia_determinism_finding]], [[project_hermia_stack_fingerprint]], [[project_hermia_data_accounting]], [[backlog_qwen3_8b_anomaly]]
+
+---
+
+## Terminology (used throughout)
+
+The word **cell** from the parent spec is retired here in favor of two precise terms:
+
+- **trial** — one execution: one prompt delivered, one response received, one grade computed. **One trial = one JSONL result row.** (Analogous to a request/response "packet pair" in API-security tooling.)
+- **trial group** — all trials sharing the same `(model, test)` identity on one host. Running `--repeat N` produces one trial group of N trials per `(model, test)`. The trial group is the unit over which reproducibility is measured.
+
+(Across hosts, the full grouping identity is `(host/stack, model, test)`; within a single host's eval loop — where this work lives — `host` is fixed, so the group key is `(model, test)`.)
+
+---
+
+## Problem
+
+The eval is now sampling-deterministic (`temperature=0.0`, `seed=42`, pinned and immutable — PR #113). But determinism is **necessary, not sufficient**: at `temp=0`, residual run-to-run nondeterminism can still flip outputs, driven by server-side batch-variant FP-reduction order (Thinking Machines), not RNG. Before Hermia can make any **cross-stack** divergence claim, it must first characterize **intra-group self-divergence** — how much a single fixed stack disagrees with itself across identical re-runs.
+
+This is the noise floor. A cross-stack difference is only real if it exceeds this floor. Today Hermia measures nothing of the sort.
+
+## Goal
+
+Add a per-trial-group `reproducibility` block to every result row, computed over the N repeats already produced by `--repeat`. The block answers: **"When this (model, stack, test) is run N identical times, how consistently does it produce the same output, and how reliably does it pass?"**
+
+Acceptance bar (from parent §B, ChatGPT side of the resolved split): **within-stack variance << between-stack variance** — NOT hard-zero. Residual batch/FP nondeterminism makes a hard-0 floor unattainable on real GPUs, so a relative bar is used. This spec ships the *measurement*; the A/B proof that the bar holds is scope item #5 (MVP experiment).
+
+## Non-goals
+
+- **Semantic / functional equivalence** (a real but out-of-scope third rung). `8`, `7+1`, `4+4`, `2×2×2` are "the same answer" to a human but differ at both byte and JSON-canonical levels. Detecting this requires a per-test equivalence function or LLM-as-judge — expensive and test-specific. Our current corpus grades structured JSON, where schema-canonical equality already captures functional sameness, so this rung does not bite yet. It belongs in the divergence-ladder work (parent §C) as a future rung between `canonical_json_equal` and a human judge, not here. **Recorded so it is not silently forgotten.**
+- **Latency / performance reproducibility.** Reproducibility of *output* is this item. Reproducibility of *timing* is a separate correctness-vs-performance concern (parent spec splits these sub-trees deliberately) and is not added here.
+- **Per-test or per-host N.** N is the existing global `--repeat` flag (see Decision 4).
+- **Cross-stack comparison / the A/B proof.** That is scope item #5; this item only establishes the per-group measurement it will consume.
+
+---
+
+## Design decisions (background + trade-offs)
+
+### Decision 1 — Extend the existing repeat loop, do not build a parallel subsystem
+
+`fleet.py:_run_host_eval` already runs N repeats per `(model, test)`, accumulates them into `run_results: list[dict]`, calls `score_rows(run_results)`, and stamps the robustness aggregates on every row before writing (lines 213–237). Reproducibility is conceptually *one more aggregate over the same list*. We add a second function call into that same loop.
+
+- **Trade-off:** Every eval run now produces reproducibility data for free (not opt-in). Upside: anyone running `--repeat 10` gets the determinism signal automatically. Cost: the metric becomes part of the **output-schema contract** — downstream consumers (Grafana, submission API, `hermia-analyze`, TUI) will expect the field, so we own its correctness, shape-stability, and performance from here forward. Accepted: the loop already does the expensive work (the N model calls); the aggregate is microseconds on top.
+
+### Decision 2 — Denormalize the group summary onto every trial row
+
+The `reproducibility` block is a property of the **trial group**, but it is stamped identically onto **every trial row** in that group (mirroring how `consistency_pct`/`pass_count`/`robustness_n` already work).
+
+Concretely — 10 repeats of `(qwen3:8b, tool-calling)` produce 10 JSONL rows; each keeps its **own** `raw_response`/`elapsed_sec`/`tokens`, and each **also** carries a copy of the same `reproducibility` summary.
+
+- **Trade-off vs. emitting one summary row per group:** the per-group-summary layout would write fewer rows but **discard the individual `raw_response` strings** — which are the *evidence* for the reported rates. Denormalizing costs redundant storage (the summary repeats N times) but keeps every row self-describing and preserves the raw outputs a reviewer needs to verify the number. For an audit-grade research tool whose consumers read flat JSONL (no join/aggregation step), this is the correct trade: **schema follows the queries you expect to run** ("show me a row / rows matching X"), not normalization theory.
+
+### Decision 3 — Same dict reference on every row in a group (safe here)
+
+`row["reproducibility"] = repro` assigns the *same* dict object to every row in the group. This is safe because the next operation is `append_result(...)`, which JSON-serializes each row (a deep copy to disk); nothing mutates the dict between assignment and serialization. The loop is small enough that the safety is obvious from reading it. (A defensive `dict(repro)` copy would be visually-obvious-correct at zero real cost; the plan may choose it for reader-friendliness — optimize for the reader.)
+
+### Decision 4 — N is the existing `--repeat` flag
+
+No per-test annotation, no per-host YAML field. The parent spec calls for N=10–20 to characterize the floor; `--repeat 15` already does that. YAGNI: adding per-test/per-host N buys flexibility we do not need and a config surface we would have to test, document, and explain. If reality later forces per-test N, refactor then — carrying unused flexibility forward is the more common, costlier mistake.
+
+### Decision 5 — Errored trials: honest "both" via an explicit valid-count
+
+Some trials produce no output (90s TIMEOUT, EMPTY_RESPONSE, transport error); their `raw_response` is `""`. The poison case: if **all** N trials error, all empty strings match each other → a naive exact-match returns **1.0 ("perfectly reproducible")** about a model that produced nothing N times. That number can never be published.
+
+Resolution (consistent with parent §G "drop TIMEOUT/EMPTY_RESPONSE from exact-match; report timeout rate separately"):
+
+- **Exact-match rates** (`raw`, `canonical`) are computed **only over valid trials** (those that produced output). If `n_valid == 0`, both are `null` ("not measurable") — never 1.0, never 0.0.
+- **Pass rate** is computed over **all N trials** — a timeout *is* an end-to-end failure from the user's standpoint and must count against it.
+- **`n_valid`** is recorded so the error count (`n_repeats − n_valid`) is explicit and the reader can reconstruct any blended view.
+
+This represents *both* realities the user asked for without a degenerate number: "when it answered, how consistent was it?" (exact-match over valid) and "how often did the whole thing work?" (pass-rate over all). The per-trial `failure_reason` and `raw_response` remain on every row regardless — the summary is a convenience, never the only copy of the truth.
+
+A precomputed end-to-end "overall identical-output rate" was considered and rejected as redundant: `n_valid` + the two rates let any consumer derive it, and every extra precomputed field is one more thing to keep correct. Add it later only if practice demands it.
+
+---
+
+## Schema
+
+A single `reproducibility` object on each result row:
+
+```python
+reproducibility: {
+    "n_repeats": int,                            # total trials attempted in the group
+    "n_valid": int,                              # trials that produced output (n_repeats − errored)
+    "exact_match_rate_raw": float | None,        # P(trial.raw_response == modal raw_response),
+                                                 #   over VALID trials only; null if n_valid == 0
+    "exact_match_rate_canonical": float | None,  # same, over canonicalized output; null if n_valid == 0
+    "pass_rate_mean": float,                     # mean(passed) over ALL n_repeats (timeout = fail)
+    "pass_rate_stddev": float,                   # population stddev of pass outcomes over ALL n_repeats
+}
+```
+
+Field semantics:
+
+- **`n_repeats`** — lets consumers weight/filter by sample size (a rate at N=2 is not a rate at N=20).
+- **`n_valid`** — the valid-trial denominator for the exact-match rates; `n_repeats − n_valid` is the error count.
+- **`exact_match_rate_raw`** — fraction of valid trials whose byte-exact `raw_response` equals the **modal** (most common) raw output in the group. `1.0` = token-level determinism (the industry's target); low = stochastic drift. Modal (not all-pairs) is chosen for O(N) cost and because it matches the intuition "what's the dominant output and how reliably is it produced?"
+- **`exact_match_rate_canonical`** — same, but over the canonicalized output (strip markdown fences + whitespace — the *same transform the grader applies*). Measures "did the grader see identical input each time?" A high-canonical / low-raw split means meaning is stable but formatting drifts.
+- **`pass_rate_mean`** — fraction of all N trials that passed (`schema_compliant and not failure_reason`). Distinct from the existing `consistency_pct`, which measures self-agreement (an all-fail group is 100% consistent); `pass_rate_mean` measures actual success.
+- **`pass_rate_stddev`** — population stddev of the binary pass outcomes. For binary data this is `sqrt(p(1−p))` (a function of the mean, not independent information) but is standard hygiene next to a rate and costs nothing.
+
+Deliberately excluded: an `is_reproducible` boolean (threshold is the consumer's value judgment — publish numbers, not verdicts); `unique_output_count` (derivable from raw rows); per-rank rates (analysis-tier, for item #5).
+
+---
+
+## Components / isolation
+
+- **`robustness.py` — new `compute_reproducibility(run_results) -> ReproducibilityResult`.** Lives next to `score_rows` because `robustness.py` already *is* "turn N trial dicts into a summary"; reproducibility is one more such summary. Reuses the module's established dataclass + unit-test pattern. Returns a frozen `ReproducibilityResult` dataclass whose five+one field names match the schema verbatim, so `dataclasses.asdict(result)` yields the exact nested dict — type-safe and testable (`result.exact_match_rate_raw == 0.9`) without string-keying.
+- **Canonicalization — shared, not duplicated.** The canonical exact-match MUST use the *same* transform the grader uses (`runner._strip_fences`, then strip) so `exact_match_rate_canonical` aligns with what the grader actually saw. Today neither `runner.py` nor `robustness.py` imports the other. To keep them in sync without a fragile `robustness → runner` dependency, extract `_strip_fences` into a small pure module (e.g. `hermia/normalize.py`, no deps) and import it from both. This is the one production refactor in scope — low-risk (move one pure function, update one import site in `runner.py`), justified by the new shared need (improve the code you're working in, don't bolt on a divergent copy).
+- **`fleet.py:_run_host_eval` — one added call + one added stamp.** After the existing `score_rows` call: `repro = compute_reproducibility(run_results)`, then inside the per-row write loop `row["reproducibility"] = asdict(repro)`. No structural change to the loop.
+
+Error classification (which trials are "valid"): a trial is **invalid** when it failed to produce output — `failure_reason` indicates TIMEOUT / EMPTY_RESPONSE / transport error, equivalently `raw_response == ""`. `compute_reproducibility` filters on this to form the valid set for exact-match while keeping all N for pass-rate. The exact predicate is finalized in the plan against the `failure_reason` vocabulary in `run_test`.
+
+---
+
+## Data flow
+
+```
+_run_host_eval, per (model, test) trial group:
+    run_results = []
+    for run_index in 1..repeat:
+        run_results.append(run_test(...))            # one trial → one row
+
+    rob   = score_rows(run_results)                  # existing
+    repro = compute_reproducibility(run_results)     # NEW — aggregate over the same list
+    for row in run_results:
+        row["consistency_pct"], row["pass_count"], row["robustness_n"] = rob...   # existing
+        row["reproducibility"] = asdict(repro)       # NEW — group summary on every trial row
+        append_result(row, jsonl_path, csv_path)     # existing — serializes each row independently
+```
+
+---
+
+## Testing
+
+Unit (`tests/unit/test_robustness.py`, a new `compute_reproducibility` test section alongside the existing `score_rows` tests):
+
+- All-identical valid trials → `exact_match_rate_raw == 1.0`, `n_valid == n_repeats`.
+- All-different valid trials → low raw rate; canonical higher when only formatting differs (fence/whitespace-only delta → `canonical == 1.0`, `raw < 1.0`).
+- Mixed pass/fail valid trials → `pass_rate_mean` over all N; `pass_rate_stddev` matches `sqrt(p(1−p))`.
+- **All-errored group → exact-match rates are `null` (NOT 1.0), `n_valid == 0`, `pass_rate_mean == 0.0`.** (The poison-case guard.)
+- Partial-error group → exact-match over valid only; `n_valid == n_repeats − errored`; pass-rate over all N.
+- Single trial (`n_repeats == 1`) → degenerate-but-defined (rate 1.0 over the one valid trial; stddev 0.0).
+- Empty input → zeroed/`null` result, mirroring `score_rows([])`.
+- `dataclasses.asdict()` of the result equals the documented schema dict exactly (field-name contract test).
+
+Integration (`tests/unit/test_fleet.py`, extending the new repeat-loop family already added):
+
+- `--repeat N` stamps an identical `reproducibility` block on all N rows of a group; `n_repeats == N`.
+- Two tests × repeat=2 → each group's `n_repeats == 2` (per-group, not global) — already covered structurally by `test_run_host_eval_aggregates_are_per_cell_not_global`; extend to assert the `reproducibility` block.
+
+Canonicalization parity:
+
+- `exact_match_rate_canonical` uses the same fence-stripping as the grader — a fenced-vs-unfenced pair of otherwise-identical JSON is canonical-equal. Asserted against `normalize._strip_fences` directly so the shared helper can't silently drift from the grader.
+
+---
+
+## Backward compatibility
+
+Purely additive: one new `reproducibility` key on each row; no existing field changes. The 895 pre-determinism rows simply lack the key (a missing `reproducibility` is the schema marker for "measured before this slice"), consistent with the data-accounting backfill plan ([[project_hermia_data_accounting]]). The `_strip_fences` extraction is a behavior-preserving move (same function, new home).
+
+## Out-of-scope follow-ups (recorded)
+
+- Semantic/functional-equivalence rung in the divergence ladder (parent §C).
+- The A/B cross-stack proof experiment that consumes this floor (scope item #5).
+- Optional precomputed end-to-end "overall identical-output rate" field — add only if practice demands it.

--- a/src/hermia/corpus_audit/confusion.py
+++ b/src/hermia/corpus_audit/confusion.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-from hermia.runner import _strip_fences
+from hermia.normalize import strip_fences
 from hermia.schemas import SCHEMA_CHECKS
 
 
@@ -22,7 +22,7 @@ def grade_response(test_id: str, response: Any) -> bool:
         return False
     if isinstance(response, str):
         try:
-            parsed = json.loads(_strip_fences(response))
+            parsed = json.loads(strip_fences(response))
         except json.JSONDecodeError:
             return False
     else:

--- a/src/hermia/corpus_audit/mining.py
+++ b/src/hermia/corpus_audit/mining.py
@@ -6,8 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from hermia.normalize import strip_fences
 from hermia.results import load_jsonl
-from hermia.runner import _strip_fences
 
 _UNPARSEABLE = "__unparseable__"
 
@@ -16,7 +16,7 @@ def _shape_key(raw: str) -> str:
     """Normalize a raw response to a shape key: parsed JSON re-serialized with
     sorted keys and compact separators. Unparseable text collapses to one bucket."""
     try:
-        parsed = json.loads(_strip_fences(raw))
+        parsed = json.loads(strip_fences(raw))
     except json.JSONDecodeError:
         return _UNPARSEABLE
     return json.dumps(parsed, sort_keys=True, separators=(",", ":"))

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -118,12 +118,13 @@ def _run_host_eval(
     Models run strictly sequentially within the host (VRAM-aware: one model loaded
     at a time). Safe to call concurrently for *different* hosts.
     """
+    from dataclasses import asdict
     from datetime import UTC, datetime
 
     from hermia.backend import resolve_stack
     from hermia.metrics import MetricsSampler
     from hermia.results import append_result
-    from hermia.robustness import score_rows
+    from hermia.robustness import compute_reproducibility, score_rows
     from hermia.runner import _normalize_host, get_available_models, load_tests_all, run_test
     from hermia.transport.ollama import OllamaTransport
     from hermia.transport.openai_compat import OpenAICompatTransport
@@ -228,12 +229,15 @@ def _run_host_eval(
                 ))
                 run_results.append(result)
 
-            # Compute robustness aggregates across all repeat runs for this pair
+            # Compute robustness + reproducibility aggregates across all repeat
+            # runs for this (model, test) trial group, then stamp on every row.
             rob = score_rows(run_results)
+            repro_dict = asdict(compute_reproducibility(run_results))
             for result in run_results:
                 result["consistency_pct"] = rob.consistency_pct
                 result["pass_count"] = rob.pass_count
                 result["robustness_n"] = rob.n
+                result["reproducibility"] = repro_dict
                 append_result(result, jsonl_path, csv_path)
 
                 if verbosity >= 0:

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -237,7 +237,7 @@ def _run_host_eval(
                 result["consistency_pct"] = rob.consistency_pct
                 result["pass_count"] = rob.pass_count
                 result["robustness_n"] = rob.n
-                result["reproducibility"] = repro_dict
+                result["reproducibility"] = dict(repro_dict)
                 append_result(result, jsonl_path, csv_path)
 
                 if verbosity >= 0:

--- a/src/hermia/normalize.py
+++ b/src/hermia/normalize.py
@@ -1,0 +1,18 @@
+"""Output normalization shared by the grader and reproducibility scoring.
+
+`strip_fences` MUST stay the single source of truth: the eval grader uses it
+to extract JSON before checking schema, and reproducibility scoring uses it to
+compute canonical-output equality. They must apply the identical transform or
+`exact_match_rate_canonical` would diverge from what the grader actually saw.
+"""
+
+import re
+
+
+def strip_fences(text: str) -> str:
+    """Extract content from markdown code fences, ignoring surrounding prose."""
+    text = text.strip()
+    match = re.search(r'```(?:json)?\s*\n?(.*?)\n?\s*```', text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text

--- a/src/hermia/robustness.py
+++ b/src/hermia/robustness.py
@@ -32,6 +32,17 @@ class ReproducibilityResult:
     pass_rate_stddev: float
 
 
+def _is_pass(row: dict[str, Any]) -> bool:
+    """A result row passed iff it produced schema-compliant output with no failure.
+
+    Single source of truth for the pass predicate, shared by ``score_rows`` and
+    ``compute_reproducibility`` so the invariant
+    ``pass_rate_mean == pass_count / robustness_n`` cannot silently drift when one
+    is edited without the other.
+    """
+    return row.get("schema_compliant") is True and not row.get("failure_reason")
+
+
 def _modal_match_rate(values: list[str]) -> float:
     """Fraction of values equal to the single most common value.
 
@@ -71,10 +82,7 @@ def compute_reproducibility(run_results: list[dict[str, Any]]) -> Reproducibilit
         exact_canonical = None
 
     # Pass = compliant output, over ALL trials (timeout counts as a failure).
-    passes = [
-        1.0 if (r.get("schema_compliant") is True and not r.get("failure_reason")) else 0.0
-        for r in run_results
-    ]
+    passes = [1.0 if _is_pass(r) else 0.0 for r in run_results]
     pass_rate_mean = sum(passes) / n_repeats
     pass_rate_stddev = pstdev(passes)  # pstdev([x]) == 0.0; n_repeats >= 1 guaranteed here
 
@@ -168,9 +176,7 @@ def score_rows(
     pass_count = 0
 
     for row in result_rows:
-        if row.get("failure_reason"):
-            outcomes.append("fail")
-        elif row.get("schema_compliant") is True:
+        if _is_pass(row):
             pass_count += 1
             outcomes.append("pass")
         else:

--- a/src/hermia/robustness.py
+++ b/src/hermia/robustness.py
@@ -3,8 +3,10 @@
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
+from statistics import pstdev
 from typing import Any
 
+from hermia.normalize import strip_fences
 from hermia.schemas import _is_refusal
 
 ROBUSTNESS_THRESHOLD: float = 0.8
@@ -18,6 +20,72 @@ class RobustnessResult:
     consistency_pct: float
     is_robust: bool
     majority_outcome: str | None = None
+
+
+@dataclass(frozen=True)
+class ReproducibilityResult:
+    n_repeats: int
+    n_valid: int
+    exact_match_rate_raw: float | None
+    exact_match_rate_canonical: float | None
+    pass_rate_mean: float
+    pass_rate_stddev: float
+
+
+def _modal_match_rate(values: list[str]) -> float:
+    """Fraction of values equal to the single most common value.
+
+    `values` must be non-empty. This is the self-divergence floor: how reliably
+    the group reproduces its dominant output (O(n), vs O(n^2) all-pairs).
+    """
+    _, modal_count = Counter(values).most_common(1)[0]
+    return modal_count / len(values)
+
+
+def compute_reproducibility(run_results: list[dict[str, Any]]) -> ReproducibilityResult:
+    """Self-divergence floor over one trial group (the N repeats of a model+test).
+
+    Exact-match rates are computed over VALID trials only (those that produced
+    output, i.e. raw_response is non-empty); a group where everything errored
+    yields None, never a spurious 1.0 from empty strings matching. Pass-rate is
+    over ALL N trials, because a timeout is an end-to-end failure.
+    """
+    n_repeats = len(run_results)
+    if n_repeats == 0:
+        return ReproducibilityResult(
+            n_repeats=0, n_valid=0,
+            exact_match_rate_raw=None, exact_match_rate_canonical=None,
+            pass_rate_mean=0.0, pass_rate_stddev=0.0,
+        )
+
+    # A trial is valid for exact-match if it produced output. TIMEOUT /
+    # transport-error / EMPTY_RESPONSE rows carry raw_response="".
+    valid_raw = [str(r.get("raw_response", "")) for r in run_results if r.get("raw_response")]
+    n_valid = len(valid_raw)
+
+    if n_valid > 0:
+        exact_raw: float | None = _modal_match_rate(valid_raw)
+        exact_canonical: float | None = _modal_match_rate([strip_fences(v) for v in valid_raw])
+    else:
+        exact_raw = None
+        exact_canonical = None
+
+    # Pass = compliant output, over ALL trials (timeout counts as a failure).
+    passes = [
+        1.0 if (r.get("schema_compliant") is True and not r.get("failure_reason")) else 0.0
+        for r in run_results
+    ]
+    pass_rate_mean = sum(passes) / n_repeats
+    pass_rate_stddev = pstdev(passes)  # pstdev([x]) == 0.0; n_repeats >= 1 guaranteed here
+
+    return ReproducibilityResult(
+        n_repeats=n_repeats,
+        n_valid=n_valid,
+        exact_match_rate_raw=exact_raw,
+        exact_match_rate_canonical=exact_canonical,
+        pass_rate_mean=pass_rate_mean,
+        pass_rate_stddev=pass_rate_stddev,
+    )
 
 
 def run_n_times(

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 import threading
 import time
 import types
@@ -15,6 +14,7 @@ import requests
 
 from hermia import __version__
 from hermia.metrics import MetricsSampler, get_gpu_stats
+from hermia.normalize import strip_fences
 from hermia.schemas import SCHEMA_CHECKS, SIGNAL_EXTRACTORS
 from hermia.transport.base import SAMPLING_SCHEMA_KEYS as _SAMPLING_SCHEMA_KEYS
 from hermia.transport.base import Response, TransportError
@@ -28,15 +28,6 @@ LOAD_TIMEOUT = 120   # seconds for cold model load
 EVAL_TEMPERATURE: float = 0.0
 EVAL_SEED: int = 42
 _EVAL_SAMPLING = types.MappingProxyType({"temperature": EVAL_TEMPERATURE, "seed": EVAL_SEED})
-
-
-def _strip_fences(text: str) -> str:
-    """Extract content from markdown code fences, ignoring surrounding prose."""
-    text = text.strip()
-    match = re.search(r'```(?:json)?\s*\n?(.*?)\n?\s*```', text, re.DOTALL)
-    if match:
-        return match.group(1).strip()
-    return text
 
 
 def _normalize_host(host: str) -> str:
@@ -349,7 +340,7 @@ def run_test(
 
     signals: dict[str, bool] = {}
     if output and not error_type:
-        cleaned = _strip_fences(output)
+        cleaned = strip_fences(output)
         had_markdown_fence = cleaned != output.strip()
         try:
             parsed = json.loads(cleaned)

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -912,6 +912,142 @@ def test_load_fleet_config_stack_optional(tmp_path: Path) -> None:
     assert "stack" not in entries[0]
 
 
+# ---------------------------------------------------------------------------
+# repeat loop — run_results accumulation and score_rows stamping
+# ---------------------------------------------------------------------------
+
+
+def _minimal_pass_result(model: str, test_id: str) -> dict:
+    return {
+        "model": model, "test_id": test_id,
+        "schema_compliant": True, "failure_reason": "",
+        "elapsed_sec": 0.1, "tokens_per_sec": 1.0,
+    }
+
+
+def _minimal_fail_result(model: str, test_id: str) -> dict:
+    return {
+        "model": model, "test_id": test_id,
+        "schema_compliant": False, "failure_reason": "SCHEMA_FAIL",
+        "elapsed_sec": 0.2, "tokens_per_sec": 0.0,
+    }
+
+
+def test_run_host_eval_repeat_stamps_aggregates_on_all_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With repeat=3 all-pass, every written row carries robustness_n=3 and pass_count=3."""
+    import hermia.fleet as fleet
+    from hermia.results import load_jsonl, open_run
+
+    monkeypatch.setattr(
+        "hermia.runner.run_test",
+        lambda model, test, sampler, **kw: _minimal_pass_result(model, test["id"]),
+        raising=False,
+    )
+    monkeypatch.setattr("hermia.runner.load_tests_all", lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr(
+        "hermia.runner.get_available_models",
+        lambda host=None, headers=None: [{"name": "m1"}],
+        raising=False,
+    )
+
+    jsonl, csv = open_run(tmp_path)
+    fleet._run_host_eval(
+        {"name": "node1", "host": "http://h1:11434"},
+        repeat=3, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+    rows = load_jsonl(jsonl)
+
+    assert len(rows) == 3  # 1 model × 1 test × 3 repeats
+    for row in rows:
+        assert row["robustness_n"] == 3, "all 3 repeats must be scored together, not independently"
+        assert row["pass_count"] == 3
+        assert row["consistency_pct"] == pytest.approx(1.0)
+
+
+def test_run_host_eval_mixed_pass_fail_aggregates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2 passing + 1 failing repeat: all 3 rows get the same mixed aggregate."""
+    import hermia.fleet as fleet
+    from hermia.results import load_jsonl, open_run
+
+    call_n = {"n": 0}
+
+    def fake_run(model, test, sampler, **kw):
+        call_n["n"] += 1
+        if call_n["n"] <= 2:
+            return _minimal_pass_result(model, test["id"])
+        return _minimal_fail_result(model, test["id"])
+
+    monkeypatch.setattr("hermia.runner.run_test", fake_run, raising=False)
+    monkeypatch.setattr("hermia.runner.load_tests_all", lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr(
+        "hermia.runner.get_available_models",
+        lambda host=None, headers=None: [{"name": "m1"}],
+        raising=False,
+    )
+
+    jsonl, csv = open_run(tmp_path)
+    fleet._run_host_eval(
+        {"name": "node1", "host": "http://h1:11434"},
+        repeat=3, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+    rows = load_jsonl(jsonl)
+
+    assert len(rows) == 3
+    for row in rows:
+        assert row["robustness_n"] == 3
+        assert row["pass_count"] == 2
+        # majority=pass (2 vs 1) → consistency = 2/3
+        assert row["consistency_pct"] == pytest.approx(2 / 3)
+
+
+def test_run_host_eval_aggregates_are_per_cell_not_global(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """robustness_n reflects the repeat count per (model, test) cell, not the total row count.
+
+    With 2 tests × repeat=2, each cell gets robustness_n=2 (not 4).
+    """
+    import hermia.fleet as fleet
+    from hermia.results import load_jsonl, open_run
+
+    monkeypatch.setattr(
+        "hermia.runner.run_test",
+        lambda model, test, sampler, **kw: _minimal_pass_result(model, test["id"]),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "hermia.runner.load_tests_all",
+        lambda: [{"id": "t1"}, {"id": "t2"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "hermia.runner.get_available_models",
+        lambda host=None, headers=None: [{"name": "m1"}],
+        raising=False,
+    )
+
+    jsonl, csv = open_run(tmp_path)
+    fleet._run_host_eval(
+        {"name": "node1", "host": "http://h1:11434"},
+        repeat=2, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+    rows = load_jsonl(jsonl)
+
+    assert len(rows) == 4  # 1 model × 2 tests × 2 repeats
+    for row in rows:
+        assert row["robustness_n"] == 2, "cell accumulation must reset per test, not be global"
+
+
 def test_group_entries_by_host_serializes_same_host() -> None:
     from hermia.fleet import _group_entries_by_host
     entries = [

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1048,6 +1048,50 @@ def test_run_host_eval_aggregates_are_per_cell_not_global(
         assert row["robustness_n"] == 2, "cell accumulation must reset per test, not be global"
 
 
+def test_run_host_eval_stamps_reproducibility_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every row in a trial group carries an identical reproducibility block;
+    3 identical passing trials -> exact_match_rate_raw=1.0, n_valid=3, pass=1.0."""
+    import hermia.fleet as fleet
+    from hermia.results import load_jsonl, open_run
+
+    def fake_run(model, test, sampler, **kw):
+        return {
+            "model": model, "test_id": test["id"],
+            "schema_compliant": True, "failure_reason": "",
+            "raw_response": '{"action":"read"}',
+            "elapsed_sec": 0.1, "tokens_per_sec": 1.0,
+        }
+
+    monkeypatch.setattr("hermia.runner.run_test", fake_run, raising=False)
+    monkeypatch.setattr("hermia.runner.load_tests_all", lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr(
+        "hermia.runner.get_available_models",
+        lambda host=None, headers=None: [{"name": "m1"}],
+        raising=False,
+    )
+
+    jsonl, csv = open_run(tmp_path)
+    fleet._run_host_eval(
+        {"name": "node1", "host": "http://h1:11434"},
+        repeat=3, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+    rows = load_jsonl(jsonl)
+
+    assert len(rows) == 3
+    for row in rows:
+        repro = row["reproducibility"]
+        assert repro["n_repeats"] == 3
+        assert repro["n_valid"] == 3
+        assert repro["exact_match_rate_raw"] == 1.0
+        assert repro["exact_match_rate_canonical"] == 1.0
+        assert repro["pass_rate_mean"] == 1.0
+        assert repro["pass_rate_stddev"] == 0.0
+
+
 def test_group_entries_by_host_serializes_same_host() -> None:
     from hermia.fleet import _group_entries_by_host
     entries = [

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,28 @@
+"""Unit tests for hermia.normalize — shared output normalization."""
+
+from hermia.normalize import strip_fences
+
+
+def test_strip_fences_json_block() -> None:
+    assert strip_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_plain_block() -> None:
+    assert strip_fences('```\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_no_fences() -> None:
+    raw = '{"a": 1}'
+    assert strip_fences(raw) == raw
+
+
+def test_strip_fences_whitespace_only() -> None:
+    assert strip_fences("   ") == ""
+
+
+def test_strip_fences_prose_before_block() -> None:
+    assert strip_fences('Here is the JSON:\n```json\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_strip_fences_prose_after_block() -> None:
+    assert strip_fences('```json\n{"a": 1}\n```\nHope that helps!') == '{"a": 1}'

--- a/tests/unit/test_robustness.py
+++ b/tests/unit/test_robustness.py
@@ -217,9 +217,9 @@ def test_score_rows_raw_response_field_never_consulted() -> None:
     output is not available at this abstraction layer.
     """
     rows = [
-        {"schema_compliant": True,  "failure_reason": "",            "raw_response": '{"action":"ok"}'},
-        {"schema_compliant": False, "failure_reason": "SCHEMA_FAIL", "raw_response": '{"action":"bad"}'},
-        {"schema_compliant": False, "failure_reason": "TIMEOUT: 90s","raw_response": ""},
+        {"schema_compliant": True, "failure_reason": "", "raw_response": '{"action":"ok"}'},
+        {"schema_compliant": False, "failure_reason": "SCHEMA_FAIL", "raw_response": '{"bad":1}'},
+        {"schema_compliant": False, "failure_reason": "TIMEOUT: 90s", "raw_response": ""},
     ]
     result = score_rows(rows)
     assert result.n == 3

--- a/tests/unit/test_robustness.py
+++ b/tests/unit/test_robustness.py
@@ -3,6 +3,8 @@
 import pytest
 
 from hermia.robustness import (
+    ReproducibilityResult,
+    compute_reproducibility,
     run_n_times,
     score_rows,
 )
@@ -223,3 +225,134 @@ def test_score_rows_raw_response_field_never_consulted() -> None:
     assert result.n == 3
     assert result.pass_count == 1
     assert result.majority_outcome == "fail"  # 2 fail vs 1 pass
+
+
+# ---------------------------------------------------------------------------
+# compute_reproducibility
+# ---------------------------------------------------------------------------
+
+def _trial(
+    raw_response: str = '{"action":"read"}',
+    schema_compliant: bool = True,
+    failure_reason: str = "",
+) -> dict:
+    return {
+        "raw_response": raw_response,
+        "schema_compliant": schema_compliant,
+        "failure_reason": failure_reason,
+    }
+
+
+def test_compute_reproducibility_empty() -> None:
+    r = compute_reproducibility([])
+    assert r.n_repeats == 0
+    assert r.n_valid == 0
+    assert r.exact_match_rate_raw is None
+    assert r.exact_match_rate_canonical is None
+    assert r.pass_rate_mean == 0.0
+    assert r.pass_rate_stddev == 0.0
+
+
+def test_compute_reproducibility_all_identical_pass() -> None:
+    rows = [_trial() for _ in range(10)]
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 10
+    assert r.n_valid == 10
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.exact_match_rate_canonical == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(1.0)
+    assert r.pass_rate_stddev == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_modal_raw_rate() -> None:
+    # 7 identical, 3 different -> modal raw rate = 0.7
+    rows = [_trial('{"x":1}') for _ in range(7)] + [_trial('{"x":2}') for _ in range(3)]
+    r = compute_reproducibility(rows)
+    assert r.exact_match_rate_raw == pytest.approx(0.7)
+
+
+def test_compute_reproducibility_canonical_ignores_fences_and_whitespace() -> None:
+    # Same JSON, one fenced one bare, one with surrounding whitespace.
+    # raw differs (fences/whitespace) but canonical is identical.
+    rows = [
+        _trial('{"x":1}'),
+        _trial('```json\n{"x":1}\n```'),
+        _trial('   {"x":1}   '),
+    ]
+    r = compute_reproducibility(rows)
+    assert r.exact_match_rate_raw == pytest.approx(1 / 3)   # all three raw strings differ
+    assert r.exact_match_rate_canonical == pytest.approx(1.0)  # all canonicalize equal
+
+
+def test_compute_reproducibility_all_errored_is_null_not_one() -> None:
+    """The poison case: all trials timed out (raw_response=''). Exact-match must be
+    null (not 1.0 from empty strings matching), n_valid=0, pass_rate=0."""
+    rows = [_trial(raw_response="", schema_compliant=False, failure_reason="TIMEOUT: 90s")
+            for _ in range(5)]
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 5
+    assert r.n_valid == 0
+    assert r.exact_match_rate_raw is None
+    assert r.exact_match_rate_canonical is None
+    assert r.pass_rate_mean == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_partial_error_excludes_invalid_from_exact_match() -> None:
+    """3 valid identical + 2 timeouts: exact-match over the 3 valid (=1.0); n_valid=3;
+    pass_rate over all 5 (=0.6)."""
+    rows = (
+        [_trial('{"x":1}') for _ in range(3)]
+        + [_trial(raw_response="", schema_compliant=False, failure_reason="TIMEOUT: 90s")
+           for _ in range(2)]
+    )
+    r = compute_reproducibility(rows)
+    assert r.n_repeats == 5
+    assert r.n_valid == 3
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(0.6)
+
+
+def test_compute_reproducibility_schema_fail_row_is_valid_for_exact_match() -> None:
+    """A SCHEMA_FAIL trial produced output (bad but present) -> counts as valid for
+    exact-match, but NOT as a pass."""
+    rows = [_trial('{"wrong":1}', schema_compliant=False, failure_reason="SCHEMA_FAIL")
+            for _ in range(4)]
+    r = compute_reproducibility(rows)
+    assert r.n_valid == 4
+    assert r.exact_match_rate_raw == pytest.approx(1.0)  # all 4 bad outputs identical
+    assert r.pass_rate_mean == pytest.approx(0.0)        # none passed
+
+
+def test_compute_reproducibility_pass_stddev_matches_formula() -> None:
+    # 6 pass, 4 fail (fails still produced output) -> mean 0.6, pstdev = sqrt(.6*.4)
+    import math
+    rows = (
+        [_trial('{"x":1}') for _ in range(6)]
+        + [_trial('{"x":1}', schema_compliant=False, failure_reason="SCHEMA_FAIL")
+           for _ in range(4)]
+    )
+    r = compute_reproducibility(rows)
+    assert r.pass_rate_mean == pytest.approx(0.6)
+    assert r.pass_rate_stddev == pytest.approx(math.sqrt(0.6 * 0.4))
+
+
+def test_compute_reproducibility_single_trial() -> None:
+    r = compute_reproducibility([_trial('{"x":1}')])
+    assert r.n_repeats == 1
+    assert r.n_valid == 1
+    assert r.exact_match_rate_raw == pytest.approx(1.0)
+    assert r.pass_rate_mean == pytest.approx(1.0)
+    assert r.pass_rate_stddev == pytest.approx(0.0)
+
+
+def test_compute_reproducibility_asdict_matches_schema() -> None:
+    """asdict() of the result must equal the documented 6-field schema exactly."""
+    from dataclasses import asdict
+    r = compute_reproducibility([_trial('{"x":1}') for _ in range(3)])
+    assert isinstance(r, ReproducibilityResult)
+    d = asdict(r)
+    assert set(d.keys()) == {
+        "n_repeats", "n_valid",
+        "exact_match_rate_raw", "exact_match_rate_canonical",
+        "pass_rate_mean", "pass_rate_stddev",
+    }

--- a/tests/unit/test_robustness.py
+++ b/tests/unit/test_robustness.py
@@ -4,6 +4,7 @@ import pytest
 
 from hermia.robustness import (
     ReproducibilityResult,
+    _is_pass,
     compute_reproducibility,
     run_n_times,
     score_rows,
@@ -115,6 +116,32 @@ def test_run_n_times_custom_threshold() -> None:
     result = run_n_times(_checker, responses, threshold=0.5)
     assert result.consistency_pct == pytest.approx(0.6)
     assert result.is_robust is True
+
+
+# ---------------------------------------------------------------------------
+# _is_pass — shared pass predicate (score_rows + compute_reproducibility)
+# ---------------------------------------------------------------------------
+
+def test_is_pass_clean_compliant_row() -> None:
+    assert _is_pass({"schema_compliant": True, "failure_reason": ""}) is True
+
+
+def test_is_pass_failure_reason_set_is_fail() -> None:
+    # Even with schema_compliant True, a failure_reason means fail.
+    assert _is_pass({"schema_compliant": True, "failure_reason": "TIMEOUT: 90s"}) is False
+
+
+def test_is_pass_non_compliant_is_fail() -> None:
+    assert _is_pass({"schema_compliant": False, "failure_reason": ""}) is False
+
+
+def test_is_pass_missing_keys_default_to_fail() -> None:
+    assert _is_pass({}) is False
+
+
+def test_is_pass_schema_compliant_truthy_but_not_true_is_fail() -> None:
+    # Strict identity check: only the bool True passes, not truthy values.
+    assert _is_pass({"schema_compliant": 1, "failure_reason": ""}) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_robustness.py
+++ b/tests/unit/test_robustness.py
@@ -189,3 +189,37 @@ def test_score_rows_custom_threshold() -> None:
     rows = [_row(True)] * 3 + [_row(False, "JSON_PARSE_ERROR")] * 2
     result = score_rows(rows, threshold=0.5)
     assert result.is_robust is True  # 0.6 >= 0.5
+
+
+def test_score_rows_error_row_with_empty_raw_response() -> None:
+    """Error rows from run_test carry failure_reason set and raw_response="".
+
+    score_rows classifies by failure_reason alone; raw_response is never
+    consulted.  An empty raw_response on an error row must count as 'fail'.
+    """
+    error_row = {
+        "schema_compliant": False,
+        "failure_reason": "TIMEOUT: no response in 90s",
+        "raw_response": "",
+    }
+    result = score_rows([error_row])
+    assert result.pass_count == 0
+    assert result.n == 1
+    assert result.majority_outcome == "fail"
+
+
+def test_score_rows_raw_response_field_never_consulted() -> None:
+    """raw_response content never affects pass/fail classification.
+
+    score_rows operates on failure_reason and schema_compliant only — raw
+    output is not available at this abstraction layer.
+    """
+    rows = [
+        {"schema_compliant": True,  "failure_reason": "",            "raw_response": '{"action":"ok"}'},
+        {"schema_compliant": False, "failure_reason": "SCHEMA_FAIL", "raw_response": '{"action":"bad"}'},
+        {"schema_compliant": False, "failure_reason": "TIMEOUT: 90s","raw_response": ""},
+    ]
+    result = score_rows(rows)
+    assert result.n == 3
+    assert result.pass_count == 1
+    assert result.majority_outcome == "fail"  # 2 fail vs 1 pass

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -10,7 +10,6 @@ import hermia.runner as _runner_mod
 from hermia.runner import (
     EVAL_SEED,
     EVAL_TEMPERATURE,
-    _strip_fences,
     compute_execution_path,
     fetch_server_ps_data,
     get_available_models,
@@ -759,33 +758,8 @@ def test_run_test_response_null_coerced_to_empty_string() -> None:
     assert result["output_preview"] == "EMPTY_RESPONSE"
 
 
-# hermia-qc: _strip_fences, had_markdown_fence, failure_reason codes
+# hermia-qc: had_markdown_fence, failure_reason codes
 # ---------------------------------------------------------------------------
-
-
-def test_strip_fences_json_block() -> None:
-    assert _strip_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
-
-
-def test_strip_fences_plain_block() -> None:
-    assert _strip_fences('```\n{"a": 1}\n```') == '{"a": 1}'
-
-
-def test_strip_fences_no_fences() -> None:
-    raw = '{"a": 1}'
-    assert _strip_fences(raw) == raw
-
-
-def test_strip_fences_whitespace_only() -> None:
-    assert _strip_fences("   ") == ""
-
-
-def test_strip_fences_prose_before_block() -> None:
-    assert _strip_fences('Here is the JSON:\n```json\n{"a": 1}\n```') == '{"a": 1}'
-
-
-def test_strip_fences_prose_after_block() -> None:
-    assert _strip_fences('```json\n{"a": 1}\n```\nHope that helps!') == '{"a": 1}'
 
 
 def test_had_markdown_fence_true() -> None:


### PR DESCRIPTION
## Summary

Adds a per-trial-group **reproducibility** block to every fleet result row, computed over the existing `--repeat N` runs. This is v0.2.0 scope item #2 — the self-divergence noise floor that must be characterized *before* any cross-stack divergence claim (follows the determinism slice, #113).

A **trial** = one prompt→response→grade (one JSONL row); a **trial group** = the N repeats of one `(model, test)`. The new block answers: *when this (model, stack, test) runs N identical times, how consistently does it reproduce its output, and how reliably does it pass?*

### Schema (new `reproducibility` key on each row)
- `n_repeats` — total trials in the group
- `n_valid` — trials that produced output (`n_repeats − errored`)
- `exact_match_rate_raw` — modal byte-exact match over **valid** trials; `null` if all errored
- `exact_match_rate_canonical` — same over fence-stripped output (the transform the grader uses)
- `pass_rate_mean` — over **all** N (a timeout is a real failure)
- `pass_rate_stddev` — population stddev of pass outcomes

The two denominators are deliberate: exact-match over valid-only avoids the poison case where N timeouts (all `raw_response=""`) would otherwise report a spurious `1.0`; pass-rate over all N reflects real end-to-end reliability. `n_valid` exposes the error count so nothing is hidden.

### Changes
- `hermia/normalize.py` (**new**) — extract `strip_fences` from `runner` into a shared module so the grader and reproducibility scoring apply the identical transform (canonical-match parity). Updates all 3 importers.
- `hermia/robustness.py` — `ReproducibilityResult` frozen dataclass + `compute_reproducibility()` next to `score_rows`.
- `hermia/fleet.py` — compute once per group, denormalize `asdict(repro)` onto every row in `_run_host_eval`.
- Plus earlier test-coverage hardening for `score_rows` error path + the fleet repeat loop.

### Out of scope (recorded in spec)
Semantic/functional equivalence rung (`8 = 7+1`); the A/B cross-stack proof (item #5); optional precomputed "overall identical-output rate".

Spec: `docs/superpowers/specs/2026-06-15-reproducibility-floor-design.md`
Plan: `docs/superpowers/plans/2026-06-15-reproducibility-floor.md`

## Test Plan
- [x] Full suite green: **1480 passed** (`pytest -p no:cacheprovider --no-cov`)
- [x] `ruff check src/ tests/` clean
- [x] `mypy` clean on normalize / robustness / fleet / runner
- [x] 10 unit tests for `compute_reproducibility` incl. the all-errored→null poison case
- [x] Integration test: `--repeat 3` stamps an identical block on all 3 trial-group rows
- [x] No live `_strip_fences` references remain after the extraction
- [x] Final whole-implementation review: READY TO MERGE (CSV/JSONL contract, canonical-match parity, backward-compat all verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)