### PR TITLE
feat(fingerprint): engine dispatch — skip Ollama probe for openai-compat hosts

### DIFF
--- a/src/hermia/fingerprint/cache.py
+++ b/src/hermia/fingerprint/cache.py
@@ -62,8 +62,10 @@ class FingerprintCache:
         # auditing _provenance don't see 'api' for a value that was declared.
         probe_result = ProbeResult(engine=engine, engine_version=engine_version)
         fingerprint, provenance = assemble_fingerprint(probe_result, declared)
-        if provenance.get("runtime.engine") is not None:
-            provenance["runtime.engine"] = "declared"
-        if provenance.get("runtime.engine_version") is not None:
+        # engine is guaranteed non-None in this branch; engine_version is the
+        # caller-supplied input, so check it directly instead of re-querying
+        # the provenance dict.
+        provenance["runtime.engine"] = "declared"
+        if engine_version is not None:
             provenance["runtime.engine_version"] = "declared"
         return fingerprint, provenance

--- a/src/hermia/fingerprint/cache.py
+++ b/src/hermia/fingerprint/cache.py
@@ -6,15 +6,16 @@ from typing import Any
 
 from hermia.fingerprint.assemble import assemble_fingerprint
 from hermia.fingerprint.probes.ollama import OllamaProbe
+from hermia.fingerprint.types import ProbeResult
 
 _FP_PAIR = tuple[dict[str, Any], dict[str, str | None]]
 
 
 class FingerprintCache:
-    """Cache fingerprint results per (host, model) for the duration of a run."""
+    """Cache fingerprint results per (host, model, engine) for the duration of a run."""
 
     def __init__(self) -> None:
-        self._store: dict[tuple[str, str], _FP_PAIR] = {}
+        self._store: dict[tuple[str, str, str], _FP_PAIR] = {}
         self._probe = OllamaProbe()
 
     def get_or_probe(
@@ -24,13 +25,16 @@ class FingerprintCache:
         declared: dict[str, Any] | None,
         engine_version: str | None = None,
         headers: dict[str, str] | None = None,
+        engine: str | None = None,
     ) -> _FP_PAIR:
-        # Cache key is (host, model) only — auth headers are a transport detail,
-        # not part of the fingerprint identity.
-        key = (host, model)
+        # Cache key is (host, model, engine) — auth headers are a transport
+        # detail and not part of fingerprint identity. Engine is included so a
+        # single host serving both engines (rare but possible) doesn't collide.
+        engine_key = engine or "ollama"
+        key = (host, model, engine_key)
         if key in self._store:
             return self._store[key]
-        result = self._do_probe(host, model, declared, engine_version, headers)
+        result = self._do_probe(host, model, declared, engine_version, headers, engine)
         self._store[key] = result
         return result
 
@@ -41,8 +45,25 @@ class FingerprintCache:
         declared: dict[str, Any] | None,
         engine_version: str | None,
         headers: dict[str, str] | None,
+        engine: str | None = None,
     ) -> _FP_PAIR:
-        probe_result = self._probe.probe(
-            host, model, headers=headers, engine_version=engine_version,
-        )
-        return assemble_fingerprint(probe_result, declared)
+        # Engine dispatch: only "ollama" (or unset → default ollama for the
+        # standalone TUI) gets a live probe. Other engines (openai-compat,
+        # future vLLM/llama.cpp/SGLang) return an honest all-null ProbeResult
+        # with the engine name stamped, avoiding doomed /api/show + /api/ps
+        # round-trips to endpoints that don't exist.
+        if engine is None or engine == "ollama":
+            probe_result = self._probe.probe(
+                host, model, headers=headers, engine_version=engine_version,
+            )
+            return assemble_fingerprint(probe_result, declared)
+        # Null-probe path: the engine string came from fleet YAML (transport hint),
+        # not an API response. Correct the provenance vocabulary so consumers
+        # auditing _provenance don't see 'api' for a value that was declared.
+        probe_result = ProbeResult(engine=engine, engine_version=engine_version)
+        fingerprint, provenance = assemble_fingerprint(probe_result, declared)
+        if provenance.get("runtime.engine") is not None:
+            provenance["runtime.engine"] = "declared"
+        if provenance.get("runtime.engine_version") is not None:
+            provenance["runtime.engine_version"] = "declared"
+        return fingerprint, provenance

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -214,7 +214,7 @@ def _run_host_eval(
         model = model_entry["name"]
         declared = entry.get("stack")
         fingerprint, provenance = fp_cache.get_or_probe(
-            host_url, model, declared, headers=headers,
+            host_url, model, declared, headers=headers, engine=transport_type,
         )
         for test in tests:
             run_results: list[dict[str, Any]] = []

--- a/tests/unit/fingerprint/test_cache.py
+++ b/tests/unit/fingerprint/test_cache.py
@@ -18,7 +18,7 @@ def test_cache_miss_calls_probe() -> None:
     with patch.object(cache, "_do_probe", return_value=(_dummy_fp(), _dummy_prov())) as mock_probe:
         fp, prov = cache.get_or_probe("http://host:11434", "m1", declared=None,
                                        engine_version="0.6.2")
-    mock_probe.assert_called_once_with("http://host:11434", "m1", None, "0.6.2", None)
+    mock_probe.assert_called_once_with("http://host:11434", "m1", None, "0.6.2", None, None)
     assert fp["model"]["digest"] == "sha256:abc"
 
 
@@ -84,4 +84,63 @@ def test_cache_different_host_triggers_new_probe() -> None:
     with patch.object(cache, "_do_probe", return_value=(_dummy_fp(), _dummy_prov())) as mock_probe:
         cache.get_or_probe("http://h1:11434", "m1", declared=None, engine_version="0.6.2")
         cache.get_or_probe("http://h2:11434", "m1", declared=None, engine_version="0.6.2")
+    assert mock_probe.call_count == 2
+
+
+def test_openai_compat_engine_skips_http_probe() -> None:
+    """openai-compat hosts must not make /api/show or /api/ps round-trips.
+
+    The probe endpoints are Ollama-specific; openai-compat (vLLM, SGLang,
+    LiteLLM, etc.) would 404 them. Dispatch returns honest null fingerprint
+    with engine stamped, zero network cost.
+    """
+    cache = FingerprintCache()
+    with patch("hermia.fingerprint.probes.ollama.requests.post") as mock_post, \
+         patch("hermia.fingerprint.probes.ollama.requests.get") as mock_get:
+        # Fleet path passes engine='openai-compat' but no engine_version (it
+        # has no probe to source one from); keep the call shape realistic.
+        fp, prov = cache.get_or_probe(
+            "http://gateway:4000", "qwen3-coder:30b", declared=None,
+            engine="openai-compat",
+        )
+    mock_post.assert_not_called()
+    mock_get.assert_not_called()
+    assert fp["runtime"]["engine"] == "openai-compat"
+    assert fp["model"]["digest"] is None
+    assert prov["model.digest"] is None
+    # Provenance integrity: the engine value came from fleet YAML transport,
+    # not an API probe. Must be tagged 'declared', NEVER 'api' — otherwise
+    # the _provenance audit map lies about its source.
+    assert prov["runtime.engine"] == "declared", (
+        f"openai-compat engine value is YAML-declared, not API-derived; "
+        f"provenance must be 'declared' not {prov['runtime.engine']!r}"
+    )
+    assert prov["runtime.engine_version"] is None
+
+
+def test_engine_none_defaults_to_ollama_probe() -> None:
+    """Back-compat: callers that don't pass engine (standalone TUI) still probe."""
+    cache = FingerprintCache()
+    with patch.object(cache, "_probe") as mock_probe:
+        mock_probe.probe.return_value = MagicMock(
+            digest=None, architecture=None, family=None, parameter_count=None,
+            parameter_size=None, quant_method=None, quant_level=None,
+            context_length=None, chat_template=None, chat_template_hash=None,
+            engine="ollama", engine_version="0.6.2",
+            residency_ratio=None, execution_path=None,
+        )
+        cache.get_or_probe("http://host:11434", "m1", declared=None,
+                           engine_version="0.6.2")
+    mock_probe.probe.assert_called_once()
+
+
+def test_engine_in_cache_key_prevents_cross_engine_collision() -> None:
+    """Same (host, model) with different engines must probe independently."""
+    cache = FingerprintCache()
+    with patch.object(cache, "_do_probe",
+                      return_value=(_dummy_fp(), _dummy_prov())) as mock_probe:
+        cache.get_or_probe("http://h:11434", "m1", declared=None,
+                           engine_version="0.6.2", engine="ollama")
+        cache.get_or_probe("http://h:11434", "m1", declared=None,
+                           engine_version="0.6.2", engine="openai-compat")
     assert mock_probe.call_count == 2

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1187,9 +1187,12 @@ def test_run_host_eval_stamps_fingerprint_and_provenance(
     from hermia.fingerprint.cache import FingerprintCache
     seen_headers: list[dict | None] = []
 
+    seen_engines: list[str | None] = []
+
     def fake_get_or_probe(self, host, model, declared,
-                          engine_version=None, headers=None):
+                          engine_version=None, headers=None, engine=None):
         seen_headers.append(headers)
+        seen_engines.append(engine)
         return (fake_fp, fake_prov)
 
     monkeypatch.setattr(FingerprintCache, "get_or_probe", fake_get_or_probe)
@@ -1211,6 +1214,8 @@ def test_run_host_eval_stamps_fingerprint_and_provenance(
     assert row["_provenance"]["model.digest"] == "api"
     # Auth headers built by the fleet must be forwarded to the probe.
     assert seen_headers and seen_headers[0] is not None
+    # Default fleet entry (no transport key) → engine dispatched as "ollama".
+    assert seen_engines == ["ollama"]
 
 
 def test_run_host_eval_shares_one_cache_across_run_test_calls(
@@ -1243,7 +1248,8 @@ def test_run_host_eval_shares_one_cache_across_run_test_calls(
                         lambda *a, **k: None, raising=False)
     monkeypatch.setattr(
         FingerprintCache, "get_or_probe",
-        lambda self, host, model, declared, engine_version=None, headers=None: ({}, {}),
+        lambda self, host, model, declared, engine_version=None, headers=None,
+        engine=None: ({}, {}),
     )
 
     jsonl, csv = open_run(tmp_path)
@@ -1259,3 +1265,59 @@ def test_run_host_eval_shares_one_cache_across_run_test_calls(
     assert all(isinstance(c, FingerprintCache) for c in seen_caches)
     # ...and it's the SAME instance every time (not a fresh per-call probe).
     assert len({id(c) for c in seen_caches}) == 1
+
+
+def test_run_host_eval_dispatches_openai_compat_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """openai-compat fleet entries must dispatch engine='openai-compat' to the
+    fingerprint cache so the Ollama probe is skipped.
+
+    Regression guard: pre-dispatch, openai-compat hosts (vLLM, SGLang,
+    LiteLLM, etc.) received 3 doomed /api/show + /api/ps + /api/version
+    round-trips per model that 404'd and silently nulled out the fingerprint.
+    """
+    import hermia.fleet as fleet
+    from hermia.fingerprint.cache import FingerprintCache
+    from hermia.results import open_run
+    from hermia.transport.openai_compat import OpenAICompatTransport
+
+    seen_engines: list[str | None] = []
+
+    def fake_get_or_probe(self, host, model, declared,
+                          engine_version=None, headers=None, engine=None):
+        seen_engines.append(engine)
+        return ({}, {})
+
+    monkeypatch.setattr(FingerprintCache, "get_or_probe", fake_get_or_probe)
+    monkeypatch.setattr("hermia.runner.run_test",
+                        lambda *a, **kw: {
+                            "model": "m1", "test_id": "t1", "failure_reason": "",
+                            "elapsed_sec": 0.1, "tokens_per_sec": 1.0, "mode": "fleet",
+                            "peak_cpu_pct": None, "peak_ram_used_gb": None,
+                            "peak_gpu_pct": None, "peak_vram_used_gb": None,
+                        }, raising=False)
+    monkeypatch.setattr("hermia.runner.load_tests_all",
+                        lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr("hermia.results.append_result",
+                        lambda *a, **k: None, raising=False)
+    # openai-compat hosts call list_models() instead of /api/tags.
+    monkeypatch.setattr(OpenAICompatTransport, "list_models",
+                        lambda self: ["m1"], raising=False)
+
+    jsonl, csv = open_run(tmp_path)
+    entry = {
+        "name": "vllm-gateway",
+        "host": "http://gateway:4000",
+        "transport": "openai-compat",
+        "models": "auto",
+    }
+    fleet._run_host_eval(
+        entry, repeat=1, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=lambda s: None, verbosity=-1,
+    )
+
+    assert seen_engines == ["openai-compat"], (
+        f"openai-compat entry must dispatch engine='openai-compat'; got {seen_engines}"
+    )


### PR DESCRIPTION
## Summary
- `FingerprintCache.get_or_probe(..., engine: str | None = None)` — `"ollama"` (or unset, for standalone-TUI back-compat) gets the live probe; any other engine short-circuits to an honest all-null `ProbeResult` with the engine stamped. Zero HTTP round-trips on openai-compat hosts.
- `fleet.py` threads `engine=transport_type` into the cache, so openai-compat fleet entries (vLLM, SGLang, LiteLLM, etc.) stop hitting Ollama-only `/api/show`, `/api/ps`, `/api/version`.
- Cache key extends to `(host, model, engine)` so the rare same-host-both-engines case doesn't collide. `runner.py` and `screens.py` callers unchanged — default to `None` → ollama dispatch.
- **Opus `/review` finding (provenance integrity):** null-probe path overrides `_provenance["runtime.engine"]` from `"api"` → `"declared"` because the engine string originated in fleet YAML, not an API response. The audit map no longer lies about its source.

Closes [hermia-9dg](https://github.com/scottblydotcom/hermia/issues?q=hermia-9dg).

## Test plan
- [x] `pytest` — 1525 passed (1521 baseline + 4 new), 93% coverage held
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] Opus `/review` — one CONFIRMED finding (provenance mislabel), fixed in this PR
- [x] Pre-commit hooks — gitleaks + detect-secrets + detect-private-key all pass
- [ ] Gemini Code Assist review — pending, will post `/gemini review` after PR opens
- [ ] CI green
- [ ] Security CI green

## Out of scope (separate beads)
- `hermia-7m0` — gate probe on `not is_api_mode` in runner.py
- `hermia-czp` — reconcile dual `execution_path` keys on result row
- `hermia-2ra` — `ProbeResult.engine` default once dispatch lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)