### PR TITLE
refactor(scoring): extract compute_scores + backfill_aggregates to scoring module

### DIFF
--- a/src/hermia/scoring.py
+++ b/src/hermia/scoring.py
@@ -1,0 +1,52 @@
+"""Aggregate scoring helpers — per-model rollup and per-row aggregate backfill."""
+
+import statistics
+from typing import Any
+
+from hermia import robustness
+
+
+def compute_scores(
+    results: list[dict[str, Any]],
+) -> list[tuple[str, float, float, float, float]]:
+    """Aggregate per-model scores from a flat result list.
+
+    Returns list of (model, json_pass_rate, schema_pass_rate, agentic_score, avg_tps)
+    sorted descending by agentic_score.
+    """
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        by_model.setdefault(r["model"], []).append(r)
+    scored = []
+    for model, rs in by_model.items():
+        n = len(rs)
+        jp = sum(r["json_valid"] for r in rs) / n
+        sp = sum(r["schema_compliant"] for r in rs) / n
+        ag = (jp * 0.40) + (sp * 0.60)
+        tps = sum(r["tokens_per_sec"] for r in rs) / n
+        scored.append((model, jp, sp, ag, tps))
+    scored.sort(key=lambda x: x[3], reverse=True)
+    return scored
+
+
+def backfill_aggregates(run_results: list[dict[str, Any]]) -> None:
+    """Compute cold_warm_delta_tps and robustness fields; stamp onto each row in-place."""
+    if not run_results:
+        return
+    if len(run_results) == 1 or not run_results[0].get("is_cold"):
+        delta: float | None = None
+    else:
+        cold_tps = float(run_results[0].get("tokens_per_sec", 0.0))
+        warm_tps_list = [float(r.get("tokens_per_sec", 0.0)) for r in run_results[1:]]
+        if cold_tps == 0.0 and all(t == 0.0 for t in warm_tps_list):
+            delta = None
+        else:
+            delta = cold_tps - statistics.mean(warm_tps_list)
+
+    result = robustness.score_rows(run_results)
+
+    for row in run_results:
+        row["cold_warm_delta_tps"] = delta
+        row["consistency_pct"] = result.consistency_pct
+        row["pass_count"] = result.pass_count
+        row["robustness_n"] = result.n

--- a/src/hermia/screens.py
+++ b/src/hermia/screens.py
@@ -2,7 +2,6 @@
 
 import os
 import socket
-import statistics
 import time
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -17,7 +16,6 @@ from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Button, Checkbox, Footer, Header, Label, ProgressBar, Static
 
-from hermia import robustness
 from hermia.fingerprint.cache import FingerprintCache
 from hermia.metrics import NVIDIA_MIN_SUPPORTED_COMPUTE, MetricsSampler
 from hermia.preflight import DEFAULT_OLLAMA_HOST, run_preflight
@@ -30,6 +28,7 @@ from hermia.runner import (
     unload_model,
 )
 from hermia.schemas import TEST_IDS
+from hermia.scoring import backfill_aggregates, compute_scores
 
 
 @lru_cache(maxsize=1)
@@ -55,52 +54,6 @@ def _get_subtitle(fleet_mode: bool) -> str:
 def _sanitize_model_id(name: str) -> str:
     """Normalise a model name for use as a Textual widget ID."""
     return name.replace(":", "_").replace(".", "_")
-
-
-def _compute_scores(
-    results: list[dict[str, Any]],
-) -> list[tuple[str, float, float, float, float]]:
-    """Aggregate per-model scores from a flat result list.
-
-    Returns list of (model, json_pass_rate, schema_pass_rate, agentic_score, avg_tps)
-    sorted descending by agentic_score.
-    """
-    by_model: dict[str, list[dict[str, Any]]] = {}
-    for r in results:
-        by_model.setdefault(r["model"], []).append(r)
-    scored = []
-    for model, rs in by_model.items():
-        n = len(rs)
-        jp = sum(r["json_valid"] for r in rs) / n
-        sp = sum(r["schema_compliant"] for r in rs) / n
-        ag = (jp * 0.40) + (sp * 0.60)
-        tps = sum(r["tokens_per_sec"] for r in rs) / n
-        scored.append((model, jp, sp, ag, tps))
-    scored.sort(key=lambda x: x[3], reverse=True)
-    return scored
-
-
-def _backfill_aggregates(run_results: list[dict[str, Any]]) -> None:
-    """Compute cold_warm_delta_tps and robustness fields; stamp onto each row in-place."""
-    if not run_results:
-        return
-    if len(run_results) == 1 or not run_results[0].get("is_cold"):
-        delta: float | None = None
-    else:
-        cold_tps = float(run_results[0].get("tokens_per_sec", 0.0))
-        warm_tps_list = [float(r.get("tokens_per_sec", 0.0)) for r in run_results[1:]]
-        if cold_tps == 0.0 and all(t == 0.0 for t in warm_tps_list):
-            delta = None
-        else:
-            delta = cold_tps - statistics.mean(warm_tps_list)
-
-    result = robustness.score_rows(run_results)
-
-    for row in run_results:
-        row["cold_warm_delta_tps"] = delta
-        row["consistency_pct"] = result.consistency_pct
-        row["pass_count"] = result.pass_count
-        row["robustness_n"] = result.n
 
 
 RESULTS_DIR = Path("results")
@@ -377,7 +330,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
 
                 # Compute aggregates after all N runs, then patch the already-written
                 # rows in the JSONL. CSV written here so aggregate fields are included.
-                _backfill_aggregates(run_results_for_test)
+                backfill_aggregates(run_results_for_test)
                 patch_results(jsonl_path, run_results_for_test)
                 for result in run_results_for_test:
                     append_result(result, jsonl_path=None, csv_path=csv_path)
@@ -414,7 +367,7 @@ class RunnerScreen(Screen):  # type: ignore[type-arg]
                     if preview:
                         append_log(f"       {preview[:80]}", "warn")
 
-        scored = _compute_scores(self.all_results)
+        scored = compute_scores(self.all_results)
 
         lines = ["[bold]EVAL SUMMARY[/bold]\n"]
         lines.append(f"{'Model':<28} {'JSON%':>6} {'Schema%':>8} {'Agentic':>8} {'t/s':>6}")

--- a/tests/unit/test_screens.py
+++ b/tests/unit/test_screens.py
@@ -2,10 +2,10 @@
 
 import socket
 
+from hermia.scoring import backfill_aggregates as _backfill_aggregates
+from hermia.scoring import compute_scores as _compute_scores
 from hermia.screens import (
     RunnerScreen,
-    _backfill_aggregates,
-    _compute_scores,
     _resolve_fleet_host,
     _sanitize_model_id,
 )

--- a/tests/unit/test_screens_aggregates.py
+++ b/tests/unit/test_screens_aggregates.py
@@ -2,11 +2,7 @@
 
 import pytest
 
-try:
-    from hermia.screens import _backfill_aggregates  # speculative — red until implemented
-except ImportError:
-    def _backfill_aggregates(*_a, **_kw):  # type: ignore[misc]
-        raise NotImplementedError("_backfill_aggregates not yet implemented")
+from hermia.scoring import backfill_aggregates as _backfill_aggregates
 
 
 def _run_row(


### PR DESCRIPTION
## Summary
- Move `compute_scores` and `backfill_aggregates` out of `screens.py` into a new `hermia.scoring` module so Fleet TUI (next up) can consume them without dragging Textual imports.
- Drop the speculative `ImportError` shim in `test_screens_aggregates.py` — the module exists now.
- Closes [hermia-6l1](https://github.com/scottblydotcom/hermia/issues?q=hermia-6l1) (one of the last two v0.2.0 release-gating beads alongside Fleet TUI).

## Verification
- 1525 → 1525 tests pass
- ruff clean
- mypy clean
- Functions moved byte-for-byte; no behavior change
- Opus `/review` (7-angle finder + verify): no findings

## Test plan
- [x] `pytest` green
- [x] `ruff check src/ tests/` green
- [x] `mypy src/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)