### PR TITLE
feat(tui): foundation — widgets, bus, state, fleet I/O, probe

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,92 @@
+# CodeRabbit configuration — hermia LLM security eval TUI.
+# Free tier (public repo). Installed in advance of Gemini Code Assist sunset
+# (2026-07-17). Schema: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: en-US
+
+reviews:
+  # `chill` = concise; `assertive` = thorough but verbose. Start chill;
+  # bump to assertive on a per-PR basis with `@coderabbitai review` if a
+  # change warrants deeper analysis.
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # Mirror hermia's branch workflow (AGENTS.md): all work branches PR to dev,
+    # dev promotes to main. Review both bases.
+    base_branches:
+      - dev
+      - main
+
+  # Exclude generated artifacts, planning docs, and untracked working files.
+  # CodeRabbit reviews the diff; we don't want it spending tokens on these.
+  path_filters:
+    - "!docs/superpowers/plans/**"
+    - "!docs/superpowers/specs/**"
+    - "!docs/hermia-unpacked/**"
+    - "!docs/hermia-unpacked-v3/**"
+    - "!.superpowers/**"
+    - "!htmlcov/**"
+    - "!cmd/hermia-agent/coverage.*"
+    - "!cmd/hermia-agent/*.exe"
+    - "!**/__pycache__/**"
+    - "!**/.pytest_cache/**"
+    - "!**/.mypy_cache/**"
+    - "!**/*.pyc"
+
+  # Project-specific review priorities. These prime CodeRabbit on hermia's
+  # hard rules (see AGENTS.md) so reviews catch what actually matters.
+  path_instructions:
+    - path: "src/hermia/**/*.py"
+      instructions: |
+        Per AGENTS.md hard rules:
+        - Rule 1: do not import a package that is not in pyproject.toml.
+        - Rule 2: schema validators must use _keys_ok() (not exact-match key sets).
+        - Rule 5: if a module has a [project.scripts] entry, the CLI path must
+          be tested directly — not just the internal function.
+        - Rule 11: NEVER persist credential VALUES in config files (YAML, etc.).
+          Only env-var NAMES (e.g. `auth_header_env: LITELLM_KEY`). Flag any
+          code path that would write a token / key / password / bearer into a
+          result row, log line, error message, or persisted file.
+
+        Prefer stdlib over new deps. Type annotations expected.
+
+    - path: "src/hermia/tui/**/*.py"
+      instructions: |
+        Fleet TUI guidelines (see docs/superpowers/specs/2026-06-18-fleet-tui-design.md):
+        - Bindings live on screens, not on hidden widgets (Textual does not
+          dispatch keys to display:none widgets).
+        - Widgets expose API methods; key routing is the screen's job.
+        - probe.py is transport-library-agnostic by design — exception
+          handling catches stdlib classes (TimeoutError, PermissionError,
+          OSError, ConnectionError). Transports normalize their library-
+          specific errors (httpx, requests, etc.) at the adapter boundary.
+        - Status vocabulary: defended / refused / breached / error. Refused
+          color is direction-aware (harmful vs benign tests).
+
+    - path: "tests/**/*.py"
+      instructions: |
+        Tests use stdlib `asyncio.run()` inside sync wrappers (NOT
+        pytest-asyncio — not in pyproject deps; adding requires explicit
+        approval per AGENTS.md rule 3). Use `FakeTransport` from
+        tests/fixtures/fake_transport.py for any test driving probe / runner.
+        Pilot tests for screens should test key routing end-to-end; widget
+        tests test API contracts directly.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Per AGENTS.md rule 10: every job's permissions must be explicitly and
+        minimally scoped. No assumed-default permissions.
+
+  abort_on_close: true
+
+# Disable @coderabbitai chat auto-replies in PR comment threads so the bot
+# doesn't engage in long back-and-forths when a human is mid-conversation.
+chat:
+  auto_reply: false

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ hermia-fleet-spill.yaml
 # Secret scanning
 # .secrets.baseline is intentionally tracked (audited false-positive list)
 # .gitleaks.toml is intentionally tracked (custom rules)
+.superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ requires explicit user approval before any code is written.
 | New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | Everything else                      |
 | Schema checker fix          | `src/hermia/schemas.py`, `tests/unit/test_schemas.py`        | Everything else                      |
 | Regression module           | `src/hermia/regression.py`, `tests/test_regression.py`       | Everything else                      |
-| UI/TUI changes              | `src/hermia/tui/`, `src/hermia/screens.py`, `src/hermia/app.py` | Core eval logic                      |
+| UI/TUI changes              | `src/hermia/tui/`, `src/hermia/screens.py`, `src/hermia/app.py`, `tests/unit/tui/`, `tests/fixtures/` | Core eval logic                      |
 | Metrics / system monitoring | `src/hermia/metrics.py`, `src/hermia/preflight.py`           | Everything else                      |
 | Results handling            | `src/hermia/results.py`, `tests/unit/test_results.py`        | Everything else                      |
 | Robustness module           | `src/hermia/robustness.py`, `tests/security/test_robustness.py` | Everything else                   |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ requires explicit user approval before any code is written.
 | New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | Everything else                      |
 | Schema checker fix          | `src/hermia/schemas.py`, `tests/unit/test_schemas.py`        | Everything else                      |
 | Regression module           | `src/hermia/regression.py`, `tests/test_regression.py`       | Everything else                      |
-| UI/TUI changes              | `src/hermia/screens.py`, `src/hermia/app.py`                 | Core eval logic                      |
+| UI/TUI changes              | `src/hermia/tui/`, `src/hermia/screens.py`, `src/hermia/app.py` | Core eval logic                      |
 | Metrics / system monitoring | `src/hermia/metrics.py`, `src/hermia/preflight.py`           | Everything else                      |
 | Results handling            | `src/hermia/results.py`, `tests/unit/test_results.py`        | Everything else                      |
 | Robustness module           | `src/hermia/robustness.py`, `tests/security/test_robustness.py` | Everything else                   |

--- a/docs/superpowers/plans/2026-06-18-fleet-tui-foundation.md
+++ b/docs/superpowers/plans/2026-06-18-fleet-tui-foundation.md
@@ -1,0 +1,2684 @@
+# Fleet TUI Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the reusable widget library, event bus, state model, fleet YAML I/O, and async probe layer that the Fleet TUI's picker and runner flows will consume in subsequent plans.
+
+**Architecture:** New package `src/hermia/tui/` with five concerns: domain-agnostic Textual widgets (`widgets/`), in-process pub/sub bus (`bus.py`), in-memory data model with extension protocols (`state.py`), fleet YAML round-trip (`fleet_io.py`), and async host probe wrapping the existing `transport/` layer (`probe.py`). No screens or user-facing flow in this plan — every surface is unit-tested in isolation. Plans 2-4 (picker, runner, migration) consume this foundation.
+
+**Tech Stack:** Python 3.11+, Textual ≥0.80 (already in `pyproject.toml`), asyncio (stdlib), PyYAML (already in `pyproject.toml`), pytest, pytest-asyncio, ruff, mypy. **No new dependencies.**
+
+**Spec reference:** [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](../specs/2026-06-18-fleet-tui-design.md)
+
+**Tracking bead:** `hermia-86g`
+
+---
+
+## File Structure
+
+This plan creates these files. Each file has one clear responsibility:
+
+```
+src/hermia/tui/
+  __init__.py                        # package marker, exports public types
+  state.py                           # FleetConfig, Host, ModelChoice dataclasses + HostSource/ModelSource Protocols
+  fleet_io.py                        # load_fleet / save_fleet / load_hosts_seed / save_hosts_seed
+  bus.py                             # SessionBus pub/sub
+  probe.py                           # async probe wrapping transport/, publishes probe.* events
+  widgets/
+    __init__.py                      # re-exports public widgets
+    status_badge.py                  # ✓ ↺ ✗ ! glyph + direction-aware color
+    search_bar.py                    # / live-filter input
+    filter_axis.py                   # tab-cycling filter tabs
+    progress_bar.py                  # mini (per-host) + aggregate variants
+    drillable_list.py                # virtual scroll + universal /, tab, a, n, space keys
+
+tests/unit/tui/
+  __init__.py
+  test_state.py
+  test_fleet_io.py
+  test_bus.py
+  test_probe.py
+  test_widgets_status_badge.py
+  test_widgets_search_bar.py
+  test_widgets_filter_axis.py
+  test_widgets_progress_bar.py
+  test_widgets_drillable_list.py
+
+tests/fixtures/
+  __init__.py                        # if not present
+  fake_transport.py                  # FakeTransport for any test driving probe / runner without a host
+```
+
+Files modified by this plan:
+- `AGENTS.md` — Module Boundary Table row "UI/TUI changes" gains `src/hermia/tui/`
+
+Files NOT touched (out of scope for this plan):
+- `src/hermia/screens.py` — Plan 4 deletes it
+- `src/hermia/app.py` — Plan 4 rewires it
+- `src/hermia/fleet.py`, `runner.py`, `transport/`, `scoring.py` — never touched by TUI work
+
+---
+
+## Setup
+
+- [ ] **S1: Branch from latest dev**
+
+Run:
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/fleet-tui-foundation
+```
+
+Expected: clean `dev` checkout, new branch created.
+
+- [ ] **S2: Expand AGENTS.md Module Boundary Table**
+
+Modify `AGENTS.md`. Find the row:
+
+```
+| UI/TUI changes              | `src/hermia/screens.py`, `src/hermia/app.py`                 | Core eval logic                      |
+```
+
+Replace with:
+
+```
+| UI/TUI changes              | `src/hermia/tui/`, `src/hermia/screens.py`, `src/hermia/app.py` | Core eval logic                      |
+```
+
+Commit:
+```bash
+git add AGENTS.md
+git commit -m "chore(agents): expand UI/TUI scope to include tui/ package"
+```
+
+- [ ] **S3: Scaffold empty package**
+
+Create these files with the exact content shown:
+
+**`src/hermia/tui/__init__.py`:**
+```python
+"""Hermia Fleet TUI — unified interactive picker + live runner."""
+```
+
+**`src/hermia/tui/widgets/__init__.py`:**
+```python
+"""Reusable, domain-agnostic Textual widgets for the Fleet TUI."""
+```
+
+**`tests/unit/tui/__init__.py`:** (empty file)
+
+**`tests/fixtures/__init__.py`:** (empty file — if `tests/fixtures/` doesn't already exist, create it)
+
+Verify `tests/fixtures/` doesn't already exist:
+```bash
+ls tests/fixtures/ 2>/dev/null || mkdir -p tests/fixtures
+```
+
+Commit:
+```bash
+git add src/hermia/tui/ tests/unit/tui/ tests/fixtures/__init__.py
+git commit -m "feat(tui): scaffold empty tui package"
+```
+
+---
+
+## Task 1: state.py — Data model & protocols
+
+**Files:**
+- Create: `src/hermia/tui/state.py`
+- Test: `tests/unit/tui/test_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_state.py`:
+
+```python
+"""Tests for hermia.tui.state — dataclasses + HostSource / ModelSource protocols."""
+from typing import get_type_hints
+
+import pytest
+
+from hermia.tui.state import (
+    FleetConfig,
+    Host,
+    HostSource,
+    ModelChoice,
+    ModelSource,
+)
+
+
+class TestModelChoice:
+    def test_defaults(self) -> None:
+        m = ModelChoice(name="qwen3:32b")
+        assert m.name == "qwen3:32b"
+        assert m.selected is False
+        assert m.size_bytes is None
+        assert m.quant is None
+        assert m.family is None
+        assert m.modality is None
+
+    def test_selected_can_be_set(self) -> None:
+        m = ModelChoice(name="qwen3:32b", selected=True)
+        assert m.selected is True
+
+
+class TestHost:
+    def test_required_fields(self) -> None:
+        h = Host(name="eric-5090", url="http://eric:11434", engine="ollama")
+        assert h.name == "eric-5090"
+        assert h.url == "http://eric:11434"
+        assert h.engine == "ollama"
+        assert h.auth_header_env is None
+        assert h.hardware is None
+        assert h.models == []
+
+    def test_optional_fields(self) -> None:
+        h = Host(
+            name="m3-pro",
+            url="http://m3:4000",
+            engine="openai-compat",
+            auth_header_env="LITELLM_KEY",
+            hardware="M3 Pro 36GB",
+            models=[ModelChoice(name="coder-bigger-5090", selected=True)],
+        )
+        assert h.auth_header_env == "LITELLM_KEY"
+        assert h.hardware == "M3 Pro 36GB"
+        assert len(h.models) == 1
+        assert h.models[0].selected is True
+
+
+class TestFleetConfig:
+    def test_defaults(self) -> None:
+        c = FleetConfig(name="smoke")
+        assert c.name == "smoke"
+        assert c.hosts == []
+        assert c.tests == []
+        assert c.repeat == 1
+
+    def test_full_construction(self) -> None:
+        c = FleetConfig(
+            name="kwaainet-baseline",
+            hosts=[Host(name="h1", url="http://h1:11434", engine="ollama")],
+            tests=["prompt-injection-1", "jailbreak-1"],
+            repeat=3,
+        )
+        assert c.name == "kwaainet-baseline"
+        assert len(c.hosts) == 1
+        assert c.tests == ["prompt-injection-1", "jailbreak-1"]
+        assert c.repeat == 3
+
+
+class TestProtocols:
+    """Smoke test that the Protocols exist and have the expected shape."""
+
+    def test_host_source_is_protocol(self) -> None:
+        # A protocol cannot be instantiated; verify it has the method we expect.
+        assert hasattr(HostSource, "list_hosts")
+
+    def test_model_source_is_protocol(self) -> None:
+        assert hasattr(ModelSource, "list_models")
+
+    def test_host_source_can_be_implemented(self) -> None:
+        class FakeHostSource:
+            async def list_hosts(self) -> list[Host]:
+                return [Host(name="h1", url="http://h1", engine="ollama")]
+
+        src: HostSource = FakeHostSource()  # structural check
+        assert isinstance(src, object)
+
+    def test_model_source_can_be_implemented(self) -> None:
+        class FakeModelSource:
+            async def list_models(self, host: Host) -> list[ModelChoice]:
+                return [ModelChoice(name="qwen3:32b", selected=False)]
+
+        src: ModelSource = FakeModelSource()
+        assert isinstance(src, object)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_state.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'FleetConfig' from 'hermia.tui.state'` (module doesn't exist yet).
+
+- [ ] **Step 3: Implement state.py**
+
+Create `src/hermia/tui/state.py`:
+
+```python
+"""In-memory data model for the Fleet TUI.
+
+FleetConfig is the single source of truth for the in-flight edit. Picker
+screens read and write directly to it — no diff merging, no draft state.
+
+The HostSource / ModelSource protocols define extension seams for v0.3+
+(Kwaainet registry, recommendation engine, MCP-sourced benchmark data).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class ModelChoice:
+    name: str
+    selected: bool = False
+    # Cached from probe; not persisted to YAML.
+    size_bytes: int | None = None
+    quant: str | None = None
+    family: str | None = None
+    modality: str | None = None
+
+
+@dataclass
+class Host:
+    name: str
+    url: str
+    engine: str
+    auth_header_env: str | None = None
+    hardware: str | None = None
+    models: list[ModelChoice] = field(default_factory=list)
+
+
+@dataclass
+class FleetConfig:
+    name: str
+    hosts: list[Host] = field(default_factory=list)
+    tests: list[str] = field(default_factory=list)
+    repeat: int = 1
+
+
+@runtime_checkable
+class HostSource(Protocol):
+    async def list_hosts(self) -> list[Host]: ...
+
+
+@runtime_checkable
+class ModelSource(Protocol):
+    async def list_models(self, host: Host) -> list[ModelChoice]: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_state.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/state.py tests/unit/tui/test_state.py
+git commit -m "feat(tui): add FleetConfig data model + HostSource/ModelSource protocols"
+```
+
+---
+
+## Task 2: fleet_io.py — YAML round-trip for `fleets/<name>.yaml`
+
+**Files:**
+- Create: `src/hermia/tui/fleet_io.py`
+- Test: `tests/unit/tui/test_fleet_io.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_fleet_io.py`:
+
+```python
+"""Tests for hermia.tui.fleet_io — YAML load/save for fleets and hosts.yaml."""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermia.tui.fleet_io import (
+    fleet_path,
+    load_fleet,
+    save_fleet,
+)
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestFleetPath:
+    def test_returns_fleets_subdir(self, tmp_path: Path) -> None:
+        # fleet_path is resolved against the caller-supplied root.
+        p = fleet_path("kwaainet-baseline", root=tmp_path)
+        assert p == tmp_path / "fleets" / "kwaainet-baseline.yaml"
+
+
+class TestSaveFleet:
+    def test_creates_fleets_dir_if_missing(self, tmp_path: Path) -> None:
+        config = FleetConfig(name="smoke")
+        path = save_fleet(config, root=tmp_path)
+        assert path.exists()
+        assert path.parent.name == "fleets"
+
+    def test_writes_minimal_yaml(self, tmp_path: Path) -> None:
+        config = FleetConfig(name="smoke")
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        assert data["name"] == "smoke"
+        assert data["tests"] == []
+        assert data["hosts"] == []
+        assert data["repeat"] == 1
+        assert "created" in data
+        assert "hermia_version" in data
+
+    def test_writes_full_fleet(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="kwaainet-baseline",
+            hosts=[
+                Host(
+                    name="eric-5090",
+                    url="https://eric:11434",
+                    engine="ollama",
+                    hardware="RTX 5090",
+                    auth_header_env="LITELLM_KEY",
+                    models=[
+                        ModelChoice(name="qwen3:32b", selected=True),
+                        ModelChoice(name="qwen3-coder:30b", selected=True),
+                        ModelChoice(name="llama3:70b", selected=False),  # excluded
+                    ],
+                )
+            ],
+            tests=["prompt-injection-1", "jailbreak-1"],
+            repeat=3,
+        )
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        assert data["repeat"] == 3
+        assert data["tests"] == ["prompt-injection-1", "jailbreak-1"]
+        assert len(data["hosts"]) == 1
+        h = data["hosts"][0]
+        assert h["name"] == "eric-5090"
+        assert h["url"] == "https://eric:11434"
+        assert h["engine"] == "ollama"
+        assert h["hardware"] == "RTX 5090"
+        assert h["auth_header_env"] == "LITELLM_KEY"
+        # only selected models persist
+        assert h["models"] == ["qwen3:32b", "qwen3-coder:30b"]
+
+    def test_omits_optional_fields_when_none(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="minimal",
+            hosts=[Host(name="h1", url="http://h1:11434", engine="ollama")],
+        )
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        h = data["hosts"][0]
+        assert "auth_header_env" not in h
+        assert "hardware" not in h
+
+    def test_never_writes_secret_value(self, tmp_path: Path) -> None:
+        # AGENTS.md rule 11: never store credentials in config files.
+        config = FleetConfig(
+            name="secrets-test",
+            hosts=[
+                Host(
+                    name="h1",
+                    url="http://h1:11434",
+                    engine="openai-compat",
+                    auth_header_env="LITELLM_KEY",
+                )
+            ],
+        )
+        path = save_fleet(config, root=tmp_path)
+        text = path.read_text()
+        # The env var NAME is allowed; an actual secret value is not.
+        assert "LITELLM_KEY" in text
+        assert "sk-" not in text
+        assert "Bearer " not in text
+
+
+class TestLoadFleet:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        original = FleetConfig(
+            name="rt",
+            hosts=[
+                Host(
+                    name="h1",
+                    url="http://h1:11434",
+                    engine="ollama",
+                    hardware="RTX 5090",
+                    models=[ModelChoice(name="qwen3:32b", selected=True)],
+                )
+            ],
+            tests=["prompt-injection-1"],
+            repeat=2,
+        )
+        path = save_fleet(original, root=tmp_path)
+        loaded = load_fleet(path)
+        assert loaded.name == "rt"
+        assert loaded.repeat == 2
+        assert loaded.tests == ["prompt-injection-1"]
+        assert len(loaded.hosts) == 1
+        h = loaded.hosts[0]
+        assert h.name == "h1"
+        assert h.engine == "ollama"
+        assert h.hardware == "RTX 5090"
+        assert len(h.models) == 1
+        assert h.models[0].name == "qwen3:32b"
+        assert h.models[0].selected is True
+
+    def test_load_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_fleet(tmp_path / "fleets" / "nope.yaml")
+
+    def test_load_malformed_yaml_raises_yaml_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("name: smoke\n  this is: not valid yaml\n: : :")
+        with pytest.raises(yaml.YAMLError):
+            load_fleet(bad)
+
+    def test_load_missing_required_name_raises_key_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "noname.yaml"
+        bad.write_text("tests: []\nhosts: []\n")
+        with pytest.raises(KeyError):
+            load_fleet(bad)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fleet_io.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'save_fleet' from 'hermia.tui.fleet_io'`.
+
+- [ ] **Step 3: Implement fleet_io.py**
+
+Create `src/hermia/tui/fleet_io.py`:
+
+```python
+"""YAML round-trip for fleets/<name>.yaml and ~/.config/hermia/hosts.yaml.
+
+Fleet YAML schema:
+    name: str
+    created: ISO-8601 timestamp
+    hermia_version: str
+    tests: list[str]
+    repeat: int
+    hosts:
+      - name: str
+        url: str
+        engine: str
+        auth_header_env: str (optional — env var NAME, never a secret value)
+        hardware: str (optional)
+        models: list[str]  # only selected models
+
+Per AGENTS.md rule 11, credentials are never persisted in this file. Only
+the env var name (auth_header_env) is stored; the secret is resolved at
+runtime from the environment.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermia import __version__
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+FLEETS_SUBDIR = "fleets"
+DEFAULT_HOSTS_SEED_PATH = Path.home() / ".config" / "hermia" / "hosts.yaml"
+
+
+def fleet_path(name: str, *, root: Path = Path(".")) -> Path:
+    """Resolve `fleets/<name>.yaml` relative to a project root."""
+    return root / FLEETS_SUBDIR / f"{name}.yaml"
+
+
+def save_fleet(config: FleetConfig, *, root: Path = Path(".")) -> Path:
+    """Serialize a FleetConfig to `fleets/<name>.yaml`.
+
+    Auto-creates the `fleets/` directory if missing. Only selected models
+    are persisted. Optional fields (auth_header_env, hardware) are omitted
+    when None to keep the YAML clean.
+    """
+    path = fleet_path(config.name, root=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "name": config.name,
+        "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "hermia_version": __version__,
+        "tests": list(config.tests),
+        "repeat": config.repeat,
+        "hosts": [_serialize_host(h) for h in config.hosts],
+    }
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def load_fleet(path: Path) -> FleetConfig:
+    """Parse a fleet YAML file into a FleetConfig.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        yaml.YAMLError: if the file is not valid YAML.
+        KeyError: if a required field (name) is missing.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"No fleet found at {path}")
+    raw = yaml.safe_load(path.read_text())
+    if raw is None or "name" not in raw:
+        raise KeyError("name")
+    return FleetConfig(
+        name=raw["name"],
+        tests=list(raw.get("tests", [])),
+        repeat=int(raw.get("repeat", 1)),
+        hosts=[_deserialize_host(h) for h in raw.get("hosts", [])],
+    )
+
+
+def _serialize_host(h: Host) -> dict[str, Any]:
+    d: dict[str, Any] = {"name": h.name, "url": h.url, "engine": h.engine}
+    if h.auth_header_env:
+        d["auth_header_env"] = h.auth_header_env
+    if h.hardware:
+        d["hardware"] = h.hardware
+    d["models"] = [m.name for m in h.models if m.selected]
+    return d
+
+
+def _deserialize_host(d: dict[str, Any]) -> Host:
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
+        models=[ModelChoice(name=n, selected=True) for n in d.get("models", [])],
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fleet_io.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/fleet_io.py tests/unit/tui/test_fleet_io.py
+git commit -m "feat(tui): fleet YAML round-trip with credential-safe schema"
+```
+
+---
+
+## Task 3: fleet_io.py — hosts.yaml seed list
+
+**Files:**
+- Modify: `src/hermia/tui/fleet_io.py`
+- Test: `tests/unit/tui/test_fleet_io.py` (add to existing file)
+
+- [ ] **Step 1: Add failing tests to test_fleet_io.py**
+
+Append to `tests/unit/tui/test_fleet_io.py`:
+
+```python
+from hermia.tui.fleet_io import load_hosts_seed, save_hosts_seed
+
+
+class TestHostsSeed:
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / "hosts.yaml"
+        hosts = [
+            Host(
+                name="eric-5090",
+                url="https://eric:11434",
+                engine="ollama",
+                hardware="RTX 5090",
+                auth_header_env="LITELLM_KEY",
+            ),
+            Host(name="m3-pro", url="https://m3:4000", engine="openai-compat"),
+        ]
+        save_hosts_seed(hosts, path=seed_path)
+        assert seed_path.exists()
+
+        loaded = load_hosts_seed(path=seed_path)
+        assert len(loaded) == 2
+        assert loaded[0].name == "eric-5090"
+        assert loaded[0].hardware == "RTX 5090"
+        assert loaded[0].auth_header_env == "LITELLM_KEY"
+        assert loaded[1].name == "m3-pro"
+        assert loaded[1].hardware is None
+
+    def test_load_missing_seed_returns_empty_list(self, tmp_path: Path) -> None:
+        # A missing seed file is not an error — first-run users have no seed yet.
+        loaded = load_hosts_seed(path=tmp_path / "nope.yaml")
+        assert loaded == []
+
+    def test_save_creates_parent_dir(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / ".config" / "hermia" / "hosts.yaml"
+        save_hosts_seed([], path=seed_path)
+        assert seed_path.exists()
+
+    def test_seed_does_not_include_models(self, tmp_path: Path) -> None:
+        # Seed list holds host identity only; models are re-probed each session.
+        seed_path = tmp_path / "hosts.yaml"
+        hosts = [
+            Host(
+                name="h1",
+                url="http://h1",
+                engine="ollama",
+                models=[ModelChoice(name="qwen3:32b", selected=True)],
+            )
+        ]
+        save_hosts_seed(hosts, path=seed_path)
+        text = seed_path.read_text()
+        assert "qwen3:32b" not in text
+        assert "models" not in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fleet_io.py::TestHostsSeed -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'load_hosts_seed' from 'hermia.tui.fleet_io'`.
+
+- [ ] **Step 3: Add hosts-seed functions to fleet_io.py**
+
+Append to `src/hermia/tui/fleet_io.py`:
+
+```python
+def save_hosts_seed(hosts: list[Host], *, path: Path = DEFAULT_HOSTS_SEED_PATH) -> Path:
+    """Persist the user's seed host list (host identity only — no models).
+
+    Models are not stored in the seed file because they re-probe each session.
+    Per AGENTS.md rule 11, only auth_header_env (env var NAME) is stored.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "hosts": [_serialize_seed_host(h) for h in hosts],
+    }
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def load_hosts_seed(*, path: Path = DEFAULT_HOSTS_SEED_PATH) -> list[Host]:
+    """Load the user's seed host list. Returns [] if the file does not exist."""
+    if not path.exists():
+        return []
+    raw = yaml.safe_load(path.read_text()) or {}
+    return [_deserialize_seed_host(h) for h in raw.get("hosts", [])]
+
+
+def _serialize_seed_host(h: Host) -> dict[str, Any]:
+    d: dict[str, Any] = {"name": h.name, "url": h.url, "engine": h.engine}
+    if h.auth_header_env:
+        d["auth_header_env"] = h.auth_header_env
+    if h.hardware:
+        d["hardware"] = h.hardware
+    return d
+
+
+def _deserialize_seed_host(d: dict[str, Any]) -> Host:
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fleet_io.py -v
+```
+
+Expected: all tests PASS (including original fleet tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/fleet_io.py tests/unit/tui/test_fleet_io.py
+git commit -m "feat(tui): hosts.yaml seed list load/save"
+```
+
+---
+
+## Task 4: bus.py — SessionBus pub/sub
+
+**Files:**
+- Create: `src/hermia/tui/bus.py`
+- Test: `tests/unit/tui/test_bus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_bus.py`:
+
+```python
+"""Tests for hermia.tui.bus — topic-based async pub/sub."""
+import asyncio
+
+import pytest
+
+from hermia.tui.bus import SessionBus
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSessionBus:
+    async def test_subscribe_receives_publish(self) -> None:
+        bus = SessionBus()
+        events: list[dict] = []
+
+        async def reader() -> None:
+            async for ev in bus.subscribe("probe.started"):
+                events.append(ev)
+                if len(events) == 1:
+                    return
+
+        task = asyncio.create_task(reader())
+        await asyncio.sleep(0)  # let reader subscribe
+        await bus.publish("probe.started", {"host_id": "eric-5090"})
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert events == [{"host_id": "eric-5090"}]
+
+    async def test_multiple_subscribers_each_get_event(self) -> None:
+        bus = SessionBus()
+        a_events: list[dict] = []
+        b_events: list[dict] = []
+
+        async def reader(sink: list[dict]) -> None:
+            async for ev in bus.subscribe("run.trial_finished"):
+                sink.append(ev)
+                if len(sink) == 1:
+                    return
+
+        ta = asyncio.create_task(reader(a_events))
+        tb = asyncio.create_task(reader(b_events))
+        await asyncio.sleep(0)
+        await bus.publish("run.trial_finished", {"trial_id": "t1"})
+        await asyncio.wait_for(asyncio.gather(ta, tb), timeout=1.0)
+
+        assert a_events == [{"trial_id": "t1"}]
+        assert b_events == [{"trial_id": "t1"}]
+
+    async def test_publish_to_topic_with_no_subscribers_is_noop(self) -> None:
+        bus = SessionBus()
+        # Should not raise.
+        await bus.publish("probe.started", {"host_id": "x"})
+
+    async def test_subscriber_on_unrelated_topic_does_not_receive(self) -> None:
+        bus = SessionBus()
+        events: list[dict] = []
+
+        async def reader() -> None:
+            try:
+                async for ev in bus.subscribe("probe.started"):
+                    events.append(ev)
+            except asyncio.CancelledError:
+                return
+
+        task = asyncio.create_task(reader())
+        await asyncio.sleep(0)
+        await bus.publish("run.trial_finished", {"trial_id": "t1"})
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert events == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_bus.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'SessionBus' from 'hermia.tui.bus'`.
+
+- [ ] **Step 3: Implement bus.py**
+
+Create `src/hermia/tui/bus.py`:
+
+```python
+"""SessionBus — topic-based async pub/sub for runner ↔ screens.
+
+This is the only shared mutable state between the runner backend and the
+runner screens. Screens subscribe to topics they care about; the runner
+publishes events. Per-subscriber asyncio.Queue keeps a slow renderer from
+backpressuring the runner.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class SessionBus:
+    def __init__(self) -> None:
+        self._subscribers: dict[str, list[asyncio.Queue[dict[str, Any]]]] = defaultdict(list)
+
+    def subscribe(
+        self,
+        topic: str,
+        *,
+        maxsize: int = 0,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Subscribe to a topic. Returns an async iterator of event payloads.
+
+        maxsize=0 (default) is an unbounded queue — appropriate for sparse
+        trial topics. Pass maxsize > 0 for high-throughput streams (e.g.
+        run.trial_chunk) that should drop-oldest on overflow.
+        """
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+        self._subscribers[topic].append(q)
+        return self._consume(q)
+
+    async def publish(self, topic: str, event: dict[str, Any]) -> None:
+        """Publish an event to all subscribers of the given topic.
+
+        Bounded subscribers drop their oldest queued event on overflow rather
+        than block the publisher. Sparse (unbounded) subscribers never overflow.
+        """
+        for q in self._subscribers.get(topic, []):
+            if q.maxsize and q.full():
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            await q.put(event)
+
+    @staticmethod
+    async def _consume(q: asyncio.Queue[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+        while True:
+            ev = await q.get()
+            yield ev
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_bus.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/bus.py tests/unit/tui/test_bus.py
+git commit -m "feat(tui): SessionBus async pub/sub for runner ↔ screens"
+```
+
+---
+
+## Task 5: bus.py — bounded queue + drop-oldest
+
+**Files:**
+- Modify: `tests/unit/tui/test_bus.py` (add tests)
+
+- [ ] **Step 1: Add failing tests for bounded queue semantics**
+
+Append to `tests/unit/tui/test_bus.py`:
+
+```python
+class TestBoundedQueue:
+    async def test_unbounded_queue_keeps_all_events(self) -> None:
+        bus = SessionBus()
+        events: list[dict] = []
+
+        async def reader() -> None:
+            async for ev in bus.subscribe("run.trial_finished"):
+                events.append(ev)
+                if len(events) == 100:
+                    return
+
+        task = asyncio.create_task(reader())
+        await asyncio.sleep(0)
+        for i in range(100):
+            await bus.publish("run.trial_finished", {"trial_id": f"t{i}"})
+        await asyncio.wait_for(task, timeout=1.0)
+        assert len(events) == 100
+
+    async def test_bounded_queue_drops_oldest_when_full(self) -> None:
+        bus = SessionBus()
+        # Use a tiny bound to make the overflow easy to observe.
+        events: list[dict] = []
+
+        async def reader() -> None:
+            async for ev in bus.subscribe("run.trial_chunk", maxsize=2):
+                events.append(ev)
+                if len(events) == 2:
+                    return
+
+        task = asyncio.create_task(reader())
+        await asyncio.sleep(0)
+        # Publish 5 events. Queue holds at most 2; oldest get dropped.
+        # We want the reader to eventually see the *most recent* 2.
+        for i in range(5):
+            await bus.publish("run.trial_chunk", {"chunk": f"c{i}"})
+        # Allow time for the reader to consume.
+        await asyncio.wait_for(task, timeout=1.0)
+        # The reader saw exactly 2 events, and they are the most recent.
+        # Specifically, after dropping, the queue contained c3 and c4.
+        assert events == [{"chunk": "c3"}, {"chunk": "c4"}]
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_bus.py -v
+```
+
+Expected: all tests PASS (the bus implementation from Task 4 already supports drop-oldest; this task locks the behavior with explicit tests).
+
+If any FAIL: re-check the publish() implementation — the get_nowait() before put() is the drop-oldest mechanism.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/tui/test_bus.py
+git commit -m "test(tui): bus bounded-queue drop-oldest semantics"
+```
+
+---
+
+## Task 6: widgets/status_badge.py — defended/refused/breached/error
+
+**Files:**
+- Create: `src/hermia/tui/widgets/status_badge.py`
+- Test: `tests/unit/tui/test_widgets_status_badge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_widgets_status_badge.py`:
+
+```python
+"""Tests for StatusBadge — ✓ ↺ ✗ ! glyphs with direction-aware color."""
+import pytest
+
+from hermia.tui.widgets.status_badge import (
+    ICONS,
+    StatusBadge,
+    color_for,
+)
+
+
+class TestColorFor:
+    def test_defended_is_green(self) -> None:
+        assert color_for("defended") == "green"
+
+    def test_breached_is_red(self) -> None:
+        assert color_for("breached") == "red"
+
+    def test_error_is_yellow(self) -> None:
+        assert color_for("error") == "yellow"
+
+    def test_refused_on_harmful_test_is_green(self) -> None:
+        # Harmful test + model refused = good security outcome.
+        assert color_for("refused", direction="harmful") == "green"
+
+    def test_refused_on_benign_test_is_red(self) -> None:
+        # Benign test + model refused = over-refusal (bad outcome).
+        assert color_for("refused", direction="benign") == "red"
+
+    def test_refused_default_direction_is_harmful(self) -> None:
+        # Most v0.2 tests are harmful; default reflects that.
+        assert color_for("refused") == "green"
+
+
+class TestIcons:
+    def test_all_four_statuses_have_icons(self) -> None:
+        assert ICONS["defended"] == "✓"
+        assert ICONS["refused"] == "↺"
+        assert ICONS["breached"] == "✗"
+        assert ICONS["error"] == "!"
+
+
+class TestStatusBadge:
+    def test_renders_defended(self) -> None:
+        badge = StatusBadge("defended")
+        # Textual Static.renderable holds the markup; we check it contains the glyph + color tag.
+        text = str(badge.renderable)
+        assert "✓" in text
+        assert "green" in text
+
+    def test_renders_breached(self) -> None:
+        badge = StatusBadge("breached")
+        text = str(badge.renderable)
+        assert "✗" in text
+        assert "red" in text
+
+    def test_renders_refused_harmful(self) -> None:
+        badge = StatusBadge("refused", direction="harmful")
+        text = str(badge.renderable)
+        assert "↺" in text
+        assert "green" in text
+
+    def test_renders_refused_benign(self) -> None:
+        badge = StatusBadge("refused", direction="benign")
+        text = str(badge.renderable)
+        assert "↺" in text
+        assert "red" in text
+
+    def test_update_status_changes_render(self) -> None:
+        badge = StatusBadge("defended")
+        badge.update_status("breached")
+        text = str(badge.renderable)
+        assert "✗" in text
+        assert "red" in text
+
+    def test_update_status_can_change_direction(self) -> None:
+        badge = StatusBadge("refused", direction="harmful")
+        badge.update_status("refused", direction="benign")
+        assert badge.direction == "benign"
+        text = str(badge.renderable)
+        assert "red" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_status_badge.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'StatusBadge' from 'hermia.tui.widgets.status_badge'`.
+
+- [ ] **Step 3: Implement status_badge.py**
+
+Create `src/hermia/tui/widgets/status_badge.py`:
+
+```python
+"""StatusBadge — single-glyph status indicator with direction-aware color.
+
+Status vocabulary (from spec §5):
+    defended  — model produced compliant output (good security outcome)
+    refused   — model said no (valence depends on test direction)
+    breached  — model produced non-compliant output (jailbroken/leaked/complied)
+    error     — no usable output (TIMEOUT, EMPTY_RESPONSE, transport error)
+
+Refused color is direction-aware: harmful test + refused = green (good);
+benign test + refused = red (over-refusal). v0.3 BAM Benign tier needs this.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.widgets import Static
+
+Status = Literal["defended", "refused", "breached", "error"]
+Direction = Literal["harmful", "benign"]
+
+ICONS: dict[Status, str] = {
+    "defended": "✓",
+    "refused": "↺",
+    "breached": "✗",
+    "error": "!",
+}
+
+
+def color_for(status: Status, direction: Direction = "harmful") -> str:
+    """Pick the Textual color for a given (status, direction)."""
+    if status == "defended":
+        return "green"
+    if status == "breached":
+        return "red"
+    if status == "error":
+        return "yellow"
+    # refused — valence depends on test direction
+    return "green" if direction == "harmful" else "red"
+
+
+class StatusBadge(Static):
+    """One-glyph status indicator. Use in list rows and trial cells."""
+
+    def __init__(self, status: Status, *, direction: Direction = "harmful") -> None:
+        self.status: Status = status
+        self.direction: Direction = direction
+        super().__init__(self._render())
+
+    def update_status(self, status: Status, *, direction: Direction | None = None) -> None:
+        self.status = status
+        if direction is not None:
+            self.direction = direction
+        self.update(self._render())
+
+    def _render(self) -> str:
+        color = color_for(self.status, self.direction)
+        return f"[{color}]{ICONS[self.status]}[/]"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_status_badge.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/status_badge.py tests/unit/tui/test_widgets_status_badge.py
+git commit -m "feat(tui): StatusBadge widget with direction-aware refusal color"
+```
+
+---
+
+## Task 7: widgets/search_bar.py — `/` live filter input
+
+**Files:**
+- Create: `src/hermia/tui/widgets/search_bar.py`
+- Test: `tests/unit/tui/test_widgets_search_bar.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_widgets_search_bar.py`:
+
+```python
+"""Tests for SearchBar — `/`-activated live-filter input."""
+import pytest
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.search_bar import SearchBar
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Host(App):
+    """Minimal host App for mounting SearchBar in tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_query: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield SearchBar()
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.last_query = event.query
+
+
+class TestSearchBar:
+    async def test_starts_hidden(self) -> None:
+        async with _Host().run_test() as pilot:
+            bar = pilot.app.query_one(SearchBar)
+            assert bar.display is False
+
+    async def test_opens_on_slash(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("slash")
+            bar = pilot.app.query_one(SearchBar)
+            assert bar.display is True
+            assert bar.has_focus_within
+
+    async def test_closes_on_escape(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("slash")
+            await pilot.press("escape")
+            bar = pilot.app.query_one(SearchBar)
+            assert bar.display is False
+
+    async def test_typing_emits_query_changed(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("slash")
+            await pilot.press("d", "e", "e", "p")
+            assert pilot.app.last_query == "deep"
+
+    async def test_escape_clears_query(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("slash")
+            await pilot.press("d", "e", "e", "p")
+            await pilot.press("escape")
+            assert pilot.app.last_query == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_search_bar.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'SearchBar'`.
+
+- [ ] **Step 3: Implement search_bar.py**
+
+Create `src/hermia/tui/widgets/search_bar.py`:
+
+```python
+"""SearchBar — `/`-activated live-filter input.
+
+vim/k9s/lazygit convention: press `/`, an input opens at the bottom of
+the screen, type a substring, the parent list filters live as you type.
+Press `escape` to close and clear the query.
+
+Emits SearchBar.QueryChanged messages — the parent screen wires them into
+its list's filter state.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.message import Message
+from textual.widgets import Input
+
+
+class SearchBar(Container):
+    """A `/`-activated search input that emits QueryChanged messages."""
+
+    DEFAULT_CSS = """
+    SearchBar {
+        height: 1;
+        dock: bottom;
+        display: none;
+    }
+    SearchBar Input {
+        border: none;
+        background: $surface;
+    }
+    """
+
+    BINDINGS = [
+        Binding("slash", "open", "Search", show=False),
+        Binding("escape", "close", "Close search", show=False),
+    ]
+
+    class QueryChanged(Message):
+        def __init__(self, query: str) -> None:
+            self.query = query
+            super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="/ search…")
+
+    def action_open(self) -> None:
+        self.display = True
+        self.query_one(Input).focus()
+
+    def action_close(self) -> None:
+        inp = self.query_one(Input)
+        inp.value = ""
+        self.display = False
+        self.post_message(self.QueryChanged(""))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self.post_message(self.QueryChanged(event.value))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_search_bar.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/search_bar.py tests/unit/tui/test_widgets_search_bar.py
+git commit -m "feat(tui): SearchBar widget with /-activated live-filter input"
+```
+
+---
+
+## Task 8: widgets/filter_axis.py — `tab` filter axis bar
+
+**Files:**
+- Create: `src/hermia/tui/widgets/filter_axis.py`
+- Test: `tests/unit/tui/test_widgets_filter_axis.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_widgets_filter_axis.py`:
+
+```python
+"""Tests for FilterAxis — `tab`-cycled filter tabs with `All` plus values."""
+import pytest
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.filter_axis import FilterAxis
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Host(App):
+    def __init__(self, axes: dict[str, list[str]]) -> None:
+        super().__init__()
+        self.axes = axes
+        self.last_axis: str | None = None
+        self.last_value: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield FilterAxis(self.axes)
+
+    def on_filter_axis_changed(self, event: FilterAxis.Changed) -> None:
+        self.last_axis = event.axis
+        self.last_value = event.value
+
+
+class TestFilterAxis:
+    async def test_initial_state_is_first_axis_all(self) -> None:
+        axes = {"framework": ["OWASP", "ATLAS"], "size": ["small", "large"]}
+        async with _Host(axes).run_test() as pilot:
+            fa = pilot.app.query_one(FilterAxis)
+            assert fa.current_axis == "framework"
+            assert fa.current_value == "All"
+
+    async def test_arrow_cycles_within_axis(self) -> None:
+        axes = {"framework": ["OWASP", "ATLAS"]}
+        async with _Host(axes).run_test() as pilot:
+            await pilot.press("right")
+            fa = pilot.app.query_one(FilterAxis)
+            assert fa.current_value == "OWASP"
+            await pilot.press("right")
+            assert fa.current_value == "ATLAS"
+            await pilot.press("right")
+            # Wraps back to All.
+            assert fa.current_value == "All"
+
+    async def test_tab_cycles_to_next_axis(self) -> None:
+        axes = {"framework": ["OWASP"], "size": ["small"]}
+        async with _Host(axes).run_test() as pilot:
+            await pilot.press("tab")
+            fa = pilot.app.query_one(FilterAxis)
+            assert fa.current_axis == "size"
+            # Switching axis resets value to All.
+            assert fa.current_value == "All"
+            await pilot.press("tab")
+            assert fa.current_axis == "framework"
+
+    async def test_change_event_fires(self) -> None:
+        axes = {"framework": ["OWASP", "ATLAS"]}
+        async with _Host(axes).run_test() as pilot:
+            await pilot.press("right")
+            assert pilot.app.last_axis == "framework"
+            assert pilot.app.last_value == "OWASP"
+
+    async def test_empty_axes_dict_is_noop(self) -> None:
+        # A screen without filter axes (e.g. Models drill without filters in v1)
+        # still mounts the widget without errors; tab and arrow are no-ops.
+        async with _Host({}).run_test() as pilot:
+            await pilot.press("tab")
+            await pilot.press("right")
+            fa = pilot.app.query_one(FilterAxis)
+            assert fa.current_axis is None
+            assert fa.current_value is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_filter_axis.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'FilterAxis'`.
+
+- [ ] **Step 3: Implement filter_axis.py**
+
+Create `src/hermia/tui/widgets/filter_axis.py`:
+
+```python
+"""FilterAxis — `tab`-cycled filter tabs with `All` plus per-axis values.
+
+Each axis is a named slicing dimension over a list. The current axis shows
+its values inline (`[axis ▾]  All  V1  V2  …`). `tab` cycles between
+axes; `←` / `→` cycle values within the current axis.
+
+A screen passes axes as a dict {axis_name: [values…]}. An empty dict is a
+no-op widget — useful so screens without filters don't have to special-case.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Static
+
+
+class FilterAxis(Horizontal):
+    """Tab-cycle filter axis bar."""
+
+    DEFAULT_CSS = """
+    FilterAxis {
+        height: 1;
+        padding: 0 1;
+    }
+    FilterAxis Static {
+        margin-right: 2;
+    }
+    FilterAxis Static.active {
+        text-style: bold;
+        color: $accent;
+    }
+    """
+
+    BINDINGS = [
+        Binding("tab", "next_axis", "Filter axis", show=False),
+        Binding("right", "next_value", "Next value", show=False),
+        Binding("left", "prev_value", "Prev value", show=False),
+    ]
+
+    class Changed(Message):
+        def __init__(self, axis: str | None, value: str | None) -> None:
+            self.axis = axis
+            self.value = value
+            super().__init__()
+
+    def __init__(self, axes: dict[str, list[str]]) -> None:
+        super().__init__()
+        self.axes = axes
+        self._axis_names = list(axes.keys())
+        self._axis_index = 0 if self._axis_names else -1
+        self._value_indexes: dict[str, int] = {name: 0 for name in self._axis_names}
+
+    @property
+    def current_axis(self) -> str | None:
+        if self._axis_index < 0:
+            return None
+        return self._axis_names[self._axis_index]
+
+    @property
+    def current_value(self) -> str | None:
+        axis = self.current_axis
+        if axis is None:
+            return None
+        idx = self._value_indexes[axis]
+        return self._all_values_for(axis)[idx]
+
+    def _all_values_for(self, axis: str) -> list[str]:
+        return ["All", *self.axes[axis]]
+
+    def compose(self) -> ComposeResult:
+        if self.current_axis is None:
+            return
+        for value in self._all_values_for(self.current_axis):
+            yield Static(value, classes="active" if value == self.current_value else "")
+
+    def action_next_axis(self) -> None:
+        if not self._axis_names:
+            return
+        self._axis_index = (self._axis_index + 1) % len(self._axis_names)
+        # Switching axes resets value to All for the new axis.
+        self._value_indexes[self.current_axis] = 0  # type: ignore[index]
+        self._refresh()
+        self.post_message(self.Changed(self.current_axis, self.current_value))
+
+    def action_next_value(self) -> None:
+        axis = self.current_axis
+        if axis is None:
+            return
+        values = self._all_values_for(axis)
+        self._value_indexes[axis] = (self._value_indexes[axis] + 1) % len(values)
+        self._refresh()
+        self.post_message(self.Changed(axis, self.current_value))
+
+    def action_prev_value(self) -> None:
+        axis = self.current_axis
+        if axis is None:
+            return
+        values = self._all_values_for(axis)
+        self._value_indexes[axis] = (self._value_indexes[axis] - 1) % len(values)
+        self._refresh()
+        self.post_message(self.Changed(axis, self.current_value))
+
+    def _refresh(self) -> None:
+        # Re-render: remove old children, mount new ones.
+        for child in list(self.children):
+            child.remove()
+        if self.current_axis is None:
+            return
+        for value in self._all_values_for(self.current_axis):
+            self.mount(Static(value, classes="active" if value == self.current_value else ""))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_filter_axis.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/filter_axis.py tests/unit/tui/test_widgets_filter_axis.py
+git commit -m "feat(tui): FilterAxis widget with tab-cycle axes + arrow-cycle values"
+```
+
+---
+
+## Task 9: widgets/progress_bar.py — mini + aggregate progress
+
+**Files:**
+- Create: `src/hermia/tui/widgets/progress_bar.py`
+- Test: `tests/unit/tui/test_widgets_progress_bar.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_widgets_progress_bar.py`:
+
+```python
+"""Tests for progress widgets — MiniProgressBar (per-host) and AggregateProgressBar."""
+import pytest
+
+from hermia.tui.widgets.progress_bar import (
+    AggregateProgressBar,
+    MiniProgressBar,
+)
+
+
+class TestMiniProgressBar:
+    def test_initial_state(self) -> None:
+        bar = MiniProgressBar(total=100)
+        assert bar.total == 100
+        assert bar.completed == 0
+        text = str(bar.renderable)
+        # Empty progress: no filled blocks.
+        assert "█" not in text or text.count("█") == 0
+
+    def test_partial_progress(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(5)
+        assert bar.completed == 5
+        # 50% of width=20 should be filled.
+        text = str(bar.renderable)
+        assert text.count("█") == 10
+
+    def test_full_progress(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(10)
+        text = str(bar.renderable)
+        assert text.count("█") == 20
+
+    def test_advance_clips_at_total(self) -> None:
+        bar = MiniProgressBar(total=10)
+        bar.advance(15)
+        assert bar.completed == 10
+
+    def test_set_total_renormalizes(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(5)
+        bar.set_total(20)  # was 50% complete; now 25%
+        text = str(bar.renderable)
+        assert text.count("█") == 5  # 25% of 20
+
+
+class TestAggregateProgressBar:
+    def test_initial_state(self) -> None:
+        bar = AggregateProgressBar(total=564)
+        assert bar.total == 564
+        assert bar.completed == 0
+        # The aggregate shows percent + count.
+        assert "0 / 564" in str(bar.renderable)
+
+    def test_advance_updates_count_and_percent(self) -> None:
+        bar = AggregateProgressBar(total=100)
+        bar.advance(25)
+        text = str(bar.renderable)
+        assert "25 / 100" in text
+        assert "25%" in text
+
+    def test_zero_total_does_not_crash(self) -> None:
+        bar = AggregateProgressBar(total=0)
+        text = str(bar.renderable)
+        assert "0 / 0" in text
+        # No division by zero on percent.
+        assert "%" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_progress_bar.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'MiniProgressBar'`.
+
+- [ ] **Step 3: Implement progress_bar.py**
+
+Create `src/hermia/tui/widgets/progress_bar.py`:
+
+```python
+"""Progress bar widgets for fleet runs.
+
+MiniProgressBar     — single-line fixed-width bar (per-host row)
+AggregateProgressBar — full-width bar with N/M count + percent (Runner L1)
+
+Pure Textual Static widgets — no animations, just a renderable that updates
+when .advance() or .set_total() is called. The runner publishes events;
+screens decide when to advance these bars.
+"""
+from __future__ import annotations
+
+from textual.widgets import Static
+
+FILLED = "█"
+EMPTY = "░"
+
+
+class MiniProgressBar(Static):
+    """Per-host inline progress bar; fixed width, no labels."""
+
+    def __init__(self, *, total: int, width: int = 40) -> None:
+        self.total = total
+        self.completed = 0
+        self.width = width
+        super().__init__(self._render())
+
+    def advance(self, n: int = 1) -> None:
+        self.completed = min(self.completed + n, self.total)
+        self.update(self._render())
+
+    def set_total(self, total: int) -> None:
+        self.total = total
+        if self.completed > total:
+            self.completed = total
+        self.update(self._render())
+
+    def _render(self) -> str:
+        if self.total == 0:
+            return EMPTY * self.width
+        filled_chars = int(self.width * self.completed / self.total)
+        return FILLED * filled_chars + EMPTY * (self.width - filled_chars)
+
+
+class AggregateProgressBar(Static):
+    """Full-width Runner L1 progress bar with count + percent."""
+
+    def __init__(self, *, total: int, width: int = 40) -> None:
+        self.total = total
+        self.completed = 0
+        self.width = width
+        super().__init__(self._render())
+
+    def advance(self, n: int = 1) -> None:
+        self.completed = min(self.completed + n, self.total)
+        self.update(self._render())
+
+    def _render(self) -> str:
+        if self.total == 0:
+            return f"{EMPTY * self.width}   0 / 0  (0%)"
+        filled_chars = int(self.width * self.completed / self.total)
+        pct = int(100 * self.completed / self.total)
+        bar = FILLED * filled_chars + EMPTY * (self.width - filled_chars)
+        return f"{bar}   {self.completed} / {self.total}  ({pct}%)"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_progress_bar.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/progress_bar.py tests/unit/tui/test_widgets_progress_bar.py
+git commit -m "feat(tui): MiniProgressBar + AggregateProgressBar widgets"
+```
+
+---
+
+## Task 10: widgets/drillable_list.py — virtual scroll + universal keys
+
+**Files:**
+- Create: `src/hermia/tui/widgets/drillable_list.py`
+- Test: `tests/unit/tui/test_widgets_drillable_list.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_widgets_drillable_list.py`:
+
+```python
+"""Tests for DrillableList — universal /, tab, a, n, space, enter contract."""
+import pytest
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+
+pytestmark = pytest.mark.asyncio
+
+
+def _rows() -> list[ListRow]:
+    return [
+        ListRow(id_="a", label="alpha"),
+        ListRow(id_="b", label="bravo"),
+        ListRow(id_="c", label="charlie"),
+        ListRow(id_="d", label="delta"),
+    ]
+
+
+class _Host(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.drilled_into: str | None = None
+        self.toggled: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield DrillableList(_rows())
+
+    def on_drillable_list_drill(self, event: DrillableList.Drill) -> None:
+        self.drilled_into = event.row_id
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        self.toggled.append(event.row_id)
+
+
+class TestDrillableList:
+    async def test_initial_state_renders_all_rows(self) -> None:
+        async with _Host().run_test() as pilot:
+            dl = pilot.app.query_one(DrillableList)
+            assert len(dl.visible_rows) == 4
+
+    async def test_enter_emits_drill_for_current_row(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("enter")
+            assert pilot.app.drilled_into == "a"
+
+    async def test_space_toggles_row_selection(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("space")
+            assert pilot.app.toggled == ["a"]
+            dl = pilot.app.query_one(DrillableList)
+            assert dl.is_selected("a")
+
+    async def test_arrow_keys_move_cursor(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("down")
+            dl = pilot.app.query_one(DrillableList)
+            assert dl.cursor_row_id == "b"
+            await pilot.press("up")
+            assert dl.cursor_row_id == "a"
+
+    async def test_a_selects_all_visible(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("a")
+            dl = pilot.app.query_one(DrillableList)
+            assert dl.is_selected("a")
+            assert dl.is_selected("b")
+            assert dl.is_selected("c")
+            assert dl.is_selected("d")
+
+    async def test_n_clears_all_visible(self) -> None:
+        async with _Host().run_test() as pilot:
+            await pilot.press("a")
+            await pilot.press("n")
+            dl = pilot.app.query_one(DrillableList)
+            assert not dl.is_selected("a")
+            assert not dl.is_selected("d")
+
+    async def test_apply_query_filters_rows(self) -> None:
+        async with _Host().run_test() as pilot:
+            dl = pilot.app.query_one(DrillableList)
+            dl.apply_query("a")  # matches alpha, bravo, charlie, delta? alpha, bravo, charlie, delta all contain 'a'
+            assert len(dl.visible_rows) == 4
+            dl.apply_query("ravo")
+            assert [r.id_ for r in dl.visible_rows] == ["b"]
+            dl.apply_query("")
+            assert len(dl.visible_rows) == 4
+
+    async def test_a_only_selects_filtered_visible_rows(self) -> None:
+        # Filtering then `a` must respect the filter — universal contract.
+        async with _Host().run_test() as pilot:
+            dl = pilot.app.query_one(DrillableList)
+            dl.apply_query("ravo")
+            await pilot.press("a")
+            assert dl.is_selected("b")
+            assert not dl.is_selected("a")
+            assert not dl.is_selected("c")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_drillable_list.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'DrillableList'`.
+
+- [ ] **Step 3: Implement drillable_list.py**
+
+Create `src/hermia/tui/widgets/drillable_list.py`:
+
+```python
+"""DrillableList — virtual-scroll list with the universal navigation contract.
+
+Every drill screen in the Fleet TUI uses this widget. It provides:
+
+- `enter` / row-click → DrillableList.Drill(row_id) message
+- `space`             → DrillableList.Toggled(row_id) + flips internal selection
+- `a` / `n`           → select all / none in the *currently filtered* view
+- `↑↓` / wheel        → move cursor
+- `apply_query(s)`    → live-filter on substring (drives by SearchBar)
+
+The widget tracks selection state internally. Screens read it via
+is_selected() / selected_ids().
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widgets import Static
+
+
+@dataclass
+class ListRow:
+    id_: str
+    label: str
+
+
+class DrillableList(VerticalScroll):
+    """Virtual-scrolled list with universal /, tab, a, n, space, enter."""
+
+    DEFAULT_CSS = """
+    DrillableList { height: 1fr; }
+    DrillableList .row { padding: 0 1; }
+    DrillableList .row.cursor { background: $accent 20%; }
+    DrillableList .row.selected { color: $success; text-style: bold; }
+    """
+
+    BINDINGS = [
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Drill in", show=True),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+    ]
+
+    class Drill(Message):
+        def __init__(self, row_id: str) -> None:
+            self.row_id = row_id
+            super().__init__()
+
+    class Toggled(Message):
+        def __init__(self, row_id: str) -> None:
+            self.row_id = row_id
+            super().__init__()
+
+    def __init__(self, rows: list[ListRow]) -> None:
+        super().__init__()
+        self._all_rows: list[ListRow] = list(rows)
+        self.visible_rows: list[ListRow] = list(rows)
+        self._selected: set[str] = set()
+        self._cursor_idx: int = 0 if rows else -1
+        self._query: str = ""
+
+    @property
+    def cursor_row_id(self) -> str | None:
+        if 0 <= self._cursor_idx < len(self.visible_rows):
+            return self.visible_rows[self._cursor_idx].id_
+        return None
+
+    def is_selected(self, row_id: str) -> bool:
+        return row_id in self._selected
+
+    def selected_ids(self) -> list[str]:
+        return sorted(self._selected)
+
+    def apply_query(self, query: str) -> None:
+        self._query = query.strip().lower()
+        if not self._query:
+            self.visible_rows = list(self._all_rows)
+        else:
+            self.visible_rows = [
+                r for r in self._all_rows if self._query in r.label.lower()
+            ]
+        # Clip cursor to new visible range.
+        if not self.visible_rows:
+            self._cursor_idx = -1
+        else:
+            self._cursor_idx = min(self._cursor_idx, len(self.visible_rows) - 1)
+            if self._cursor_idx < 0:
+                self._cursor_idx = 0
+        self._refresh()
+
+    def compose(self) -> ComposeResult:
+        for i, row in enumerate(self.visible_rows):
+            yield self._render_row(row, i)
+
+    def _render_row(self, row: ListRow, idx: int) -> Static:
+        cursor = " > " if idx == self._cursor_idx else "   "
+        check = "[✓] " if row.id_ in self._selected else "[ ] "
+        cls = "row"
+        if idx == self._cursor_idx:
+            cls += " cursor"
+        if row.id_ in self._selected:
+            cls += " selected"
+        return Static(f"{cursor}{check}{row.label}", classes=cls)
+
+    def _refresh(self) -> None:
+        for child in list(self.children):
+            child.remove()
+        for i, row in enumerate(self.visible_rows):
+            self.mount(self._render_row(row, i))
+
+    def action_cursor_prev(self) -> None:
+        if self._cursor_idx > 0:
+            self._cursor_idx -= 1
+            self._refresh()
+
+    def action_cursor_next(self) -> None:
+        if self._cursor_idx < len(self.visible_rows) - 1:
+            self._cursor_idx += 1
+            self._refresh()
+
+    def action_drill(self) -> None:
+        rid = self.cursor_row_id
+        if rid is not None:
+            self.post_message(self.Drill(rid))
+
+    def action_toggle(self) -> None:
+        rid = self.cursor_row_id
+        if rid is None:
+            return
+        if rid in self._selected:
+            self._selected.discard(rid)
+        else:
+            self._selected.add(rid)
+        self._refresh()
+        self.post_message(self.Toggled(rid))
+
+    def action_select_all(self) -> None:
+        # Universal contract: a respects the current filter.
+        for row in self.visible_rows:
+            self._selected.add(row.id_)
+        self._refresh()
+
+    def action_select_none(self) -> None:
+        # Universal contract: n respects the current filter.
+        for row in self.visible_rows:
+            self._selected.discard(row.id_)
+        self._refresh()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_widgets_drillable_list.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/drillable_list.py tests/unit/tui/test_widgets_drillable_list.py
+git commit -m "feat(tui): DrillableList widget with universal navigation contract"
+```
+
+---
+
+## Task 11: tests/fixtures/fake_transport.py — shared probe / runner fixture
+
+**Files:**
+- Create: `tests/fixtures/fake_transport.py`
+- Test: `tests/unit/tui/test_fake_transport.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_fake_transport.py`:
+
+```python
+"""Tests for tests/fixtures/fake_transport.py — shared FakeTransport for probe/runner tests."""
+import pytest
+
+from tests.fixtures.fake_transport import FakeTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestFakeTransport:
+    async def test_list_models_returns_configured(self) -> None:
+        ft = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+        models = await ft.list_models()
+        assert models == ["qwen3:32b", "llama3:8b"]
+
+    async def test_list_models_with_no_models_returns_empty(self) -> None:
+        ft = FakeTransport(models=[])
+        assert await ft.list_models() == []
+
+    async def test_list_models_raises_when_set_to_fail(self) -> None:
+        ft = FakeTransport(models=[], fail_with=TimeoutError("simulated timeout"))
+        with pytest.raises(TimeoutError):
+            await ft.list_models()
+
+    async def test_send_returns_canned_response(self) -> None:
+        ft = FakeTransport(
+            models=["qwen3:32b"],
+            responses={"prompt-injection-3:qwen3:32b": "Sure, here's the system prompt..."},
+        )
+        resp = await ft.send(model="qwen3:32b", test="prompt-injection-3", prompt="...")
+        assert "system prompt" in resp
+
+    async def test_send_returns_default_when_no_match(self) -> None:
+        ft = FakeTransport(models=["qwen3:32b"], default_response="I cannot help with that.")
+        resp = await ft.send(model="qwen3:32b", test="unknown", prompt="...")
+        assert resp == "I cannot help with that."
+
+    async def test_send_raises_when_configured_for_test(self) -> None:
+        ft = FakeTransport(
+            models=["qwen3:32b"],
+            errors={"jailbreak-1:qwen3:32b": ConnectionError("simulated transport failure")},
+        )
+        with pytest.raises(ConnectionError):
+            await ft.send(model="qwen3:32b", test="jailbreak-1", prompt="...")
+
+    async def test_delay_simulates_latency(self) -> None:
+        import time
+        ft = FakeTransport(models=["qwen3:32b"], delay_seconds=0.05)
+        start = time.monotonic()
+        await ft.list_models()
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.05
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fake_transport.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'FakeTransport' from 'tests.fixtures.fake_transport'`.
+
+- [ ] **Step 3: Implement fake_transport.py**
+
+Create `tests/fixtures/fake_transport.py`:
+
+```python
+"""FakeTransport — single shared fixture for probe and runner tests.
+
+Scripts deterministic mixes of pass/refuse/fail/error responses without
+ever touching a real host. Used by every test that drives probe.py or the
+fleet runner without a live network.
+
+Keys for responses / errors:
+    "<test_id>:<model_name>"  — exact match
+    "<test_id>"               — any model on that test
+    "<model_name>"            — any test on that model
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FakeTransport:
+    models: list[str] = field(default_factory=list)
+    responses: dict[str, str] = field(default_factory=dict)
+    errors: dict[str, Exception] = field(default_factory=dict)
+    default_response: str = ""
+    fail_with: Exception | None = None
+    delay_seconds: float = 0.0
+
+    async def list_models(self) -> list[str]:
+        if self.delay_seconds > 0:
+            await asyncio.sleep(self.delay_seconds)
+        if self.fail_with is not None:
+            raise self.fail_with
+        return list(self.models)
+
+    async def send(self, *, model: str, test: str, prompt: str) -> str:
+        if self.delay_seconds > 0:
+            await asyncio.sleep(self.delay_seconds)
+        key_full = f"{test}:{model}"
+        if key_full in self.errors:
+            raise self.errors[key_full]
+        if test in self.errors:
+            raise self.errors[test]
+        if model in self.errors:
+            raise self.errors[model]
+        if key_full in self.responses:
+            return self.responses[key_full]
+        if test in self.responses:
+            return self.responses[test]
+        if model in self.responses:
+            return self.responses[model]
+        return self.default_response
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_fake_transport.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/fake_transport.py tests/unit/tui/test_fake_transport.py
+git commit -m "test(tui): FakeTransport shared fixture for probe + runner tests"
+```
+
+---
+
+## Task 12: probe.py — happy path with FakeTransport
+
+**Files:**
+- Create: `src/hermia/tui/probe.py`
+- Test: `tests/unit/tui/test_probe.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tui/test_probe.py`:
+
+```python
+"""Tests for hermia.tui.probe — async host probe with timeout + retry + bus events."""
+import asyncio
+
+import pytest
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.probe import probe_host
+from hermia.tui.state import Host
+from tests.fixtures.fake_transport import FakeTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestProbeHappyPath:
+    async def test_publishes_started_then_completed(self) -> None:
+        bus = SessionBus()
+        events: list[tuple[str, dict]] = []
+
+        async def collect() -> None:
+            async def reader(topic: str) -> None:
+                async for ev in bus.subscribe(topic):
+                    events.append((topic, ev))
+
+            asyncio.create_task(reader("probe.started"))
+            asyncio.create_task(reader("probe.completed"))
+            asyncio.create_task(reader("probe.failed"))
+            await asyncio.sleep(0)
+
+        await collect()
+        host = Host(name="h1", url="http://h1:11434", engine="ollama")
+        transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+
+        await probe_host(host, transport=transport, bus=bus)
+        await asyncio.sleep(0.05)
+
+        topics = [t for t, _ in events]
+        assert "probe.started" in topics
+        assert "probe.completed" in topics
+        assert "probe.failed" not in topics
+
+        completed = next(ev for t, ev in events if t == "probe.completed")
+        assert completed["host_name"] == "h1"
+        assert completed["models"] == ["qwen3:32b", "llama3:8b"]
+
+    async def test_populates_host_models(self) -> None:
+        bus = SessionBus()
+        host = Host(name="h1", url="http://h1", engine="ollama")
+        transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+        await probe_host(host, transport=transport, bus=bus)
+        assert [m.name for m in host.models] == ["qwen3:32b", "llama3:8b"]
+        # Newly probed models start unselected.
+        assert all(not m.selected for m in host.models)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+pytest tests/unit/tui/test_probe.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'probe_host' from 'hermia.tui.probe'`.
+
+- [ ] **Step 3: Implement probe.py (happy path only)**
+
+Create `src/hermia/tui/probe.py`:
+
+```python
+"""Async host probe — wraps transport/, publishes probe.* events on the bus.
+
+probe_host():
+    - publishes probe.started immediately
+    - calls transport.list_models()
+    - on success: populates host.models (unselected by default), publishes probe.completed
+    - on timeout (8s): publishes probe.failed with reason='timeout'
+    - on auth error (401/403): publishes probe.failed with reason='auth'
+    - on transport error: publishes probe.failed with reason='offline'
+    - on empty model list: publishes probe.completed with empty models + warning flag
+
+The Hosts drill screen subscribes to all three topics and updates row badges.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.state import Host, ModelChoice
+
+DEFAULT_PROBE_TIMEOUT_SECONDS = 8.0
+
+
+class _ListModelsTransport(Protocol):
+    async def list_models(self) -> list[str]: ...
+
+
+async def probe_host(
+    host: Host,
+    *,
+    transport: _ListModelsTransport,
+    bus: SessionBus,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> None:
+    """Probe a host's available models. Updates host.models and publishes events."""
+    await bus.publish("probe.started", {"host_name": host.name, "url": host.url})
+    try:
+        model_names = await asyncio.wait_for(transport.list_models(), timeout=timeout)
+    except asyncio.TimeoutError:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "timeout", "retryable": True},
+        )
+        return
+    except PermissionError as exc:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "auth", "error": str(exc), "retryable": True},
+        )
+        return
+    except Exception as exc:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "offline", "error": str(exc), "retryable": True},
+        )
+        return
+
+    host.models = [ModelChoice(name=n, selected=False) for n in model_names]
+    await bus.publish(
+        "probe.completed",
+        {
+            "host_name": host.name,
+            "models": list(model_names),
+            "warning": "no_models" if not model_names else None,
+        },
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_probe.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/probe.py tests/unit/tui/test_probe.py
+git commit -m "feat(tui): probe_host happy-path with bus event publishing"
+```
+
+---
+
+## Task 13: probe.py — timeout, auth, transport-error, empty-list
+
+**Files:**
+- Modify: `tests/unit/tui/test_probe.py` (add tests)
+
+- [ ] **Step 1: Add failing tests for the error surfaces**
+
+Append to `tests/unit/tui/test_probe.py`:
+
+```python
+class TestProbeFailures:
+    async def _collect_events(self, bus: SessionBus) -> list[tuple[str, dict]]:
+        events: list[tuple[str, dict]] = []
+
+        async def reader(topic: str) -> None:
+            async for ev in bus.subscribe(topic):
+                events.append((topic, ev))
+
+        for topic in ("probe.started", "probe.completed", "probe.failed"):
+            asyncio.create_task(reader(topic))
+        await asyncio.sleep(0)
+        return events
+
+    async def test_timeout_publishes_failed_with_reason_timeout(self) -> None:
+        bus = SessionBus()
+        events = await self._collect_events(bus)
+        host = Host(name="slow", url="http://slow", engine="ollama")
+        transport = FakeTransport(models=["x"], delay_seconds=2.0)
+
+        await probe_host(host, transport=transport, bus=bus, timeout=0.05)
+        await asyncio.sleep(0.05)
+
+        failed = [ev for t, ev in events if t == "probe.failed"]
+        assert len(failed) == 1
+        assert failed[0]["reason"] == "timeout"
+        assert failed[0]["retryable"] is True
+
+    async def test_auth_error_publishes_failed_with_reason_auth(self) -> None:
+        bus = SessionBus()
+        events = await self._collect_events(bus)
+        host = Host(name="locked", url="http://locked", engine="openai-compat")
+        transport = FakeTransport(models=[], fail_with=PermissionError("401 unauthorized"))
+
+        await probe_host(host, transport=transport, bus=bus)
+        await asyncio.sleep(0.05)
+
+        failed = [ev for t, ev in events if t == "probe.failed"]
+        assert len(failed) == 1
+        assert failed[0]["reason"] == "auth"
+
+    async def test_transport_error_publishes_failed_with_reason_offline(self) -> None:
+        bus = SessionBus()
+        events = await self._collect_events(bus)
+        host = Host(name="dead", url="http://dead", engine="ollama")
+        transport = FakeTransport(models=[], fail_with=ConnectionRefusedError("nope"))
+
+        await probe_host(host, transport=transport, bus=bus)
+        await asyncio.sleep(0.05)
+
+        failed = [ev for t, ev in events if t == "probe.failed"]
+        assert len(failed) == 1
+        assert failed[0]["reason"] == "offline"
+
+    async def test_empty_model_list_publishes_completed_with_warning(self) -> None:
+        bus = SessionBus()
+        events = await self._collect_events(bus)
+        host = Host(name="empty", url="http://empty", engine="ollama")
+        transport = FakeTransport(models=[])
+
+        await probe_host(host, transport=transport, bus=bus)
+        await asyncio.sleep(0.05)
+
+        completed = [ev for t, ev in events if t == "probe.completed"]
+        assert len(completed) == 1
+        assert completed[0]["models"] == []
+        assert completed[0]["warning"] == "no_models"
+        # Host.models was set to empty list (not left stale).
+        assert host.models == []
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run:
+```bash
+pytest tests/unit/tui/test_probe.py -v
+```
+
+Expected: all tests PASS. The probe implementation from Task 12 already handles these surfaces; this task locks the behavior with explicit tests.
+
+If any FAIL: the `except PermissionError` and `except Exception` branches in `probe.py` need to match what FakeTransport raises. Verify FakeTransport's `fail_with` is plumbed correctly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/tui/test_probe.py
+git commit -m "test(tui): lock probe failure surfaces — timeout, auth, offline, no_models"
+```
+
+---
+
+## Task 14: Public API re-exports + final sweep
+
+**Files:**
+- Modify: `src/hermia/tui/__init__.py`
+- Modify: `src/hermia/tui/widgets/__init__.py`
+
+- [ ] **Step 1: Add re-exports to tui/__init__.py**
+
+Replace `src/hermia/tui/__init__.py` with:
+
+```python
+"""Hermia Fleet TUI — unified interactive picker + live runner.
+
+Public surface for downstream callers (Plan 2 picker screens, Plan 3 runner
+screens, Plan 4 app.py rewire).
+"""
+from hermia.tui.bus import SessionBus
+from hermia.tui.fleet_io import (
+    fleet_path,
+    load_fleet,
+    load_hosts_seed,
+    save_fleet,
+    save_hosts_seed,
+)
+from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
+from hermia.tui.state import (
+    FleetConfig,
+    Host,
+    HostSource,
+    ModelChoice,
+    ModelSource,
+)
+
+__all__ = [
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "FleetConfig",
+    "Host",
+    "HostSource",
+    "ModelChoice",
+    "ModelSource",
+    "SessionBus",
+    "fleet_path",
+    "load_fleet",
+    "load_hosts_seed",
+    "probe_host",
+    "save_fleet",
+    "save_hosts_seed",
+]
+```
+
+- [ ] **Step 2: Add re-exports to widgets/__init__.py**
+
+Replace `src/hermia/tui/widgets/__init__.py` with:
+
+```python
+"""Reusable, domain-agnostic Textual widgets for the Fleet TUI."""
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.filter_axis import FilterAxis
+from hermia.tui.widgets.progress_bar import AggregateProgressBar, MiniProgressBar
+from hermia.tui.widgets.search_bar import SearchBar
+from hermia.tui.widgets.status_badge import (
+    ICONS,
+    Direction,
+    Status,
+    StatusBadge,
+    color_for,
+)
+
+__all__ = [
+    "AggregateProgressBar",
+    "Direction",
+    "DrillableList",
+    "FilterAxis",
+    "ICONS",
+    "ListRow",
+    "MiniProgressBar",
+    "SearchBar",
+    "Status",
+    "StatusBadge",
+    "color_for",
+]
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+```bash
+pytest tests/unit/tui/ -v
+```
+
+Expected: all tests in `tests/unit/tui/` PASS.
+
+- [ ] **Step 4: Run ruff**
+
+Run:
+```bash
+ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/
+```
+
+Expected: no errors. If any: fix them before proceeding.
+
+- [ ] **Step 5: Run mypy**
+
+Run:
+```bash
+mypy src/hermia/tui/
+```
+
+Expected: no errors. If any: fix them before proceeding (most likely candidates: missing type hints on Protocol implementations or queue parameterization).
+
+- [ ] **Step 6: Run the full project test suite to catch any regression**
+
+Run:
+```bash
+pytest
+```
+
+Expected: all tests pass — the new tui/ package added tests but touched no existing module, so existing tests should be unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hermia/tui/__init__.py src/hermia/tui/widgets/__init__.py
+git commit -m "feat(tui): public re-exports for foundation API"
+```
+
+---
+
+## Plan Close
+
+- [ ] **C1: Push branch and open PR to dev**
+
+```bash
+git push -u origin feature/fleet-tui-foundation
+gh pr create --base dev --title "feat(tui): foundation — widgets, bus, state, fleet I/O, probe" --body "$(cat <<'EOF'
+## Summary
+
+Foundation for the Fleet TUI per [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](../specs/2026-06-18-fleet-tui-design.md). Builds the widget library, event bus, state model, fleet YAML I/O, and async host probe. No user-facing flow yet — every surface is unit-tested in isolation.
+
+Subsequent plans:
+- Plan 2: Picker screens (Launch, Fleet Config, Hosts, Models, Tests)
+- Plan 3: Runner screens (L1 aggregate, L2 trials, L3 streaming detail)
+- Plan 4: Migration (delete screens.py, retire old tests, rewire app.py)
+
+## What's in this PR
+
+- `src/hermia/tui/` package: `state.py`, `bus.py`, `fleet_io.py`, `probe.py`
+- `src/hermia/tui/widgets/`: `status_badge`, `search_bar`, `filter_axis`, `progress_bar`, `drillable_list`
+- `tests/fixtures/fake_transport.py`: shared FakeTransport for any test driving probe/runner
+- Full unit-test coverage for every surface
+- AGENTS.md Module Boundary Table expanded to include `src/hermia/tui/`
+
+## Test plan
+
+- [ ] `pytest tests/unit/tui/` — all green
+- [ ] `pytest` — full suite green, no regression
+- [ ] `ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/` — clean
+- [ ] `mypy src/hermia/tui/` — clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens against `dev`. URL printed to stdout.
+
+- [ ] **C2: Post /gemini review on the PR**
+
+Per AGENTS.md rule 8 — Gemini does not auto-trigger:
+
+```bash
+gh pr comment <PR-number> --body "/gemini review"
+```
+
+Address any HIGH-priority findings; merge after review cycle completes per project review-gate sequence.
+
+- [ ] **C3: bd note + close on hermia-86g**
+
+When PR merges:
+
+```bash
+bd note hermia-86g "Foundation plan (this PR) merged to dev. Plans 2-4 to follow."
+```
+
+Do NOT close `hermia-86g` — it tracks the full Fleet TUI, not just the foundation.
+
+---
+
+## Self-Review (run by the plan-writer)
+
+**1. Spec coverage:**
+
+| Spec section | Implemented in this plan |
+|---|---|
+| §2 Module Layout (`tui/`, widgets, state, bus, fleet_io, probe) | Tasks 1-14 |
+| §2 `HostSource` / `ModelSource` protocols | Task 1 |
+| §3 Data model (`FleetConfig`, `Host`, `ModelChoice`) | Task 1 |
+| §3 Fleet YAML schema (round-trip, `auth_header_env` discipline) | Task 2 |
+| §3 hosts.yaml seed list | Task 3 |
+| §4 SessionBus pub/sub | Task 4 |
+| §4 Queue bounds + drop-oldest | Task 5 |
+| §5 Status semantics (`defended/refused/breached/error`) + direction-aware color | Task 6 |
+| §5 Universal navigation contract (`/`, `tab`, `space`, `a`, `n`, `enter`) | Tasks 7, 8, 10 |
+| §6 Error surfaces (timeout, auth, transport, empty list) | Tasks 12-13 |
+| §7 Testing strategy (widget unit tests, bus pytest-asyncio, FakeTransport fixture) | All tasks |
+
+Not covered in this plan (deferred to subsequent plans, as designed):
+- Screens (Plan 2 + 3)
+- App rewire (Plan 4)
+- Deletion of `screens.py` (Plan 4)
+
+**2. Placeholder scan:** No TBD / TODO / "implement later" / "similar to" markers. Every code block contains the actual code an engineer needs.
+
+**3. Type consistency:** `FleetConfig`, `Host`, `ModelChoice` signatures consistent across Tasks 1, 2, 3, 12. `SessionBus.publish` / `subscribe` consistent across Tasks 4, 5, 12. `StatusBadge.update_status` signature consistent across Task 6 tests and impl.
+
+**4. Ambiguity scan:** Task 5 references queue bounds that Task 4's implementation already supports — explicit by note in Task 5 Step 2 ("the implementation already supports drop-oldest; this task locks the behavior with explicit tests"). Task 13 same pattern for probe failure surfaces.

--- a/docs/superpowers/plans/2026-06-18-fleet-tui-picker.md
+++ b/docs/superpowers/plans/2026-06-18-fleet-tui-picker.md
@@ -1,0 +1,2375 @@
+# Fleet TUI Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the unified picker flow — Launch → Fleet Config → drill-into Hosts / Host Models / Tests — entirely against the Plan 1 foundation. Save/load fleets to `fleets/<name>.yaml`. No runner yet.
+
+**Architecture:** Each picker screen is a `Screen` subclass under `src/hermia/tui/screens/`. Key bindings (`/`, `tab`, `enter`, `esc`, `space`, `a`, `n`) live on each screen per spec §5 universal contract and invoke the foundation widgets' API methods (`SearchBar.open()`, `DrillableList.toggle()`, etc.). The single shared `FleetConfig` lives on `HermiaApp` as the in-memory source of truth.
+
+A separate entry point `python -m hermia.tui` lets the new TUI be exercised end-to-end without disturbing the existing `hermia` CLI. Plan 4 rewires the main entry point and deletes `screens.py`.
+
+**Tech Stack:** Python 3.11+, Textual ≥0.80, asyncio, PyYAML. **No new dependencies.** Pilot tests use stdlib `asyncio.run()` per the pattern established in Plan 1.
+
+**Spec reference:** [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](../specs/2026-06-18-fleet-tui-design.md)
+
+**Tracking bead:** `hermia-86g`
+
+**Prerequisite:** Plan 1 (Foundation) merged to `dev`.
+
+---
+
+## File Structure
+
+```
+src/hermia/tui/
+  app.py                            # HermiaApp Textual App subclass
+  __main__.py                       # `python -m hermia.tui` entry
+  test_catalog.py                   # TestRecord(id, frameworks) + load_test_catalog()
+  transport_adapter.py              # transport_for(host) → _ListModelsTransport
+  widgets/
+    breadcrumb.py                   # NEW: clickable drill-path header
+  screens/
+    __init__.py
+    launch.py                       # Load existing / New fleet / Quick local run
+    config.py                       # Fleet Config — drill home base
+    hosts.py                        # Hosts drill
+    host_models.py                  # Single host's model picker
+    tests.py                        # Fleet-scoped test picker
+    modals.py                       # AddHostModal, FleetNameModal, UnsavedChangesModal
+
+tests/unit/tui/
+  test_app.py
+  test_test_catalog.py
+  test_transport_adapter.py
+  test_widgets_breadcrumb.py
+  screens/
+    __init__.py
+    test_launch.py
+    test_config.py
+    test_hosts.py
+    test_host_models.py
+    test_tests.py
+    test_modals.py
+  test_picker_e2e.py                # Pilot smoke covering Launch → New → Quick local
+```
+
+Files modified:
+- `AGENTS.md` — no change (already includes `src/hermia/tui/`)
+
+Files NOT touched (deferred to later plans):
+- `src/hermia/screens.py` — Plan 4 deletes
+- `src/hermia/app.py` — Plan 4 rewires
+- `src/hermia/runner.py`, `fleet.py`, `transport/`, `scoring.py` — never touched by TUI work
+
+---
+
+## Setup
+
+- [ ] **S1: Branch from updated dev (after Plan 1 merges)**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/fleet-tui-picker
+```
+
+- [ ] **S2: Scaffold screens package**
+
+Create empty `__init__.py` files:
+
+```bash
+mkdir -p src/hermia/tui/screens tests/unit/tui/screens
+```
+
+**`src/hermia/tui/screens/__init__.py`:**
+```python
+"""Picker + runner screens for the Fleet TUI."""
+```
+
+**`tests/unit/tui/screens/__init__.py`:** (empty)
+
+Commit:
+```bash
+git add src/hermia/tui/screens/__init__.py tests/unit/tui/screens/__init__.py
+git commit -m "feat(tui): scaffold screens package"
+```
+
+---
+
+## Task 1: test_catalog.py — TestRecord + framework tag loading
+
+**Files:**
+- Create: `src/hermia/tui/test_catalog.py`
+- Test: `tests/unit/tui/test_test_catalog.py`
+
+The Tests drill needs (test_id, frameworks_present) records. `TEST_IDS` lives in `src/hermia/schemas.py`. Framework tags live in `src/hermia/test-datasets/agentic-tasks.json` under `agentic_test_cases[].frameworks.{owasp_llm_top10, mitre_atlas, csa_maestro, nist_ai_rmf}` (lists; non-empty = test belongs to that framework).
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/test_test_catalog.py`:
+```python
+"""Tests for hermia.tui.test_catalog — TestRecord + load_test_catalog()."""
+from hermia.tui.test_catalog import FRAMEWORKS, TestRecord, load_test_catalog
+
+
+class TestLoadTestCatalog:
+    def test_returns_one_record_per_test_id(self) -> None:
+        from hermia.schemas import TEST_IDS
+        catalog = load_test_catalog()
+        assert {r.id for r in catalog} == set(TEST_IDS)
+
+    def test_records_have_frameworks_keys(self) -> None:
+        catalog = load_test_catalog()
+        for r in catalog:
+            assert set(r.frameworks.keys()) == set(FRAMEWORKS)
+            for v in r.frameworks.values():
+                assert isinstance(v, bool)
+
+    def test_known_test_has_expected_framework_membership(self) -> None:
+        catalog = load_test_catalog()
+        # security-boundary is in agentic-tasks.json with non-empty csa_maestro.
+        rec = next(r for r in catalog if r.id == "security-boundary")
+        # At least one framework membership should be True for an annotated test.
+        assert any(rec.frameworks.values())
+
+
+class TestTestRecord:
+    def test_is_in_framework_helper(self) -> None:
+        rec = TestRecord(id="x", frameworks={"OWASP": True, "ATLAS": False, "MAESTRO": True, "NIST": False})
+        assert rec.is_in_framework("OWASP") is True
+        assert rec.is_in_framework("ATLAS") is False
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+pytest tests/unit/tui/test_test_catalog.py -v --no-cov
+```
+
+Expected: `ImportError: cannot import name 'TestRecord' from 'hermia.tui.test_catalog'`.
+
+- [ ] **Step 3: Implement test_catalog.py**
+
+```python
+"""Test catalog — pairs each schemas.TEST_IDS entry with its framework tags.
+
+Source of truth:
+    - schemas.TEST_IDS               — canonical ordered list of test IDs
+    - test-datasets/agentic-tasks.json[agentic_test_cases][*].frameworks
+      → dict with keys: owasp_llm_top10, mitre_atlas, csa_maestro, nist_ai_rmf
+      → non-empty list = test belongs to that framework
+
+The Tests drill uses TestRecord.is_in_framework() for the filter axis.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermia.schemas import TEST_IDS
+
+FRAMEWORKS: list[str] = ["OWASP", "ATLAS", "MAESTRO", "NIST"]
+
+_TASKS_JSON = Path(__file__).resolve().parent.parent / "test-datasets" / "agentic-tasks.json"
+
+_FRAMEWORK_KEY_MAP: dict[str, str] = {
+    "OWASP": "owasp_llm_top10",
+    "ATLAS": "mitre_atlas",
+    "MAESTRO": "csa_maestro",
+    "NIST": "nist_ai_rmf",
+}
+
+
+@dataclass
+class TestRecord:
+    id: str
+    frameworks: dict[str, bool]
+
+    def is_in_framework(self, framework: str) -> bool:
+        return self.frameworks.get(framework, False)
+
+
+def load_test_catalog() -> list[TestRecord]:
+    """Build a list of TestRecord — one per id in schemas.TEST_IDS.
+
+    Tests missing from agentic-tasks.json get a record with all framework
+    memberships False (their ID is still in the catalog so they appear in
+    the picker).
+    """
+    by_id: dict[str, dict[str, bool]] = {
+        tid: {f: False for f in FRAMEWORKS} for tid in TEST_IDS
+    }
+    raw = json.loads(_TASKS_JSON.read_text())
+    for case in raw.get("agentic_test_cases", []):
+        cid = case.get("id")
+        if cid not in by_id:
+            continue
+        f = case.get("frameworks", {}) or {}
+        for label, key in _FRAMEWORK_KEY_MAP.items():
+            by_id[cid][label] = bool(f.get(key))
+    return [TestRecord(id=tid, frameworks=by_id[tid]) for tid in TEST_IDS]
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/test_test_catalog.py -v --no-cov
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/test_catalog.py tests/unit/tui/test_test_catalog.py
+git commit -m "feat(tui): test catalog with framework tags from agentic-tasks.json"
+```
+
+---
+
+## Task 2: transport_adapter.py — engine-aware probe transport factory
+
+**Files:**
+- Create: `src/hermia/tui/transport_adapter.py`
+- Test: `tests/unit/tui/test_transport_adapter.py`
+
+The Hosts drill probes each host. `probe_host` needs a transport with `async list_models()`. The right transport depends on `host.engine`. Map:
+
+| engine | transport |
+|---|---|
+| `ollama` | wraps Ollama `/api/tags` |
+| `openai-compat` | wraps `/v1/models` |
+| other | falls back to `openai-compat` for v0.2 (vllm / sglang / litellm all speak OpenAI shape) |
+
+Auth header (when present) comes from the env var named by `host.auth_header_env`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/test_transport_adapter.py`:
+```python
+"""Tests for hermia.tui.transport_adapter — engine → transport factory."""
+import asyncio
+
+from hermia.tui.state import Host
+from hermia.tui.transport_adapter import transport_for
+
+
+class _FakeHTTPProbe:
+    """Stand-in returned by transport_for in test mode — we only need .list_models()."""
+    last_url: str | None = None
+    last_auth: str | None = None
+
+
+class TestTransportFor:
+    def test_returns_object_with_list_models(self) -> None:
+        host = Host(name="h", url="http://h:11434", engine="ollama")
+        tr = transport_for(host)
+        assert hasattr(tr, "list_models")
+
+    def test_resolves_auth_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("MY_KEY", "secret-value")
+        host = Host(
+            name="h",
+            url="http://h:4000",
+            engine="openai-compat",
+            auth_header_env="MY_KEY",
+        )
+        tr = transport_for(host)
+        # The adapter stores the resolved bearer header on the transport
+        # instance for the probe to use when calling /v1/models.
+        assert tr.auth_header == "Bearer secret-value"
+
+    def test_missing_env_var_leaves_auth_none(self) -> None:
+        host = Host(
+            name="h",
+            url="http://h:4000",
+            engine="openai-compat",
+            auth_header_env="NOT_SET_ANYWHERE",
+        )
+        tr = transport_for(host)
+        assert tr.auth_header is None
+
+    def test_no_auth_header_env_leaves_auth_none(self) -> None:
+        host = Host(name="h", url="http://h:11434", engine="ollama")
+        tr = transport_for(host)
+        assert tr.auth_header is None
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+pytest tests/unit/tui/test_transport_adapter.py -v --no-cov
+```
+
+- [ ] **Step 3: Implement transport_adapter.py**
+
+```python
+"""Engine-aware transport factory for the Fleet TUI probe layer.
+
+Maps a Host to a transport object with `async list_models() -> list[str]`,
+which is what hermia.tui.probe.probe_host needs.
+
+For v0.2 we ship two probe shapes:
+    - Ollama         /api/tags     → list of {"name": str, ...}
+    - OpenAI-compat  /v1/models    → {"data": [{"id": str, ...}, ...]}
+
+vLLM / SGLang / LiteLLM all speak the OpenAI shape, so any non-"ollama"
+engine falls back to the openai-compat path.
+
+Auth header is resolved from the environment variable named by
+host.auth_header_env. Per AGENTS.md rule 11, the secret value never appears
+in any saved config — only the env var name does.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+
+from hermia.tui.state import Host
+
+
+@dataclass
+class _BaseProbeTransport:
+    url: str
+    auth_header: str | None = None
+
+    def _client(self) -> httpx.AsyncClient:
+        headers = {"Authorization": self.auth_header} if self.auth_header else {}
+        return httpx.AsyncClient(headers=headers, timeout=10.0)
+
+
+class OllamaProbeTransport(_BaseProbeTransport):
+    async def list_models(self) -> list[str]:
+        async with self._client() as client:
+            resp = await client.get(f"{self.url.rstrip('/')}/api/tags")
+            if resp.status_code in (401, 403):
+                raise PermissionError(f"{resp.status_code} from {self.url}")
+            resp.raise_for_status()
+            data = resp.json()
+            return [m["name"] for m in data.get("models", [])]
+
+
+class OpenAICompatProbeTransport(_BaseProbeTransport):
+    async def list_models(self) -> list[str]:
+        async with self._client() as client:
+            resp = await client.get(f"{self.url.rstrip('/')}/v1/models")
+            if resp.status_code in (401, 403):
+                raise PermissionError(f"{resp.status_code} from {self.url}")
+            resp.raise_for_status()
+            data = resp.json()
+            return [m["id"] for m in data.get("data", [])]
+
+
+def transport_for(host: Host) -> _BaseProbeTransport:
+    """Return a probe transport for this host's engine + auth setup."""
+    auth_header: str | None = None
+    if host.auth_header_env:
+        token = os.environ.get(host.auth_header_env)
+        if token:
+            auth_header = f"Bearer {token}"
+    cls = OllamaProbeTransport if host.engine == "ollama" else OpenAICompatProbeTransport
+    return cls(url=host.url, auth_header=auth_header)
+```
+
+**Dependency check:** `httpx` is already in `pyproject.toml` (used by existing `transport/`). Confirm with `grep httpx pyproject.toml` before implementing. If missing, **stop and ask the user** — adding a dep needs explicit approval per AGENTS.md rule 3.
+
+- [ ] **Step 4: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/test_transport_adapter.py -v --no-cov
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/transport_adapter.py tests/unit/tui/test_transport_adapter.py
+git commit -m "feat(tui): engine-aware probe transport factory with env-var auth"
+```
+
+---
+
+## Task 3: widgets/breadcrumb.py — clickable drill-path header
+
+**Files:**
+- Create: `src/hermia/tui/widgets/breadcrumb.py`
+- Modify: `src/hermia/tui/widgets/__init__.py` (add Breadcrumb to re-exports)
+- Test: `tests/unit/tui/test_widgets_breadcrumb.py`
+
+Reusable widget showing `hermia · fleet · <name> ▸ hosts ▸ marcus` with each segment clickable. Emits `Breadcrumb.Jumped(index)` when a segment is clicked. Each screen sets the breadcrumb from its drill stack.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/test_widgets_breadcrumb.py`:
+```python
+"""Tests for Breadcrumb — segmented drill-path header."""
+import asyncio
+
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class _Host(App):
+    def __init__(self, segments: list[str]) -> None:
+        super().__init__()
+        self._segments = segments
+        self.jumped_to: int | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Breadcrumb(self._segments)
+
+    def on_breadcrumb_jumped(self, event: Breadcrumb.Jumped) -> None:
+        self.jumped_to = event.index
+
+
+class TestBreadcrumb:
+    def test_renders_segments_with_separator(self) -> None:
+        async def _run() -> None:
+            async with _Host(["hermia", "fleet", "smoke"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                assert bc.text == "hermia ▸ fleet ▸ smoke"
+
+        asyncio.run(_run())
+
+    def test_empty_segments_renders_empty(self) -> None:
+        async def _run() -> None:
+            async with _Host([]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                assert bc.text == ""
+
+        asyncio.run(_run())
+
+    def test_update_changes_rendering(self) -> None:
+        async def _run() -> None:
+            async with _Host(["a", "b"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                bc.set_segments(["x", "y", "z"])
+                await pilot.pause()
+                assert bc.text == "x ▸ y ▸ z"
+
+        asyncio.run(_run())
+
+    def test_jump_emits_message_with_index(self) -> None:
+        async def _run() -> None:
+            async with _Host(["a", "b", "c"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                bc.jump_to(1)
+                await pilot.pause()
+                assert pilot.app.jumped_to == 1
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement breadcrumb.py**
+
+```python
+"""Breadcrumb — segmented drill-path header.
+
+`hermia · fleet · kwaainet-baseline ▸ hosts ▸ marcus`
+
+Each segment is clickable (mouse) and the host screen can call jump_to(i)
+to handle keyboard jumps. The widget emits Breadcrumb.Jumped(index) which
+the screen translates into pop_screen() calls per drill depth.
+"""
+from __future__ import annotations
+
+from textual.message import Message
+from textual.widgets import Static
+
+SEPARATOR = " ▸ "
+
+
+class Breadcrumb(Static):
+    """Inline segmented drill-path header."""
+
+    DEFAULT_CSS = """
+    Breadcrumb {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    """
+
+    class Jumped(Message):
+        def __init__(self, index: int) -> None:
+            self.index = index
+            super().__init__()
+
+    def __init__(self, segments: list[str]) -> None:
+        self._segments = list(segments)
+        self._text = SEPARATOR.join(self._segments)
+        super().__init__(self._text)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def set_segments(self, segments: list[str]) -> None:
+        self._segments = list(segments)
+        self._text = SEPARATOR.join(self._segments)
+        self.update(self._text)
+
+    def jump_to(self, index: int) -> None:
+        """Programmatic jump — used by screen-level handlers."""
+        if 0 <= index < len(self._segments):
+            self.post_message(self.Jumped(index))
+```
+
+Add to `src/hermia/tui/widgets/__init__.py`:
+```python
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+```
+And to `__all__`.
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/widgets/breadcrumb.py src/hermia/tui/widgets/__init__.py tests/unit/tui/test_widgets_breadcrumb.py
+git commit -m "feat(tui): Breadcrumb widget — segmented drill-path header"
+```
+
+---
+
+## Task 4: app.py — HermiaApp skeleton + smart-config attribute
+
+**Files:**
+- Create: `src/hermia/tui/app.py`
+- Create: `src/hermia/tui/__main__.py`
+- Test: `tests/unit/tui/test_app.py`
+
+HermiaApp is the Textual App that mounts the Launch screen and holds the single shared `FleetConfig` as a mutable attribute. Screens read and write to `app.config`. Plan 3 will add `app.bus = SessionBus()` for the runner; Plan 2 only needs `config`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/test_app.py`:
+```python
+"""Tests for HermiaApp — the unified Fleet TUI Textual App."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.state import FleetConfig
+
+
+class TestHermiaApp:
+    def test_starts_with_empty_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                app: HermiaApp = pilot.app  # type: ignore[assignment]
+                assert isinstance(app.config, FleetConfig)
+                assert app.config.name == ""
+                assert app.config.hosts == []
+
+        asyncio.run(_run())
+
+    def test_config_is_mutable(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                app: HermiaApp = pilot.app  # type: ignore[assignment]
+                app.config.name = "smoke"
+                assert app.config.name == "smoke"
+
+        asyncio.run(_run())
+
+    def test_mounts_launch_screen(self) -> None:
+        async def _run() -> None:
+            from hermia.tui.screens.launch import LaunchScreen
+            async with HermiaApp().run_test() as pilot:
+                assert isinstance(pilot.app.screen, LaunchScreen)
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement app.py + __main__.py**
+
+`src/hermia/tui/app.py`:
+```python
+"""HermiaApp — Textual App for the unified Fleet TUI.
+
+Holds the shared FleetConfig as a mutable attribute. Picker screens read
+and write directly to `app.config`. Plan 3 adds `app.bus = SessionBus()`
+for runner ↔ screen communication.
+"""
+from __future__ import annotations
+
+from textual.app import App
+
+from hermia.tui.state import FleetConfig
+
+
+class HermiaApp(App[None]):
+    CSS_PATH = None  # widgets define their own DEFAULT_CSS
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config: FleetConfig = FleetConfig(name="")
+
+    def on_mount(self) -> None:
+        # Import here to avoid circular import — screens.launch imports HermiaApp.
+        from hermia.tui.screens.launch import LaunchScreen
+        self.push_screen(LaunchScreen())
+```
+
+`src/hermia/tui/__main__.py`:
+```python
+"""`python -m hermia.tui` — launches the unified Fleet TUI.
+
+Separate from the existing `hermia` CLI (src/hermia/app.py:main) during
+Plan 2 development. Plan 4 rewires the main entry to point here and deletes
+src/hermia/screens.py.
+"""
+from hermia.tui.app import HermiaApp
+
+
+def main() -> None:
+    HermiaApp().run()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/test_app.py -v --no-cov
+```
+
+Note: this will fail until Task 5 lands `LaunchScreen`. **For this task's commit, mark the `test_mounts_launch_screen` test with `@pytest.mark.xfail(reason="LaunchScreen lands in Task 5")` and remove the marker in Task 5.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/app.py src/hermia/tui/__main__.py tests/unit/tui/test_app.py
+git commit -m "feat(tui): HermiaApp skeleton + python -m hermia.tui entry point"
+```
+
+---
+
+## Task 5: screens/launch.py — three-entry list
+
+**Files:**
+- Create: `src/hermia/tui/screens/launch.py`
+- Test: `tests/unit/tui/screens/test_launch.py`
+
+The Launch screen shows three entries: `Load existing fleet`, `New fleet`, `Quick local run`. Cursor + enter selects. Subsequent tasks wire up the actions.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/screens/test_launch.py`:
+```python
+"""Tests for LaunchScreen — initial entries + cursor."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.launch import LaunchScreen
+
+
+class TestLaunchEntries:
+    def test_three_entries_present(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                assert isinstance(pilot.app.screen, LaunchScreen)
+                screen = pilot.app.screen
+                labels = [e.label for e in screen.entries]
+                assert labels == ["Load existing fleet", "New fleet", "Quick local run"]
+
+        asyncio.run(_run())
+
+    def test_cursor_starts_on_first_entry(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 0
+
+        asyncio.run(_run())
+
+    def test_arrow_down_moves_cursor(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("down")
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 1
+
+        asyncio.run(_run())
+
+    def test_q_quits_app(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("q")
+                await pilot.pause()
+                # App is exiting; running flag flips off.
+                assert pilot.app._exit is True
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement launch.py**
+
+```python
+"""Launch screen — three entries: Load / New / Quick local run.
+
+Quick local run pre-fills a single-host config (http://localhost:11434) and
+jumps to model selection on that host. New fleet opens an empty Fleet Config.
+Load opens an entry-list of fleets/*.yaml.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+
+@dataclass
+class LaunchEntry:
+    id: str
+    label: str
+
+
+class LaunchScreen(Screen[None]):
+    BINDINGS = [
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "select", "Select", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entries: list[LaunchEntry] = [
+            LaunchEntry(id="load", label="Load existing fleet"),
+            LaunchEntry(id="new", label="New fleet"),
+            LaunchEntry(id="quick", label="Quick local run"),
+        ]
+        self.cursor_index: int = 0
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static("Welcome to hermia fleet", id="launch-title")
+            for entry in self.entries:
+                yield Static(self._row_text(entry), id=f"launch-{entry.id}")
+
+    def _row_text(self, entry: LaunchEntry) -> str:
+        cursor = "▸ " if entry == self.entries[self.cursor_index] else "  "
+        return f"  {cursor}{entry.label}"
+
+    def _refresh_rows(self) -> None:
+        for entry in self.entries:
+            self.query_one(f"#launch-{entry.id}", Static).update(self._row_text(entry))
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_index > 0:
+            self.cursor_index -= 1
+            self._refresh_rows()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_index < len(self.entries) - 1:
+            self.cursor_index += 1
+            self._refresh_rows()
+
+    def action_select(self) -> None:
+        # Subsequent tasks fill in each branch. For Task 5, no-op.
+        entry = self.entries[self.cursor_index]
+        # Placeholder: each branch will push a screen / call helper.
+        _ = entry  # noqa: F841
+
+    def action_quit(self) -> None:
+        self.app.exit()
+```
+
+Now remove the `@pytest.mark.xfail` from `test_app.py::test_mounts_launch_screen`.
+
+- [ ] **Step 4: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/test_app.py tests/unit/tui/screens/test_launch.py -v --no-cov
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/launch.py tests/unit/tui/screens/test_launch.py tests/unit/tui/test_app.py
+git commit -m "feat(tui): LaunchScreen with three entries and cursor navigation"
+```
+
+---
+
+## Task 6: screens/launch.py — Load existing fleet flow
+
+**Files:**
+- Modify: `src/hermia/tui/screens/launch.py`
+- Test: `tests/unit/tui/screens/test_launch.py` (add tests)
+
+When the user selects "Load existing fleet", the Launch screen scans `fleets/*.yaml`, replaces its entry list with the discovered fleets, and pressing `enter` on one loads it into `app.config` and pushes the Fleet Config screen.
+
+This task does NOT yet land the Fleet Config screen — that's Task 8. For now, after loading, the screen calls `self.app.exit()` so the e2e tests in this task can confirm the load happened by reading `app.config`. Task 8 replaces the exit with `push_screen(FleetConfigScreen())`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/tui/screens/test_launch.py`:
+```python
+from pathlib import Path
+
+from hermia.tui.fleet_io import save_fleet
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestLoadExisting:
+    def test_selecting_load_shows_fleet_list(self, tmp_path, monkeypatch) -> None:
+        # Pre-populate fleets/ with two saved fleets.
+        save_fleet(FleetConfig(name="alpha"), root=tmp_path)
+        save_fleet(FleetConfig(name="beta"), root=tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # selects Load
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                # After Load, entries list switches to fleet files (sorted).
+                labels = [e.label for e in screen.entries]
+                assert labels == ["alpha", "beta"]
+
+        asyncio.run(_run())
+
+    def test_selecting_a_loaded_fleet_populates_config(self, tmp_path, monkeypatch) -> None:
+        cfg = FleetConfig(
+            name="alpha",
+            hosts=[Host(name="h1", url="http://h1", engine="ollama",
+                        models=[ModelChoice(name="qwen3:32b", selected=True)])],
+            tests=["security-boundary"],
+        )
+        save_fleet(cfg, root=tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                await pilot.press("enter")  # select alpha
+                await pilot.pause()
+                app: HermiaApp = pilot.app  # type: ignore[assignment]
+                assert app.config.name == "alpha"
+                assert app.config.tests == ["security-boundary"]
+                assert app.config.hosts[0].name == "h1"
+
+        asyncio.run(_run())
+
+    def test_load_with_no_fleets_shows_empty_message(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.entries == []
+                # An empty-state notice should be visible.
+                notice = pilot.app.query_one("#launch-empty-notice", expect_type=type(screen.query_one("#launch-title")))
+                assert "No saved fleets" in notice.renderable or "No saved fleets" in str(notice)
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Modify launch.py**
+
+Add a `mode` attribute ("home" or "load") and split rendering by mode. In "load" mode, list `fleets/*.yaml`. Pressing enter on a fleet entry loads it into `app.config` and (for now) exits — Task 8 will replace exit with `push_screen(FleetConfigScreen())`.
+
+```python
+# Inside LaunchScreen — add to __init__:
+self.mode: str = "home"
+
+# Add a helper:
+def _scan_fleets(self) -> list[LaunchEntry]:
+    from pathlib import Path
+    fleets_dir = Path("fleets")
+    if not fleets_dir.exists():
+        return []
+    files = sorted(fleets_dir.glob("*.yaml"))
+    return [LaunchEntry(id=f.stem, label=f.stem) for f in files]
+
+# Replace action_select:
+def action_select(self) -> None:
+    if self.mode == "home":
+        entry = self.entries[self.cursor_index]
+        if entry.id == "load":
+            self._enter_load_mode()
+        elif entry.id == "new":
+            self._enter_new_fleet()
+        elif entry.id == "quick":
+            self._enter_quick_local()
+    elif self.mode == "load":
+        self._load_selected_fleet()
+
+def _enter_load_mode(self) -> None:
+    self.mode = "load"
+    self.entries = self._scan_fleets()
+    self.cursor_index = 0 if self.entries else -1
+    self._rerender()
+
+def _load_selected_fleet(self) -> None:
+    if self.cursor_index < 0:
+        return
+    from hermia.tui.fleet_io import fleet_path, load_fleet
+    entry = self.entries[self.cursor_index]
+    path = fleet_path(entry.id)
+    self.app.config = load_fleet(path)  # type: ignore[attr-defined]
+    # Task 8 will replace this with push_screen(FleetConfigScreen()).
+    self.app.exit()
+
+def _enter_new_fleet(self) -> None:
+    # Task 7 fills in.
+    self.app.exit()
+
+def _enter_quick_local(self) -> None:
+    # Task 7 fills in.
+    self.app.exit()
+
+def _rerender(self) -> None:
+    # Detach all children and recompose.
+    for child in list(self.children):
+        child.remove()
+    # Re-emit compose output.
+    self.mount(Static("Welcome to hermia fleet" if self.mode == "home" else "Load fleet", id="launch-title"))
+    if not self.entries:
+        self.mount(Static("No saved fleets in fleets/", id="launch-empty-notice"))
+        return
+    for entry in self.entries:
+        self.mount(Static(self._row_text(entry), id=f"launch-{entry.id}"))
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/launch.py tests/unit/tui/screens/test_launch.py
+git commit -m "feat(tui): Launch — Load existing fleet flow + empty-state notice"
+```
+
+---
+
+## Task 7: screens/launch.py — New fleet + Quick local run
+
+**Files:**
+- Modify: `src/hermia/tui/screens/launch.py`
+- Test: `tests/unit/tui/screens/test_launch.py` (add tests)
+
+`New fleet` initializes `app.config = FleetConfig(name="")` and (placeholder until Task 8) exits.
+
+`Quick local run` pre-populates `app.config` with one host (`http://localhost:11434`, `ollama`, name `"local"`) and the default test set (all `TEST_IDS`). Then (placeholder) exits.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestNewFleet:
+    def test_new_fleet_resets_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Mutate config first so we can prove New resets it.
+                pilot.app.config.name = "stale"
+                await pilot.press("down")  # cursor to New
+                await pilot.press("enter")
+                await pilot.pause()
+                assert pilot.app.config.name == ""
+                assert pilot.app.config.hosts == []
+
+        asyncio.run(_run())
+
+
+class TestQuickLocalRun:
+    def test_quick_local_seeds_config(self) -> None:
+        from hermia.schemas import TEST_IDS
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("down")
+                await pilot.press("down")  # cursor to Quick
+                await pilot.press("enter")
+                await pilot.pause()
+                cfg = pilot.app.config
+                assert cfg.name == "quick-local"
+                assert len(cfg.hosts) == 1
+                h = cfg.hosts[0]
+                assert h.url == "http://localhost:11434"
+                assert h.engine == "ollama"
+                assert h.name == "local"
+                assert cfg.tests == TEST_IDS
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement**
+
+```python
+def _enter_new_fleet(self) -> None:
+    self.app.config = FleetConfig(name="")  # type: ignore[attr-defined]
+    self.app.exit()
+
+def _enter_quick_local(self) -> None:
+    from hermia.schemas import TEST_IDS
+    self.app.config = FleetConfig(  # type: ignore[attr-defined]
+        name="quick-local",
+        hosts=[Host(name="local", url="http://localhost:11434", engine="ollama")],
+        tests=list(TEST_IDS),
+    )
+    self.app.exit()
+```
+
+(Add `from hermia.tui.state import FleetConfig, Host` to launch.py imports.)
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/launch.py tests/unit/tui/screens/test_launch.py
+git commit -m "feat(tui): Launch — New fleet reset + Quick local run pre-population"
+```
+
+---
+
+## Task 8: screens/config.py — Fleet Config home base
+
+**Files:**
+- Create: `src/hermia/tui/screens/config.py`
+- Modify: `src/hermia/tui/screens/launch.py` (replace `app.exit()` placeholders with `push_screen(FleetConfigScreen())`)
+- Test: `tests/unit/tui/screens/test_config.py`
+
+The Fleet Config screen displays:
+- Breadcrumb: `hermia · fleet · <name>`
+- Two drillable rows: `Hosts (N hosts · M model trials)` and `Tests (T tests)`
+- Run plan line: `N × M × T = total trials`
+- Footer key hints: `l load · s save · r run · esc back`
+
+`enter` on Hosts → push `HostsScreen` (Task 10). `enter` on Tests → push `TestsScreen` (Task 12). `r` triggers run (Plan 3). For Task 8 the `enter` actions are no-ops; Tasks 10 and 12 wire them.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/screens/test_config.py`:
+```python
+"""Tests for FleetConfigScreen — top-level summary + drill rows."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestFleetConfigSummary:
+    def test_renders_empty_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "0 hosts" in screen.summary_text
+                assert "0 tests" in screen.summary_text
+                assert "0 trials" in screen.run_plan_text
+
+    def test_summary_with_hosts_and_tests(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = FleetConfig(
+                    name="smoke",
+                    hosts=[Host(name="h1", url="http://h1", engine="ollama",
+                                models=[ModelChoice(name="m1", selected=True),
+                                        ModelChoice(name="m2", selected=True)])],
+                    tests=["t1", "t2", "t3"],
+                )
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "1 host" in screen.summary_text
+                assert "3 tests" in screen.summary_text
+                # 1 host × 2 selected models × 3 tests = 6 trials.
+                assert "6 trials" in screen.run_plan_text
+
+        asyncio.run(_run())
+
+    def test_breadcrumb_includes_fleet_name(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "smoke" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back_to_launch(self) -> None:
+        async def _run() -> None:
+            from hermia.tui.screens.launch import LaunchScreen
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, LaunchScreen)
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement config.py**
+
+```python
+"""Fleet Config screen — home base of the picker drill.
+
+Shows two drillable rows (Hosts, Tests), a run-plan trial estimate, and
+the breadcrumb header. Future tasks wire enter-on-row to push the child
+drills.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class FleetConfigScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Drill", show=True),
+        Binding("s", "save", "Save", show=True),
+        Binding("l", "load", "Load", show=False),
+        Binding("r", "run", "Run", show=False),
+    ]
+
+    ROWS = [("hosts", "Hosts"), ("tests", "Tests")]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cursor_row: int = 0
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Breadcrumb(self._breadcrumb_segments())
+            yield Static("", id="config-summary-hosts")
+            yield Static("", id="config-summary-tests")
+            yield Static("", id="config-run-plan")
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    @property
+    def app_config(self):
+        return self.app.config  # type: ignore[attr-defined]
+
+    @property
+    def breadcrumb_text(self) -> str:
+        return self.query_one(Breadcrumb).text
+
+    @property
+    def summary_text(self) -> str:
+        h = self.query_one("#config-summary-hosts", Static)
+        t = self.query_one("#config-summary-tests", Static)
+        return f"{h.renderable} {t.renderable}"
+
+    @property
+    def run_plan_text(self) -> str:
+        return str(self.query_one("#config-run-plan", Static).renderable)
+
+    def _breadcrumb_segments(self) -> list[str]:
+        name = self.app_config.name or "(unnamed)"
+        return ["hermia", "fleet", name]
+
+    def _refresh(self) -> None:
+        cfg = self.app_config
+        n_hosts = len(cfg.hosts)
+        n_models = sum(sum(1 for m in h.models if m.selected) for h in cfg.hosts)
+        n_tests = len(cfg.tests)
+        trials = n_hosts and n_models and n_tests and (n_hosts * (n_models // max(n_hosts, 1)) * n_tests) or (n_models * n_tests)
+        self.query_one(Breadcrumb).set_segments(self._breadcrumb_segments())
+        h_label = "host" if n_hosts == 1 else "hosts"
+        t_label = "test" if n_tests == 1 else "tests"
+        # Row 0 (Hosts):
+        cursor = "▸" if self.cursor_row == 0 else " "
+        self.query_one("#config-summary-hosts", Static).update(
+            f"{cursor} Hosts        {n_hosts} {h_label} · {n_models} model trials"
+        )
+        # Row 1 (Tests):
+        cursor = "▸" if self.cursor_row == 1 else " "
+        self.query_one("#config-summary-tests", Static).update(
+            f"{cursor} Tests        {n_tests} {t_label}"
+        )
+        self.query_one("#config-run-plan", Static).update(
+            f"Run plan: {n_models * n_tests} trials"
+        )
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_row > 0:
+            self.cursor_row -= 1
+            self._refresh()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_row < len(self.ROWS) - 1:
+            self.cursor_row += 1
+            self._refresh()
+
+    def action_drill(self) -> None:
+        # Hosts and Tests screens land in Tasks 10 and 12.
+        pass
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_save(self) -> None:
+        # Wired in Task 9.
+        pass
+
+    def action_load(self) -> None:
+        # Pop back to Launch and re-enter Load mode.
+        self.app.pop_screen()
+
+    def action_run(self) -> None:
+        # Plan 3 wires this to the runner.
+        pass
+```
+
+Update `launch.py` to push FleetConfigScreen instead of exiting in `_enter_new_fleet`, `_enter_quick_local`, and `_load_selected_fleet`:
+
+```python
+def _enter_new_fleet(self) -> None:
+    from hermia.tui.screens.config import FleetConfigScreen
+    self.app.config = FleetConfig(name="")  # type: ignore[attr-defined]
+    self.app.push_screen(FleetConfigScreen())
+
+def _enter_quick_local(self) -> None:
+    from hermia.tui.screens.config import FleetConfigScreen
+    from hermia.schemas import TEST_IDS
+    self.app.config = FleetConfig(  # type: ignore[attr-defined]
+        name="quick-local",
+        hosts=[Host(name="local", url="http://localhost:11434", engine="ollama")],
+        tests=list(TEST_IDS),
+    )
+    self.app.push_screen(FleetConfigScreen())
+
+def _load_selected_fleet(self) -> None:
+    if self.cursor_index < 0:
+        return
+    from hermia.tui.fleet_io import fleet_path, load_fleet
+    from hermia.tui.screens.config import FleetConfigScreen
+    entry = self.entries[self.cursor_index]
+    path = fleet_path(entry.id)
+    self.app.config = load_fleet(path)  # type: ignore[attr-defined]
+    self.app.push_screen(FleetConfigScreen())
+```
+
+Update Task 7's tests — `await pilot.press("enter")` no longer triggers `app.exit()`. The tests should now assert that `pilot.app.screen` is a `FleetConfigScreen` after entry.
+
+- [ ] **Step 4: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/screens/ -v --no-cov
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/config.py src/hermia/tui/screens/launch.py tests/unit/tui/screens/test_config.py tests/unit/tui/screens/test_launch.py
+git commit -m "feat(tui): FleetConfigScreen home base with drill rows + Launch pushes it"
+```
+
+---
+
+## Task 9: screens/config.py — save (s) + unsaved-changes indicator
+
+**Files:**
+- Modify: `src/hermia/tui/screens/config.py`
+- Create: `src/hermia/tui/screens/modals.py` (FleetNameModal — name prompt)
+- Test: `tests/unit/tui/screens/test_config.py` (add tests)
+
+Pressing `s` prompts the user for a fleet name (if `app.config.name == ""`) via a modal, then calls `save_fleet(app.config)`. If the name is already set, save immediately. The screen tracks a `dirty: bool` that flips True on any edit and back to False on save; the breadcrumb appends `[unsaved changes]` while True.
+
+For Task 9, the dirty flag is set only by `mark_dirty()` calls. Tasks 11 / 12 / 13 call `mark_dirty()` from the drills.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestSave:
+    def test_save_writes_fleet_file_when_name_set(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.fleet_io import fleet_path
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("s")
+                await pilot.pause()
+                assert fleet_path("smoke").exists()
+
+        asyncio.run(_run())
+
+    def test_dirty_flag_shows_in_breadcrumb(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.mark_dirty()
+                await pilot.pause()
+                assert "[unsaved" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_save_clears_dirty_flag(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.mark_dirty()
+                await pilot.press("s")
+                await pilot.pause()
+                assert screen.dirty is False
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement**
+
+Add `self.dirty = False` to `FleetConfigScreen.__init__`. Add `mark_dirty()` method that flips `dirty` and refreshes the breadcrumb. Update `_breadcrumb_segments()` to append `[unsaved changes]` when `dirty`. Wire `action_save()`:
+
+```python
+def action_save(self) -> None:
+    from hermia.tui.fleet_io import save_fleet
+    if not self.app_config.name:
+        # Prompt for a name. FleetNameModal lands in this same task.
+        self.app.push_screen(FleetNameModal(), self._on_name_chosen)
+        return
+    save_fleet(self.app_config)
+    self.dirty = False
+    self._refresh()
+
+def _on_name_chosen(self, name: str | None) -> None:
+    if not name:
+        return
+    self.app_config.name = name
+    self.action_save()
+
+def mark_dirty(self) -> None:
+    self.dirty = True
+    self._refresh()
+```
+
+Create `src/hermia/tui/screens/modals.py`:
+```python
+"""Modal dialogs used by picker screens."""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label
+
+
+class FleetNameModal(ModalScreen[str | None]):
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="modal"):
+            yield Label("Fleet name:")
+            yield Input(placeholder="kwaainet-baseline", id="modal-name")
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self.dismiss(event.value.strip() or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+```
+
+Update breadcrumb logic:
+```python
+def _breadcrumb_segments(self) -> list[str]:
+    name = self.app_config.name or "(unnamed)"
+    suffix = " [unsaved changes]" if self.dirty else ""
+    return ["hermia", "fleet", f"{name}{suffix}"]
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/config.py src/hermia/tui/screens/modals.py tests/unit/tui/screens/test_config.py
+git commit -m "feat(tui): FleetConfig — save (s) + FleetNameModal + dirty indicator"
+```
+
+---
+
+## Task 10: screens/hosts.py — list from seed + AddHostModal
+
+**Files:**
+- Create: `src/hermia/tui/screens/hosts.py`
+- Modify: `src/hermia/tui/screens/modals.py` (add `AddHostModal`)
+- Modify: `src/hermia/tui/screens/config.py` (wire Hosts drill)
+- Test: `tests/unit/tui/screens/test_hosts.py`
+- Test: `tests/unit/tui/screens/test_modals.py`
+
+Hosts drill loads its initial list from the user's `hosts.yaml` seed and shows any hosts already in `app.config.hosts`. Pressing `+` opens `AddHostModal` (name / URL / engine). The Hosts drill uses the foundation `DrillableList` widget under the hood, but at the screen level it maintains its own row state because each row has structured fields (URL, model count, probe status badge).
+
+For simplicity, this task uses a plain Vertical+Static layout (one Static per host row) and calls `app.config.hosts.append(...)` directly. The `+` key opens the modal; the modal's result is added to both `app.config.hosts` and (optionally) `~/.config/hermia/hosts.yaml` via `save_hosts_seed`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/screens/test_hosts.py`:
+```python
+"""Tests for HostsScreen — list + AddHostModal + escape back."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.screens.hosts import HostsScreen
+from hermia.tui.state import Host
+
+
+class TestHostsScreen:
+    def test_initial_render_shows_existing_hosts(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="eric-5090", url="http://e:11434", engine="ollama"),
+                    Host(name="m3-pro", url="http://m:4000", engine="openai-compat"),
+                ]
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                screen: HostsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.host_names == ["eric-5090", "m3-pro"]
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())
+
+    def test_plus_opens_add_modal(self) -> None:
+        async def _run() -> None:
+            from hermia.tui.screens.modals import AddHostModal
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                await pilot.press("plus")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, AddHostModal)
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement HostsScreen + AddHostModal**
+
+`src/hermia/tui/screens/hosts.py`:
+```python
+"""Hosts drill — list, add, remove, probe state."""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.state import Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class HostsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("plus", "add_host", "Add host", show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cursor_idx: int = 0
+
+    @property
+    def app_config(self):
+        return self.app.config  # type: ignore[attr-defined]
+
+    @property
+    def host_names(self) -> list[str]:
+        return [h.name for h in self.app_config.hosts]
+
+    def compose(self) -> ComposeResult:
+        name = self.app_config.name or "(unnamed)"
+        with Vertical():
+            yield Breadcrumb(["hermia", "fleet", name, "hosts"])
+            yield Static("", id="hosts-empty-notice")
+            for i, h in enumerate(self.app_config.hosts):
+                yield Static(self._row_text(h, i), id=f"host-row-{i}")
+
+    def on_mount(self) -> None:
+        self._refresh_empty_notice()
+
+    def _row_text(self, host: Host, idx: int) -> str:
+        cursor = "▸" if idx == self.cursor_idx else " "
+        return f"{cursor} {host.name}    {host.url}    [{host.engine}]"
+
+    def _refresh_empty_notice(self) -> None:
+        notice = self.query_one("#hosts-empty-notice", Static)
+        if self.app_config.hosts:
+            notice.update("")
+        else:
+            notice.update("No hosts yet — press '+' to add one.")
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_idx > 0:
+            self.cursor_idx -= 1
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_idx < len(self.app_config.hosts) - 1:
+            self.cursor_idx += 1
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_add_host(self) -> None:
+        from hermia.tui.screens.modals import AddHostModal
+        self.app.push_screen(AddHostModal(), self._on_host_added)
+
+    def _on_host_added(self, host: Host | None) -> None:
+        if host is None:
+            return
+        self.app_config.hosts.append(host)
+        # Re-mount to show the new row.
+        for child in list(self.children):
+            child.remove()
+        for w in self.compose():
+            self.mount(w)
+        self._refresh_empty_notice()
+```
+
+Add to `modals.py`:
+```python
+class AddHostModal(ModalScreen["Host | None"]):
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="modal"):
+            yield Label("Add host:")
+            yield Input(placeholder="name (eric-5090)", id="addhost-name")
+            yield Input(placeholder="url (http://eric:11434)", id="addhost-url")
+            yield Input(placeholder="engine (ollama / openai-compat)", id="addhost-engine")
+
+    def on_mount(self) -> None:
+        self.query_one("#addhost-name", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Submit on the engine field — last in the form.
+        if event.input.id != "addhost-engine":
+            return
+        from hermia.tui.state import Host
+        name = self.query_one("#addhost-name", Input).value.strip()
+        url = self.query_one("#addhost-url", Input).value.strip()
+        engine = (self.query_one("#addhost-engine", Input).value.strip()
+                  or "ollama")
+        if not name or not url:
+            return
+        self.dismiss(Host(name=name, url=url, engine=engine))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+```
+
+Update `config.py`'s `action_drill`:
+```python
+def action_drill(self) -> None:
+    from hermia.tui.screens.hosts import HostsScreen
+    from hermia.tui.screens.tests import TestsScreen
+    if self.cursor_row == 0:
+        self.app.push_screen(HostsScreen())
+    elif self.cursor_row == 1:
+        self.app.push_screen(TestsScreen())  # lands in Task 12
+```
+
+Task 10 will not import TestsScreen yet — defer that part until Task 12, or guard the import with a try/except. Cleanest: only push HostsScreen now, leave the tests-row enter as a no-op until Task 12:
+
+```python
+def action_drill(self) -> None:
+    if self.cursor_row == 0:
+        from hermia.tui.screens.hosts import HostsScreen
+        self.app.push_screen(HostsScreen())
+    # Tests drill lands in Task 12.
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/hosts.py src/hermia/tui/screens/modals.py src/hermia/tui/screens/config.py tests/unit/tui/screens/test_hosts.py
+git commit -m "feat(tui): HostsScreen + AddHostModal; config wires Hosts drill"
+```
+
+---
+
+## Task 11: screens/hosts.py — probe wiring + status badges
+
+**Files:**
+- Modify: `src/hermia/tui/screens/hosts.py`
+- Test: `tests/unit/tui/screens/test_hosts.py` (add tests)
+
+When the Hosts screen mounts (or after a host is added), kick off async probes via `probe_host()` for each host that hasn't been probed yet. Track per-host probe state ("idle" / "probing" / "ok" / "failed") and reflect it in the row.
+
+For testing without a network: the probe layer takes a transport argument. We override `transport_for` via dependency injection — `HostsScreen` accepts a `transport_factory: Callable[[Host], Transport] | None = None`. In tests, pass a factory that returns FakeTransport instances. Production uses the real `transport_for`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestHostsProbe:
+    def test_probe_populates_models_and_flips_to_ok(self) -> None:
+        from tests.fixtures.fake_transport import FakeTransport
+        from hermia.tui.state import Host
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [Host(name="h1", url="http://h1", engine="ollama")]
+                # Inject a factory that returns FakeTransport with two models.
+                screen = HostsScreen(transport_factory=lambda h: FakeTransport(models=["a", "b"]))
+                pilot.app.push_screen(screen)
+                await pilot.pause()
+                # Give the worker a beat to finish.
+                for _ in range(20):
+                    if screen.probe_state.get("h1") == "ok":
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["h1"] == "ok"
+                assert [m.name for m in pilot.app.config.hosts[0].models] == ["a", "b"]
+
+        asyncio.run(_run())
+
+    def test_probe_timeout_flips_to_failed(self) -> None:
+        from tests.fixtures.fake_transport import FakeTransport
+        from hermia.tui.state import Host
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [Host(name="slow", url="http://slow", engine="ollama")]
+                screen = HostsScreen(
+                    transport_factory=lambda h: FakeTransport(models=["x"], delay_seconds=2.0),
+                    probe_timeout=0.05,
+                )
+                pilot.app.push_screen(screen)
+                await pilot.pause()
+                for _ in range(20):
+                    if screen.probe_state.get("slow") in ("ok", "failed"):
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["slow"] == "failed"
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement**
+
+Add `from textual import work` import. Update `HostsScreen.__init__` to accept the factory and timeout. Add `self.probe_state: dict[str, str] = {}`. Add a Textual `@work` worker that runs `probe_host(...)` for each host and subscribes to `app.bus` if present (Plan 3 adds bus; for Plan 2 we can just await directly).
+
+Actually for Plan 2 the simplest: in `on_mount`, call `self.app.call_later(self._probe_all)`. `_probe_all` is an async method that iterates hosts and awaits `probe_host` with a per-host SessionBus subscriber that updates `probe_state`. Even simpler: use a private bus per screen.
+
+```python
+import asyncio
+from collections.abc import Callable
+from textual import work
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
+from hermia.tui.transport_adapter import transport_for as default_transport_for
+
+class HostsScreen(Screen[None]):
+    def __init__(
+        self,
+        *,
+        transport_factory: Callable[[Host], object] | None = None,
+        probe_timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+    ) -> None:
+        super().__init__()
+        self.cursor_idx = 0
+        self._make_transport = transport_factory or default_transport_for
+        self._probe_timeout = probe_timeout
+        self.probe_state: dict[str, str] = {}
+        self._bus = SessionBus()
+
+    def on_mount(self) -> None:
+        self._refresh_empty_notice()
+        self._start_probes()
+
+    @work
+    async def _start_probes(self) -> None:
+        # Subscribe before publishing so events aren't dropped.
+        async def listen() -> None:
+            async for ev in self._bus.subscribe("probe.started"):
+                self.probe_state[ev["host_name"]] = "probing"
+            async for ev in self._bus.subscribe("probe.completed"):
+                self.probe_state[ev["host_name"]] = "ok"
+            async for ev in self._bus.subscribe("probe.failed"):
+                self.probe_state[ev["host_name"]] = "failed"
+
+        # Two separate listener tasks per topic.
+        async def listen_one(topic: str, final_state: str) -> None:
+            async for ev in self._bus.subscribe(topic):
+                self.probe_state[ev["host_name"]] = final_state
+
+        asyncio.create_task(listen_one("probe.started", "probing"))
+        asyncio.create_task(listen_one("probe.completed", "ok"))
+        asyncio.create_task(listen_one("probe.failed", "failed"))
+        await asyncio.sleep(0)
+
+        # Probe each host that hasn't been probed.
+        for host in self.app_config.hosts:
+            if self.probe_state.get(host.name):
+                continue
+            transport = self._make_transport(host)
+            await probe_host(
+                host,
+                transport=transport,
+                bus=self._bus,
+                timeout=self._probe_timeout,
+            )
+```
+
+(Remove the stray nested `listen()` helper that was an early draft above — keep only `listen_one` plus the loop.)
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/hosts.py tests/unit/tui/screens/test_hosts.py
+git commit -m "feat(tui): HostsScreen — async probe wiring + probe_state map"
+```
+
+---
+
+## Task 12: screens/host_models.py — single host model picker
+
+**Files:**
+- Create: `src/hermia/tui/screens/host_models.py`
+- Modify: `src/hermia/tui/screens/hosts.py` (drill from a host row pushes HostModelsScreen)
+- Test: `tests/unit/tui/screens/test_host_models.py`
+
+After a host's probe completes, drilling into it shows its model list. Uses the foundation `DrillableList` widget. Selection state lives on `host.models[].selected`. Universal contract bindings: `/` (search), `space` (toggle), `a` / `n` (select all/none in current filter), `esc` (back).
+
+`tab` cycling for the models filter axis (family / size / quant / modality) is deferred to v0.3 — for Plan 2 we ship the screen with `apply_query` from a SearchBar but no filter axis. The model rows include size + quant hints as their label text so `/` search still hits substring matches.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/tui/screens/test_host_models.py`:
+```python
+"""Tests for HostModelsScreen — model picker for one host."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.host_models import HostModelsScreen
+from hermia.tui.state import Host, ModelChoice
+
+
+class TestHostModelsScreen:
+    def test_renders_host_models(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = Host(name="h1", url="http://h1", engine="ollama",
+                            models=[ModelChoice(name="m1"), ModelChoice(name="m2")])
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                screen: HostModelsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert sorted(screen.visible_model_names) == ["m1", "m2"]
+
+        asyncio.run(_run())
+
+    def test_space_toggles_selection(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = Host(name="h1", url="http://h1", engine="ollama",
+                            models=[ModelChoice(name="m1"), ModelChoice(name="m2")])
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("space")
+                await pilot.pause()
+                # First model is toggled on.
+                assert host.models[0].selected is True
+
+        asyncio.run(_run())
+
+    def test_select_all_then_none(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = Host(name="h1", url="http://h1", engine="ollama",
+                            models=[ModelChoice(name="m1"), ModelChoice(name="m2")])
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("a")
+                await pilot.pause()
+                assert all(m.selected for m in host.models)
+                await pilot.press("n")
+                await pilot.pause()
+                assert not any(m.selected for m in host.models)
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Single host's model picker — uses DrillableList + universal contract."""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+
+from hermia.tui.state import Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.search_bar import SearchBar
+
+
+class HostModelsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+        Binding("slash", "search_open", "Search", show=False),
+    ]
+
+    def __init__(self, *, host: Host) -> None:
+        super().__init__()
+        self._host = host
+
+    @property
+    def visible_model_names(self) -> list[str]:
+        dl = self.query_one(DrillableList)
+        return [r.label for r in dl.visible_rows]
+
+    def compose(self) -> ComposeResult:
+        name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
+        with Vertical():
+            yield Breadcrumb(["hermia", "fleet", name, "hosts", self._host.name])
+            rows = [ListRow(id_=m.name, label=m.name) for m in self._host.models]
+            yield DrillableList(rows)
+            yield SearchBar()
+
+    def on_mount(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Pre-mark selected models.
+        for m in self._host.models:
+            if m.selected:
+                dl._selected.add(m.name)
+        dl._refresh()
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        for m in self._host.models:
+            if m.name == event.row_id:
+                m.selected = not m.selected
+                break
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.query_one(DrillableList).apply_query(event.query)
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_cursor_prev(self) -> None:
+        self.query_one(DrillableList).cursor_prev()
+
+    def action_cursor_next(self) -> None:
+        self.query_one(DrillableList).cursor_next()
+
+    def action_toggle(self) -> None:
+        self.query_one(DrillableList).toggle()
+
+    def action_select_all(self) -> None:
+        dl = self.query_one(DrillableList)
+        dl.select_all()
+        for m in self._host.models:
+            if m.name in dl._selected:
+                m.selected = True
+
+    def action_select_none(self) -> None:
+        dl = self.query_one(DrillableList)
+        dl.select_none()
+        for m in self._host.models:
+            m.selected = False
+
+    def action_search_open(self) -> None:
+        self.query_one(SearchBar).open()
+```
+
+Wire HostsScreen to push HostModelsScreen on enter:
+```python
+# In HostsScreen, add enter binding + drill action:
+Binding("enter", "drill", "Drill", show=True),
+...
+def action_drill(self) -> None:
+    from hermia.tui.screens.host_models import HostModelsScreen
+    hosts = self.app_config.hosts
+    if 0 <= self.cursor_idx < len(hosts):
+        self.app.push_screen(HostModelsScreen(host=hosts[self.cursor_idx]))
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/host_models.py src/hermia/tui/screens/hosts.py tests/unit/tui/screens/test_host_models.py
+git commit -m "feat(tui): HostModelsScreen — single-host model picker"
+```
+
+---
+
+## Task 13: screens/tests.py — fleet-scoped multi-select with framework axis
+
+**Files:**
+- Create: `src/hermia/tui/screens/tests.py`
+- Modify: `src/hermia/tui/screens/config.py` (wire Tests drill)
+- Test: `tests/unit/tui/screens/test_tests.py`
+
+Uses `DrillableList` + `SearchBar` + `FilterAxis`. The filter axis is "framework" with values ["OWASP", "ATLAS", "MAESTRO", "NIST"]. When the axis filter is set, only tests with that framework membership show; combined with `/` search.
+
+Selection writes to `app.config.tests`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Tests for TestsScreen — fleet-scoped test multi-select with framework filter."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.tests import TestsScreen
+
+
+class TestTestsScreen:
+    def test_renders_all_tests_initially(self) -> None:
+        from hermia.schemas import TEST_IDS
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                screen: TestsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert set(screen.visible_test_ids) == set(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_select_all_populates_config_tests(self) -> None:
+        from hermia.schemas import TEST_IDS
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                await pilot.press("a")
+                await pilot.pause()
+                assert set(pilot.app.config.tests) == set(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_search_filters_visible_tests(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                screen: TestsScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.apply_query("multiturn")
+                await pilot.pause()
+                ids = screen.visible_test_ids
+                assert all("multiturn" in t for t in ids)
+                assert len(ids) >= 1
+```
+
+- [ ] **Step 2: Verify RED**
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Fleet-scoped test picker with framework filter axis."""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+
+from hermia.tui.test_catalog import FRAMEWORKS, load_test_catalog
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.filter_axis import FilterAxis
+from hermia.tui.widgets.search_bar import SearchBar
+
+
+class TestsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+        Binding("slash", "search_open", "Search", show=False),
+        Binding("tab", "next_axis", "Filter axis", show=False),
+        Binding("right", "next_value", "Next value", show=False),
+        Binding("left", "prev_value", "Prev value", show=False),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._catalog = load_test_catalog()
+        self._query: str = ""
+        self._framework_filter: str = "All"
+
+    @property
+    def visible_test_ids(self) -> list[str]:
+        dl = self.query_one(DrillableList)
+        return [r.id_ for r in dl.visible_rows]
+
+    def compose(self) -> ComposeResult:
+        name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
+        with Vertical():
+            yield Breadcrumb(["hermia", "fleet", name, "tests"])
+            yield FilterAxis({"framework": FRAMEWORKS})
+            rows = [ListRow(id_=r.id, label=r.id) for r in self._catalog]
+            yield DrillableList(rows)
+            yield SearchBar()
+
+    def on_mount(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Mirror app.config.tests as the initial selection.
+        for tid in self.app.config.tests:  # type: ignore[attr-defined]
+            dl._selected.add(tid)
+        dl._refresh()
+
+    # --- helpers -----------------------------------------------------------
+
+    def apply_query(self, q: str) -> None:
+        self._query = q.strip().lower()
+        self._reapply()
+
+    def _reapply(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Compute filtered rows by combining substring + framework membership.
+        rows: list[ListRow] = []
+        for rec in self._catalog:
+            if self._query and self._query not in rec.id.lower():
+                continue
+            if self._framework_filter != "All" and not rec.is_in_framework(self._framework_filter):
+                continue
+            rows.append(ListRow(id_=rec.id, label=rec.id))
+        dl._all_rows = rows
+        dl.visible_rows = rows
+        dl._cursor_idx = 0 if rows else -1
+        dl._refresh()
+
+    # --- event handlers ----------------------------------------------------
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.apply_query(event.query)
+
+    def on_filter_axis_changed(self, event: FilterAxis.Changed) -> None:
+        self._framework_filter = event.value or "All"
+        self._reapply()
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        cfg_tests = list(self.app.config.tests)  # type: ignore[attr-defined]
+        if event.row_id in cfg_tests:
+            cfg_tests.remove(event.row_id)
+        else:
+            cfg_tests.append(event.row_id)
+        self.app.config.tests = cfg_tests  # type: ignore[attr-defined]
+
+    # --- action_* wrappers -------------------------------------------------
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_cursor_prev(self) -> None:
+        self.query_one(DrillableList).cursor_prev()
+
+    def action_cursor_next(self) -> None:
+        self.query_one(DrillableList).cursor_next()
+
+    def action_toggle(self) -> None:
+        self.query_one(DrillableList).toggle()
+
+    def action_select_all(self) -> None:
+        dl = self.query_one(DrillableList)
+        dl.select_all()
+        # Sync app.config.tests.
+        self.app.config.tests = sorted({  # type: ignore[attr-defined]
+            *self.app.config.tests,  # type: ignore[attr-defined]
+            *(r.id_ for r in dl.visible_rows),
+        })
+
+    def action_select_none(self) -> None:
+        dl = self.query_one(DrillableList)
+        visible = {r.id_ for r in dl.visible_rows}
+        dl.select_none()
+        self.app.config.tests = [t for t in self.app.config.tests  # type: ignore[attr-defined]
+                                 if t not in visible]
+
+    def action_search_open(self) -> None:
+        self.query_one(SearchBar).open()
+
+    def action_next_axis(self) -> None:
+        self.query_one(FilterAxis).next_axis()
+
+    def action_next_value(self) -> None:
+        self.query_one(FilterAxis).next_value()
+
+    def action_prev_value(self) -> None:
+        self.query_one(FilterAxis).prev_value()
+```
+
+Wire `config.py`'s `action_drill` to push TestsScreen for cursor_row == 1:
+```python
+def action_drill(self) -> None:
+    if self.cursor_row == 0:
+        from hermia.tui.screens.hosts import HostsScreen
+        self.app.push_screen(HostsScreen())
+    elif self.cursor_row == 1:
+        from hermia.tui.screens.tests import TestsScreen
+        self.app.push_screen(TestsScreen())
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/tui/screens/tests.py src/hermia/tui/screens/config.py tests/unit/tui/screens/test_tests.py
+git commit -m "feat(tui): TestsScreen — fleet-scoped multi-select with framework filter"
+```
+
+---
+
+## Task 14: End-to-end picker Pilot smoke test
+
+**Files:**
+- Create: `tests/unit/tui/test_picker_e2e.py`
+
+One Pilot test per major flow, asserting the picker writes the right `app.config` state.
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""End-to-end picker smoke — drives the Launch ▸ Config ▸ drills via Pilot."""
+import asyncio
+from pathlib import Path
+
+from hermia.schemas import TEST_IDS
+from hermia.tui.app import HermiaApp
+from hermia.tui.fleet_io import fleet_path, save_fleet
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.screens.launch import LaunchScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestPickerE2E:
+    def test_quick_local_flow_ends_in_config_screen_with_pre_populated_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Launch → Quick local run (third entry).
+                await pilot.press("down", "down", "enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+                cfg = pilot.app.config
+                assert cfg.name == "quick-local"
+                assert cfg.hosts[0].url == "http://localhost:11434"
+                assert cfg.tests == list(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_load_existing_flow_into_config(self, tmp_path, monkeypatch) -> None:
+        save_fleet(
+            FleetConfig(
+                name="loaded",
+                hosts=[Host(name="h", url="http://h", engine="ollama",
+                            models=[ModelChoice(name="m", selected=True)])],
+                tests=["security-boundary"],
+            ),
+            root=tmp_path,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Launch → Load existing (first entry) → enter on the only fleet.
+                await pilot.press("enter")
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+                assert pilot.app.config.name == "loaded"
+                assert pilot.app.config.tests == ["security-boundary"]
+
+        asyncio.run(_run())
+
+    def test_save_via_s_writes_yaml(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("down")  # New fleet
+                await pilot.press("enter")
+                await pilot.pause()
+                pilot.app.config.name = "smoke"
+                await pilot.press("s")
+                await pilot.pause()
+                assert fleet_path("smoke").exists()
+
+        asyncio.run(_run())
+```
+
+- [ ] **Step 2: Verify GREEN**
+
+```bash
+pytest tests/unit/tui/test_picker_e2e.py -v --no-cov
+```
+
+If a flow fails, fix the underlying screen — do NOT bypass the test.
+
+- [ ] **Step 3: Final sweep**
+
+```bash
+pytest --no-cov
+ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/
+mypy src/hermia/tui/
+```
+
+All three must pass. Fix anything.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/tui/test_picker_e2e.py
+git commit -m "test(tui): end-to-end picker smoke — Launch → drills → save"
+```
+
+---
+
+## Plan Close
+
+- [ ] **C1: Push and open PR to dev**
+
+```bash
+git push -u origin feature/fleet-tui-picker
+gh pr create --base dev --title "feat(tui): picker screens — Launch / Config / Hosts / Models / Tests" --body "$(cat <<'EOF'
+## Summary
+
+Picker flow for the Fleet TUI per [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](../specs/2026-06-18-fleet-tui-design.md). Builds Launch, Fleet Config, Hosts, Host Models, and Tests screens on top of the Plan 1 foundation. Single fleet config in memory, save/load to `fleets/<name>.yaml`, Quick Local Run smart-default for the laptop-user path.
+
+Runs via `python -m hermia.tui` — separate from the existing `hermia` CLI. Plan 3 (runner) wires the run path; Plan 4 cuts over the main entry and deletes `screens.py`.
+
+## Test plan
+
+- [ ] `pytest tests/unit/tui/` — all green
+- [ ] `pytest` — full suite green
+- [ ] `ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/` — clean
+- [ ] `mypy src/hermia/tui/` — clean
+- [ ] Manual: `python -m hermia.tui` — walk Quick Local Run → save → reload → exit
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **C2: Post `/gemini review`**
+
+```bash
+gh pr comment <PR-number> --body "/gemini review"
+```
+
+Address HIGH-priority findings per AGENTS.md rule 9.
+
+- [ ] **C3: bd note on hermia-86g**
+
+```bash
+bd note hermia-86g "Plan 2 (picker screens) merged to dev. Plan 3 (runner) next."
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec section | Implemented in this plan |
+|---|---|
+| §1 module layout (`screens/`, app.py) | Tasks 4-13 |
+| §2 hosts.yaml seed source | Task 10 |
+| §3 test catalog with framework tags | Task 1 |
+| §4 transport adapter (engine dispatch) | Task 2 |
+| §5 universal navigation contract (per-screen bindings) | Tasks 5-13 |
+| §5 Quick Local Run smart-default | Task 7 |
+| §5 unsaved-changes indicator | Task 9 |
+| §5 breadcrumb header | Tasks 3, 8-13 |
+| §6 probe failure surfaces wired to UI badges | Task 11 |
+
+Out of scope (Plans 3-4):
+- Runner screens (L1, L2, L3) — Plan 3
+- Unsaved-changes confirm modal at app close — Plan 4 ties this into app.py rewire
+- screens.py deletion + app.py rewire — Plan 4
+- Models drill `tab` filter axis (family/size/quant/modality) — v0.3 follow-up
+
+**2. Placeholder scan:** Every task contains real code. Test-stub branches in Task 5 are explicitly marked with `@pytest.mark.xfail` and the marker is removed in Task 5 Step 5.
+
+**3. Type consistency:** `FleetConfig` / `Host` / `ModelChoice` signatures match Plan 1. `SessionBus` usage in Task 11 matches Plan 1's API. `DrillableList` / `SearchBar` / `FilterAxis` / `Breadcrumb` usages match their defined widget APIs.
+
+**4. Ambiguity:** Task 11's screen-internal SessionBus is intentionally per-screen for Plan 2; Plan 3 introduces a shared `app.bus` for runner ↔ screens. Task 12 acknowledges the missing models filter axis as v0.3 deferred work. Task 13 wires both Hosts and Tests drills from FleetConfigScreen in the same commit since both depend on FleetConfigScreen's `action_drill`.

--- a/docs/superpowers/plans/2026-06-18-fleet-tui-picker.md
+++ b/docs/superpowers/plans/2026-06-18-fleet-tui-picker.md
@@ -317,16 +317,29 @@ For v0.2 we ship two probe shapes:
 vLLM / SGLang / LiteLLM all speak the OpenAI shape, so any non-"ollama"
 engine falls back to the openai-compat path.
 
+Implementation note: uses stdlib `urllib.request` wrapped in
+`asyncio.to_thread` rather than `httpx`. `httpx` is NOT in pyproject.toml
+and AGENTS.md rule 3 blocks adding deps without approval. urllib is
+stdlib; the thread offload keeps probe_host's async contract.
+
+Per spec §6 / probe.py docstring, this adapter MUST normalize transport
+exceptions to the stdlib classes probe.py catches:
+    - timeout              → TimeoutError  (handled at probe.py's wait_for)
+    - HTTP 401/403         → PermissionError
+    - URLError / OSError   → propagates as OSError/ConnectionError
+
 Auth header is resolved from the environment variable named by
 host.auth_header_env. Per AGENTS.md rule 11, the secret value never appears
 in any saved config — only the env var name does.
 """
 from __future__ import annotations
 
+import asyncio
+import json
 import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
-
-import httpx
 
 from hermia.tui.state import Host
 
@@ -336,31 +349,29 @@ class _BaseProbeTransport:
     url: str
     auth_header: str | None = None
 
-    def _client(self) -> httpx.AsyncClient:
-        headers = {"Authorization": self.auth_header} if self.auth_header else {}
-        return httpx.AsyncClient(headers=headers, timeout=10.0)
+    def _fetch_sync(self, path: str) -> dict:
+        req = urllib.request.Request(f"{self.url.rstrip('/')}{path}")
+        if self.auth_header:
+            req.add_header("Authorization", self.auth_header)
+        try:
+            with urllib.request.urlopen(req, timeout=10.0) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise PermissionError(f"{exc.code} from {self.url}") from exc
+            raise
 
 
 class OllamaProbeTransport(_BaseProbeTransport):
     async def list_models(self) -> list[str]:
-        async with self._client() as client:
-            resp = await client.get(f"{self.url.rstrip('/')}/api/tags")
-            if resp.status_code in (401, 403):
-                raise PermissionError(f"{resp.status_code} from {self.url}")
-            resp.raise_for_status()
-            data = resp.json()
-            return [m["name"] for m in data.get("models", [])]
+        data = await asyncio.to_thread(self._fetch_sync, "/api/tags")
+        return [m["name"] for m in data.get("models", [])]
 
 
 class OpenAICompatProbeTransport(_BaseProbeTransport):
     async def list_models(self) -> list[str]:
-        async with self._client() as client:
-            resp = await client.get(f"{self.url.rstrip('/')}/v1/models")
-            if resp.status_code in (401, 403):
-                raise PermissionError(f"{resp.status_code} from {self.url}")
-            resp.raise_for_status()
-            data = resp.json()
-            return [m["id"] for m in data.get("data", [])]
+        data = await asyncio.to_thread(self._fetch_sync, "/v1/models")
+        return [m["id"] for m in data.get("data", [])]
 
 
 def transport_for(host: Host) -> _BaseProbeTransport:
@@ -374,7 +385,7 @@ def transport_for(host: Host) -> _BaseProbeTransport:
     return cls(url=host.url, auth_header=auth_header)
 ```
 
-**Dependency check:** `httpx` is already in `pyproject.toml` (used by existing `transport/`). Confirm with `grep httpx pyproject.toml` before implementing. If missing, **stop and ask the user** — adding a dep needs explicit approval per AGENTS.md rule 3.
+**Dependency check:** stdlib-only — `urllib.request`, `urllib.error`, `json`, `asyncio`. **No `httpx` or `requests` needed.** Confirms compliance with AGENTS.md rule 3. (Note: the existing `src/hermia/transport/` uses `requests`; this is a deliberately separate codepath because the runner is sync-oriented and the TUI probe needs `async`. If a future Plan 3+ wants to share with the runner, an `asyncio.to_thread` wrap around the existing `requests`-based transports also works.)
 
 - [ ] **Step 4: Verify GREEN**
 

--- a/docs/superpowers/specs/2026-06-18-fleet-tui-design.md
+++ b/docs/superpowers/specs/2026-06-18-fleet-tui-design.md
@@ -1,0 +1,448 @@
+# Fleet TUI — Unified Interactive Picker + Live Runner
+
+**Status:** Design, pre-implementation
+**Author:** Scott Bly (with Claude)
+**Tracking bead:** `hermia-86g`
+**Blocks:** `hermia-4e8` (Cut v0.2.0)
+**Date:** 2026-06-18
+
+---
+
+## 1. Overview & Goals
+
+Replace the existing single-host TUI (`screens.py`) with a unified Fleet TUI that handles single-host *and* multi-host evaluation through one coherent interface. Fleet mode today runs only from `hermia-fleet.yaml`; this design adds interactive host / model / test selection, live drill-down progress, and named saved fleets, while preserving the headless `--fleet path.yaml` flag for CI / scripted use.
+
+### Goals
+
+- One TUI for both single-host and multi-host workflows; no parallel implementations
+- Interactive host discovery (seed-list-based for v1, active discovery on roadmap), model selection per host, and fleet-scoped test selection
+- Live drill-down runner view: aggregate → per-trial table → streaming detail
+- Named, saved fleets (`fleets/<name>.yaml`) — loadable, editable, reusable
+- Universal navigation grammar (`enter`/`esc`/`/`/`tab`/`space`/`a`/`n`) consistent across every drill screen
+- Mouse as a first-class peer to keyboard
+- Architectural seams for v0.3+: `HostSource`, `ModelSource`, recommendation engine, MCP-sourced benchmark data
+
+### Non-goals
+
+- Replace `transport/`, `scoring.py`, `robustness.py`, or `fingerprint/` — this is a UI / orchestration change only
+- Build the v0.3 recommendation engine (designed for, not built here)
+- Coordinator + worker control plane (the v0.2 TUI design intentionally stops at ~200-500 hosts; see §4 scaling envelope)
+
+---
+
+## 2. Architecture & Module Layout
+
+### New package: `src/hermia/tui/`
+
+```
+src/hermia/tui/
+  __init__.py
+  app.py                    # HermiaApp — Textual App subclass
+  screens/
+    __init__.py
+    launch.py               # Load existing / New fleet / Quick local run
+    config.py               # Fleet Config — drill home (Hosts ▸ + Tests ▸)
+    hosts.py                # Hosts drill — list + add + probe state
+    host_models.py          # Single host's model picker
+    tests.py                # Fleet-scoped test picker with framework axis
+    runner.py               # L1 aggregate
+    runner_trials.py        # L2 trial table
+    runner_detail.py        # L3 streaming detail
+  widgets/                  # Reusable, domain-agnostic
+    __init__.py
+    drillable_list.py
+    filter_axis.py
+    search_bar.py
+    status_badge.py
+    progress_bar.py
+  bus.py                    # SessionBus — runner publishes, screens subscribe
+  state.py                  # FleetConfig + HostSource / ModelSource protocols
+  fleet_io.py               # Load/save fleets/<name>.yaml
+  probe.py                  # Async host probing wrapping transport/
+```
+
+### Boundaries
+
+- `widgets/` knows nothing about hermia domain — pure Textual building blocks; reusable for any future TUI
+- `screens/` composes widgets into hermia-specific screens
+- `bus.py` is the **only** shared mutable state between runner and screens; no screen pokes runner internals
+- `state.py`'s `FleetConfig` is the in-memory source of truth for the in-flight edit; `fleet_io.py` converts to/from YAML
+- `probe.py` wraps existing `transport/` with TUI-shaped async / timeout / retry; no new transport code
+
+### Deleted in the same PR
+
+- `src/hermia/screens.py` (398 lines)
+- `tests/unit/test_screens.py` (156 lines)
+- `tests/unit/test_screens_pilot.py` (566 lines — patterns reused in new tests)
+
+### Modified
+
+- `src/hermia/app.py` — opens unified TUI; `--fleet path.yaml` headless path preserved for CI
+
+### Extension protocols (defined now, implementations come later)
+
+```python
+class HostSource(Protocol):
+    async def list_hosts(self) -> list[Host]: ...
+
+class ModelSource(Protocol):
+    async def list_models(self, host: Host) -> list[ModelChoice]: ...
+```
+
+v0.2 implementations:
+- `SeedFileHostSource` — `~/.config/hermia/hosts.yaml`
+- `ManualHostSource` — the "+ add host" affordance
+- `ProbeModelSource` — host's `/v1/models` or `/api/tags`
+
+Future implementations (v0.3+, file as bd beads, do not build now):
+- `KwaainetRegistryHostSource`, `ConsulHostSource`, `KubernetesHostSource`, `TailscaleHostSource`
+- `RecommendationModelSource`, `BenchmarkScoredModelSource`, `MCPBenchmarkSource`, `LocalCacheModelSource`
+
+---
+
+## 3. Data Model & YAML Schemas
+
+### In-memory
+
+```python
+@dataclass
+class FleetConfig:
+    name: str                       # "kwaainet-baseline" — saved as fleets/<name>.yaml
+    hosts: list[Host]
+    tests: list[str]                # test IDs, fleet-scoped (every host × model runs every test)
+    repeat: int = 1
+
+@dataclass
+class Host:
+    name: str
+    url: str
+    engine: str                     # "ollama" | "openai-compat" | "vllm" | …
+    auth_header_env: str | None = None
+    hardware: str | None = None     # static fallback; sidecar override wins
+    models: list[ModelChoice]
+
+@dataclass
+class ModelChoice:
+    name: str
+    selected: bool
+    # cached from probe — not persisted to YAML
+    size_bytes: int | None = None
+    quant: str | None = None
+    family: str | None = None
+    modality: str | None = None
+```
+
+### Saved fleet: `fleets/<name>.yaml`
+
+```yaml
+name: kwaainet-baseline
+created: 2026-06-18T16:32:14Z
+hermia_version: 0.2.0
+
+tests:
+  - prompt-injection-1
+  - jailbreak-1
+  - leakage-1
+
+hosts:
+  - name: eric-5090
+    url: https://eric.tail***.ts.net:11434
+    engine: ollama
+    hardware: RTX 5090
+    auth_header_env: LITELLM_KEY
+    models:
+      - qwen3-coder:30b
+      - qwen3:32b
+
+repeat: 1
+```
+
+### User seed list: `~/.config/hermia/hosts.yaml`
+
+```yaml
+hosts:
+  - name: eric-5090
+    url: https://eric.tail***.ts.net:11434
+    engine: ollama
+    hardware: RTX 5090
+    auth_header_env: LITELLM_KEY
+```
+
+User-level (not project-level) so it survives clones and isn't checked in by accident. New hosts added in the TUI offer to save to this file with a checkbox.
+
+### Schema decisions
+
+- `auth_header_env` stores the **env var name**, not the secret — YAML is safe to share with a Kwaainet participant
+- `hardware` is a hint, not authoritative — sidecar agent overrides at runtime; static field is bootstrap fallback
+- Model metadata not persisted in YAML — re-probed on load (cheap, always current)
+- `hermia_version` stamp lets future code know which YAML format wrote a file
+
+### Migration from `hermia-fleet.yaml`
+
+On first TUI launch, if `hermia-fleet.yaml` exists at the repo root, offer to copy it to `fleets/hermia-fleet.yaml` (one-time, with a notice). No silent migration; no force-move.
+
+---
+
+## 4. Event Bus & Concurrency
+
+### Bus
+
+A single in-process `SessionBus` attached to `HermiaApp` at mount. Topic-based async pub/sub, `asyncio.Queue` per subscriber.
+
+```python
+class SessionBus:
+    async def publish(self, topic: str, event: dict) -> None: ...
+    def subscribe(self, topic: str) -> AsyncIterator[dict]: ...
+```
+
+### Topics
+
+| Topic | Publisher | Subscribers |
+|---|---|---|
+| `probe.started` / `probe.completed` / `probe.failed` | `probe.py` | Hosts drill |
+| `run.started` / `run.completed` / `run.paused` / `run.resumed` / `run.aborted` | `runner.py` | Runner L1 |
+| `run.trial_started` / `run.trial_finished` | `runner.py` | All three runner levels |
+| `run.trial_chunk` | `runner.py` | L3 only (focused trial) |
+
+### Queue bounds
+
+- Trial event queues: **unbounded** (sparse enough that bounded would never trigger)
+- L3 chunk queue: **bounded at 64, drop-oldest** (only matters during streaming on a slow render path; "show me the tail" is the contract)
+
+### Concurrency model
+
+- **Probes:** Textual `@work` workers, bounded concurrency = 8 by default (tunable via `HERMIA_PROBE_CONCURRENCY` env), 8s timeout, cancellable, retry button re-queues
+- **Run dispatch:** the existing concurrent runner in `fleet.py` publishes through the bus instead of writing rows to disk only
+- **UI render:** Textual's reactive system + fixed throttle — L1 refreshes at most every 250 ms regardless of event volume; L2 appends at 60 fps; L3 streams as chunks arrive
+
+### Pause / abort
+
+- **Pause:** drain in-flight, no new dispatch. Resume re-arms dispatch. Mid-trial pause is not supported (inference APIs don't expose it)
+- **Abort:** cancels all in-flight workers, writes partial results via existing sink, emits `run.aborted`. TUI shows `Aborting…` state on L1 during drain (10s hard cutoff)
+
+### Cancellation contract
+
+Abort *must* drain disk writes before exiting. The runner's existing sink layer (`sink/submission.py`) handles flush; TUI waits on the abort coroutine.
+
+### Scaling envelope
+
+The TUI design is correct up to ~200-500 hosts. Friction points along the way:
+
+| Hosts | First friction | Fix |
+|---|---|---|
+| ~25 | Probe concurrency cap (8) — fleet setup waits | Bump `HERMIA_PROBE_CONCURRENCY` setting |
+| ~100 | L1 per-host roll-up becomes noisy | "Compact mode" toggle (`c` collapses inactive hosts into a sparkline row) — file as `hermia-tui-scale-2` (P3) |
+| ~200-500 | Single TUI process becomes the dispatch bottleneck | Topology change — see below |
+
+### Topology evolution
+
+Beyond ~500 hosts, the shape changes from single-process TUI to **operator console + control plane + workers** (same pattern as kubectl / Rancher / Fleet / Ansible Tower). At that scale:
+
+- Rows represent clusters / regions, not individual hosts
+- Dispatch fires from regional workers, not the TUI process
+- The TUI subscribes to a coordinator's event stream instead of probing directly
+
+**The widget library and drill idiom built here carry over unchanged** to that future topology. Only the data sources and worker layer change. The `HostSource` abstraction is the seam where coordinator-style registries plug in.
+
+### Shared-node citizenship
+
+For Kwaainet-scale shared-node deployments, hermia stays a polite citizen:
+
+- Probe rate limit per host (200ms minimum gap to same URL)
+- Transport-layer respect for 429 / 503 with exponential backoff (existing behavior preserved)
+- Future `node.capacity` advisory — if a node publishes "I can take N concurrent trials," hermia respects it (file as v0.3 bd bead)
+
+---
+
+## 5. Screens: Drill Semantics & Navigation Contract
+
+### Stack-based navigation
+
+Textual's `push_screen` / `pop_screen` is the drill mechanism. Every drill is a push; every esc / back-click is a pop. No mode flags, no global state — the stack *is* the navigation state.
+
+### Universal contract
+
+| Input | Action |
+|---|---|
+| `enter` / row click | Push detail screen — drill in |
+| `esc` / back-chip click | Pop — climb out, preserves parent's selection/filter |
+| `space` | Toggle row's selected state (where applicable) |
+| `/` | Open search input at footer — live filter |
+| `tab` | Cycle filter axis (screens without an axis no-op) |
+| `a` / `n` | Select all / none in current filter view |
+| `↑↓` / mouse wheel / drag-scroll | Move cursor / scroll |
+| `?` | Help overlay |
+| `^C` | Cancel current async action. Behavior is screen-scoped: on Hosts drill cancels in-flight probes (no confirm); on Runner L1 aborts the run (confirm modal — destructive) |
+| `q` (Launch screen only) | Quit app — confirm modal if any unsaved fleet edits exist in the stack |
+
+### Breadcrumb
+
+Every drillable screen has a breadcrumb header (`hermia · fleet · kwaainet-baseline ▸ hosts ▸ marcus`). Each `▸` segment is clickable for direct jump-back. Same affordance on the runner (L1 ▸ L2 ▸ L3).
+
+### Lifecycle hooks
+
+| Hook | Behavior |
+|---|---|
+| `on_mount` | Subscribe to bus topics; populate from state |
+| `on_screen_resume` | Re-render — called when this screen becomes top of stack again |
+| `on_screen_suspend` | Pause render work — called when a new screen pushes on top |
+| `on_unmount` | Unsubscribe; cancel pending workers |
+
+### State propagation
+
+`FleetConfig` is the single in-memory source of truth. Picker screens read and write directly to it — no diff merging, no draft state. The Fleet Config screen shows `[unsaved changes]` in the header when in-memory state diverges from disk. The unsaved-changes confirm modal triggers at **app close** (`q` from Launch or window close), not on screen pops — Fleet Config remains in memory as the user navigates the drill stack, so popping doesn't lose work.
+
+### Runner state across drills
+
+Drilling L1 ▸ L2 ▸ L3 does not pause the run. Each level subscribes to bus events at its appropriate granularity. Popping back to L1 doesn't lose state because the bus has been streaming the whole time and L1 maintains aggregates from those events.
+
+### Mouse parity
+
+`DrillableList` binds row-click and `enter` to the same handler. Mouse and keyboard are siblings, not parallel implementations. All universal-contract bindings have mouse equivalents.
+
+### Stack depth
+
+Textual's default max is 20. Our deepest drill is Launch ▸ FleetConfig ▸ Hosts ▸ Host ▸ Models = 5. 4× headroom.
+
+### UX decisions reference
+
+Settled during brainstorming, recorded here for future reference:
+
+**Status semantics:** `defended` / `refused` / `breached` / `error`
+- `defended` — model produced compliant output (good security outcome)
+- `refused` — model said no (valence depends on test direction; benign tests treat refusal as bad)
+- `breached` — model produced non-compliant output (jailbroken, leaked, complied with injection)
+- `error` — no usable output (TIMEOUT, EMPTY_RESPONSE, transport error)
+
+**Icons:** `✓ ↺ ✗ !` (with `↺` → `⊘` as a fallback if terminal rendering of the arrow proves flaky in real-world fonts)
+
+**Refusal color:** rendered per-test-direction. Harmful tests: refusal = green-ish (good). Benign tests (v0.3 BAM Benign): refusal = red-ish (over-refusal).
+
+**Filter axes by screen:**
+- Hosts: engine, lane
+- Models: family, size class, quant, modality
+- Tests: framework (OWASP / ATLAS / MAESTRO / NIST)
+
+**Probe timeout:** 8s default with Retry button on failure.
+
+**Repeats in L2:** when `repeat > 1`, each repetition is its own row in the L2 trial table (so the user can see per-rep variance). Robustness aggregates (`robustness.py`) are surfaced at L1 in the per-host roll-up summary, not in L2.
+
+**Hardware tag display:** UI shows the value plain (no "(static)" / "(sidecar)" suffix) — source distinction is internal. Sidecar-supplied value always wins when present; static value renders only when sidecar is silent.
+
+**Quick local run** Launch entry: pre-fills `http://localhost:11434` as a single host with the default test set, probes immediately, jumps to model selection. Preserves single-machine 2-click muscle memory.
+
+---
+
+## 6. Error Handling
+
+Layered model: each failure has a defined surface and a defined recovery.
+
+| Failure | Caught | UI behavior | Recovery |
+|---|---|---|---|
+| Probe timeout (8s) | `probe.py` worker | Badge `! timeout`; Retry inline | User clicks Retry |
+| Probe auth failure (401/403) | `probe.py` | Badge `! auth`; hints to check `auth_header_env` | User edits → Retry |
+| Probe transport error | `probe.py` | Badge `! offline`; no auto-retry | Retry button; user may remove host |
+| Probe returns empty model list | `probe.py` validation | Badge `! no models`; warns "0 models → 0 trials" | User adds models or removes host |
+| Trial timeout / transport error during run | `transport/` (existing) | Trial row → `! error`, counts toward error tally | Run continues; no per-trial retry from TUI |
+| Host goes offline mid-run | First failed trial cascades | All in-flight on that host fail; remaining skip with `! host-offline` | Run continues on other hosts |
+| YAML load: missing | `fleet_io.py` | Toast: "No fleet found at `<path>`" | User picks another or creates new |
+| YAML load: malformed | `fleet_io.py` validation | Toast with parse error; "open in editor" | User fixes externally; reload via `r` |
+| YAML save: permission denied | `fleet_io.py` | Toast with error; data stays in memory unsaved | User adjusts permissions |
+| YAML save: dir doesn't exist | `fleet_io.py` | Creates `fleets/` on first save automatically | None needed |
+| Bus subscriber lag | `bus.py` queue overflow | L3 chunk queue drops oldest (bounded 64); never blocks publisher | Invisible to user |
+| Sidecar disagrees with static `hardware` | `state.py` reconcile | Sidecar wins silently; static shown grayed | None — sidecar authoritative when present |
+| Screen exception | Textual error handler | Crash modal with traceback + report-issue link; pops to last-good state | User can continue or quit |
+| App crash mid-run | Process exit | CSV has what completed (existing sink behavior) | Same recovery as today |
+
+### Principles
+
+1. **No silent failures.** Every error surfaces — badge on the offending row, toast for global errors, crash modal for unhandled exceptions
+2. **Errors don't poison sibling state.** Failures are local to their scope
+3. **Recoverable failures have Retry; unrecoverable have Replace.** No exponential-backoff auto-retry loops in the UI layer — that belongs in `transport/` where it already exists
+
+### Out of scope for v1 (future bd beads)
+
+- Auto-resume from partial CSV after crash
+- Per-trial retry from L3 detail view
+- Pluggable error reporters (Sentry, etc.)
+
+---
+
+## 7. Testing Strategy
+
+Layered, no test depends on a live host. Fleet/network surface uses fakes; TUI surface uses Textual Pilot.
+
+| Layer | What | How |
+|---|---|---|
+| Widgets | `DrillableList`, `FilterAxis`, `SearchBar`, `StatusBadge`, `ProgressBar` | Pure widget unit tests in a throwaway `App` |
+| State | `FleetConfig` mutation, YAML round-trip, hosts.yaml load/save, fleet name validation, legacy migration | Plain unit tests — no Textual |
+| Bus | Topic subscription, queue bounds, drop-oldest on chunk overflow, abort propagation | `pytest-asyncio` |
+| Probe | Timeout, retry, auth failure, empty-model-list | Mock transport; assert correct `probe.*` events |
+| Screens | Drill push/pop, breadcrumb jump, save/load, picker → runner handoff, error toasts | Textual Pilot tests |
+| Runner integration | Picker → save → run → results, with fake transport scripting deterministic mix of pass/refuse/fail/error | One Pilot end-to-end per major flow |
+
+### TDD
+
+Per `superpowers:test-driven-development`. Each implementation slice: red → green → refactor.
+
+### NOT tested
+
+- Textual internals (frame timing, character-level render output)
+- Live host network behavior (`transport/` has those tests)
+- Existing scoring / robustness logic (`scoring.py`, `robustness.py` cover it)
+- Pixel-level mockup appearance
+
+### Tests retired
+
+- `tests/unit/test_screens.py` → replaced by `tests/unit/test_tui_screens.py`
+- `tests/unit/test_screens_pilot.py` → patterns retained, file replaced
+
+### Shared fixture
+
+`tests/fixtures/fake_transport.py` — a `FakeTransport` class implementing the real `transport/` protocol but scripting responses from a deterministic config (e.g., `{"prompt-injection-3 + qwen3:32b": "breached", "leakage-1 + qwen2.5:7b": "refused"}`). Single fixture for any test driving the full picker → run → results path without a real host.
+
+---
+
+## 8. Extension Points & v0.3+ Roadmap
+
+The v0.2 design exposes these seams deliberately:
+
+| Seam | v0.2 implementation | v0.3+ implementations (file as bd beads) |
+|---|---|---|
+| `HostSource` | `SeedFileHostSource`, `ManualHostSource` | `KwaainetRegistryHostSource`, `ConsulHostSource`, `KubernetesHostSource`, `TailscaleHostSource` |
+| `ModelSource` | `ProbeModelSource` | `RecommendationModelSource`, `BenchmarkScoredModelSource`, `MCPBenchmarkSource`, `LocalCacheModelSource` |
+| Launch screen entries | Load existing / New fleet / Quick local run | "Recommend models for my stack" entry that pre-populates FleetConfig from a recommendation engine |
+| Widget library | `DrillableList`, `FilterAxis`, etc. | Reused by future operator-console at enterprise scale; reused by recommendation review screens |
+
+### v0.3 bd beads to file after v0.2.0 ships
+
+- `hermia-rec-data` — normalized cross-benchmark schema (PyRIT, Garak, MMLU, HumanEval, BigBench, MTEB)
+- `hermia-rec-ingest` — pipeline for pulling + normalizing third-party benchmark data; cadence; license / attribution handling
+- `hermia-rec-engine` — hardware × use-case → ranked model recommendations
+- `hermia-rec-tui` — Launch-screen "Recommend models for my stack" entry + recommendation review screen
+- `hermia-rec-mcp` — `MCPBenchmarkSource` for consuming benchmark data via MCP servers
+- `hermia-rec-commercial` (note-only) — commercial strategy for the recommendation tier
+- `hermia-tui-scale-1` — make probe concurrency a setting (env or per-fleet)
+- `hermia-tui-scale-2` — L1 compact mode for fleets >50 hosts
+
+### Open follow-up beads already filed
+
+- `hermia-86g` — this design (the bead this spec was authored against)
+- `hermia-coc` (P2) — VRAM-aware model recommendations per fleet node (data feeds the recommendation engine)
+- `hermia-q52` (P2) — BAM Benign tier (over-refusal); the refusal-color logic in §5 is designed for this
+
+---
+
+## 9. Out of Scope
+
+Explicitly not built in this design:
+
+- Recommendation engine (v0.3 roadmap)
+- Active host discovery — mDNS / Tailscale peer enum / subnet scan (v0.3 roadmap)
+- Per-test cherry-pick UI (v1 has full multi-select; named test-set picker punted to v0.3 roadmap)
+- Per-host model overrides on top of a global model set (v0.3 roadmap)
+- Auto-resume from partial CSV after crash
+- Per-trial retry from the TUI
+- Pluggable error reporters
+- Backwards-compat shim for `screens.py` callers (none exist outside `app.py`; clean break in same PR)
+- Coordinator + worker control plane (enterprise topology; rebuild post-v0.5 if/when needed)

--- a/src/hermia/tui/__init__.py
+++ b/src/hermia/tui/__init__.py
@@ -1,1 +1,39 @@
-"""Hermia Fleet TUI — unified interactive picker + live runner."""
+"""Hermia Fleet TUI — unified interactive picker + live runner.
+
+Public surface for downstream callers (Plan 2 picker screens, Plan 3 runner
+screens, Plan 4 app.py rewire).
+"""
+from hermia.tui.bus import SessionBus
+from hermia.tui.fleet_io import (
+    DEFAULT_HOSTS_SEED_PATH,
+    fleet_path,
+    load_fleet,
+    load_hosts_seed,
+    save_fleet,
+    save_hosts_seed,
+)
+from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
+from hermia.tui.state import (
+    FleetConfig,
+    Host,
+    HostSource,
+    ModelChoice,
+    ModelSource,
+)
+
+__all__ = [
+    "DEFAULT_HOSTS_SEED_PATH",
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "FleetConfig",
+    "Host",
+    "HostSource",
+    "ModelChoice",
+    "ModelSource",
+    "SessionBus",
+    "fleet_path",
+    "load_fleet",
+    "load_hosts_seed",
+    "probe_host",
+    "save_fleet",
+    "save_hosts_seed",
+]

--- a/src/hermia/tui/__init__.py
+++ b/src/hermia/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Hermia Fleet TUI — unified interactive picker + live runner."""

--- a/src/hermia/tui/bus.py
+++ b/src/hermia/tui/bus.py
@@ -52,7 +52,11 @@ class SessionBus:
                     q.get_nowait()
                 except asyncio.QueueEmpty:
                     pass
-            await q.put(event)
+            # put_nowait keeps the get_nowait + put pair atomic in
+            # single-threaded asyncio — `await q.put` would yield between the
+            # two ops, letting another coroutine fill the slot we just freed
+            # and re-blocking the publisher on a full bounded queue.
+            q.put_nowait(event)
 
     async def _consume(
         self,

--- a/src/hermia/tui/bus.py
+++ b/src/hermia/tui/bus.py
@@ -1,0 +1,54 @@
+"""SessionBus — topic-based async pub/sub for runner ↔ screens.
+
+The only shared mutable state between the runner backend and the runner
+screens. Screens subscribe to topics they care about; the runner publishes
+events. Per-subscriber asyncio.Queue keeps a slow renderer from
+backpressuring the runner.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class SessionBus:
+    def __init__(self) -> None:
+        self._subscribers: dict[str, list[asyncio.Queue[dict[str, Any]]]] = defaultdict(list)
+
+    def subscribe(
+        self,
+        topic: str,
+        *,
+        maxsize: int = 0,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Subscribe to a topic. Returns an async iterator of event payloads.
+
+        maxsize=0 (default) is an unbounded queue — appropriate for sparse
+        trial topics. Pass maxsize > 0 for high-throughput streams (e.g.
+        run.trial_chunk) that should drop-oldest on overflow.
+        """
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+        self._subscribers[topic].append(q)
+        return self._consume(q)
+
+    async def publish(self, topic: str, event: dict[str, Any]) -> None:
+        """Publish an event to all subscribers of the given topic.
+
+        Bounded subscribers drop their oldest queued event on overflow rather
+        than block the publisher. Sparse (unbounded) subscribers never overflow.
+        """
+        for q in self._subscribers.get(topic, []):
+            if q.maxsize and q.full():
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            await q.put(event)
+
+    @staticmethod
+    async def _consume(q: asyncio.Queue[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+        while True:
+            ev = await q.get()
+            yield ev

--- a/src/hermia/tui/bus.py
+++ b/src/hermia/tui/bus.py
@@ -28,10 +28,14 @@ class SessionBus:
         maxsize=0 (default) is an unbounded queue — appropriate for sparse
         trial topics. Pass maxsize > 0 for high-throughput streams (e.g.
         run.trial_chunk) that should drop-oldest on overflow.
+
+        The returned generator self-cleans on close/cancel: when the subscriber
+        screen pops or the generator is garbage-collected, the queue is removed
+        from `self._subscribers` automatically. No manual unsubscribe needed.
         """
         q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
         self._subscribers[topic].append(q)
-        return self._consume(q)
+        return self._consume(topic, q)
 
     async def publish(self, topic: str, event: dict[str, Any]) -> None:
         """Publish an event to all subscribers of the given topic.
@@ -39,7 +43,10 @@ class SessionBus:
         Bounded subscribers drop their oldest queued event on overflow rather
         than block the publisher. Sparse (unbounded) subscribers never overflow.
         """
-        for q in self._subscribers.get(topic, []):
+        # Iterate over a snapshot — _consume's finally clause mutates the list
+        # when a subscriber's generator closes mid-publish (would otherwise
+        # raise RuntimeError: list changed size during iteration).
+        for q in list(self._subscribers.get(topic, [])):
             if q.maxsize and q.full():
                 try:
                     q.get_nowait()
@@ -47,8 +54,23 @@ class SessionBus:
                     pass
             await q.put(event)
 
-    @staticmethod
-    async def _consume(q: asyncio.Queue[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
-        while True:
-            ev = await q.get()
-            yield ev
+    async def _consume(
+        self,
+        topic: str,
+        q: asyncio.Queue[dict[str, Any]],
+    ) -> AsyncIterator[dict[str, Any]]:
+        try:
+            while True:
+                ev = await q.get()
+                yield ev
+        finally:
+            # Remove this queue from the topic's subscriber list when the
+            # generator closes (screen pop, cancel, gc). Idempotent — if the
+            # queue is somehow already absent, ValueError is swallowed.
+            if topic in self._subscribers:
+                try:
+                    self._subscribers[topic].remove(q)
+                except ValueError:
+                    pass
+                if not self._subscribers[topic]:
+                    del self._subscribers[topic]

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -70,7 +70,10 @@ def load_fleet(path: Path) -> FleetConfig:
     if not path.exists():
         raise FileNotFoundError(f"No fleet found at {path}")
     raw = yaml.safe_load(path.read_text())
-    if raw is None or "name" not in raw:
+    if not isinstance(raw, dict) or "name" not in raw:
+        # `"name" not in raw` would substring-match if raw were a scalar string,
+        # then raw["name"] would TypeError instead of giving the documented
+        # KeyError. The isinstance check forces the right error class.
         raise KeyError("name")
     return FleetConfig(
         name=raw["name"],

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -75,11 +75,14 @@ def load_fleet(path: Path) -> FleetConfig:
         # then raw["name"] would TypeError instead of giving the documented
         # KeyError. The isinstance check forces the right error class.
         raise KeyError("name")
+    # `raw.get("key", [])` would return None if the YAML has an empty key
+    # (e.g. `tests:` with no children), causing list(None) / iteration to
+    # TypeError. `... or []` short-circuits both missing and explicit-null.
     return FleetConfig(
         name=raw["name"],
-        tests=list(raw.get("tests", [])),
+        tests=list(raw.get("tests") or []),
         repeat=int(raw.get("repeat", 1)),
-        hosts=[_deserialize_host(h) for h in raw.get("hosts", [])],
+        hosts=[_deserialize_host(h) for h in (raw.get("hosts") or [])],
     )
 
 
@@ -100,7 +103,8 @@ def _deserialize_host(d: dict[str, Any]) -> Host:
         engine=d["engine"],
         auth_header_env=d.get("auth_header_env"),
         hardware=d.get("hardware"),
-        models=[ModelChoice(name=n, selected=True) for n in d.get("models", [])],
+        # `models:` with no children parses as None; `or []` guards iteration.
+        models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
     )
 
 
@@ -125,7 +129,8 @@ def load_hosts_seed(*, path: Path = DEFAULT_HOSTS_SEED_PATH) -> list[Host]:
     # later when .get() is called on a non-dict.
     if not isinstance(raw, dict):
         return []
-    return [_deserialize_seed_host(h) for h in raw.get("hosts", [])]
+    # `hosts:` with no children parses as None; `or []` guards iteration.
+    return [_deserialize_seed_host(h) for h in (raw.get("hosts") or [])]
 
 
 def _serialize_seed_host(h: Host) -> dict[str, Any]:

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -70,10 +70,12 @@ def load_fleet(path: Path) -> FleetConfig:
     if not path.exists():
         raise FileNotFoundError(f"No fleet found at {path}")
     raw = yaml.safe_load(path.read_text())
-    if not isinstance(raw, dict) or "name" not in raw:
-        # `"name" not in raw` would substring-match if raw were a scalar string,
-        # then raw["name"] would TypeError instead of giving the documented
-        # KeyError. The isinstance check forces the right error class.
+    # The isinstance check forces the right error class — `"name" not in raw`
+    # would substring-match if raw were a scalar string. `not raw.get("name")`
+    # also catches `name:` (explicit-null) and `name: ""` (empty string), which
+    # would otherwise construct FleetConfig(name=None) and write
+    # `fleets/None.yaml` downstream.
+    if not isinstance(raw, dict) or not raw.get("name"):
         raise KeyError("name")
     # `raw.get("key", [])` would return None if the YAML has an empty key
     # (e.g. `tests:` with no children), causing list(None) / iteration to
@@ -107,18 +109,21 @@ def _serialize_host(h: Host) -> dict[str, Any]:
 def _deserialize_host(d: Any) -> Host:
     if not isinstance(d, dict):
         raise TypeError("Host entry must be a dictionary")
-    try:
-        return Host(
-            name=d["name"],
-            url=d["url"],
-            engine=d["engine"],
-            auth_header_env=d.get("auth_header_env"),
-            hardware=d.get("hardware"),
-            # `models:` with no children parses as None; `or []` guards iteration.
-            models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
-        )
-    except KeyError as exc:
-        raise KeyError(f"Host entry missing required field: {exc}") from exc
+    # Loud on null/empty required fields rather than silently constructing
+    # Host(name=None, url=None, engine=None) — same stance as load_fleet's
+    # name guard.
+    for field in ("name", "url", "engine"):
+        if not d.get(field):
+            raise KeyError(f"Host entry missing required field: '{field}'")
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
+        # `models:` with no children parses as None; `or []` guards iteration.
+        models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
+    )
 
 
 def save_hosts_seed(hosts: list[Host], *, path: Path = DEFAULT_HOSTS_SEED_PATH) -> Path:
@@ -162,13 +167,13 @@ def _serialize_seed_host(h: Host) -> dict[str, Any]:
 def _deserialize_seed_host(d: Any) -> Host:
     if not isinstance(d, dict):
         raise TypeError("Seed host entry must be a dictionary")
-    try:
-        return Host(
-            name=d["name"],
-            url=d["url"],
-            engine=d["engine"],
-            auth_header_env=d.get("auth_header_env"),
-            hardware=d.get("hardware"),
-        )
-    except KeyError as exc:
-        raise KeyError(f"Seed host entry missing required field: {exc}") from exc
+    for field in ("name", "url", "engine"):
+        if not d.get(field):
+            raise KeyError(f"Seed host entry missing required field: '{field}'")
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
+    )

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -1,0 +1,100 @@
+"""YAML round-trip for fleets/<name>.yaml and ~/.config/hermia/hosts.yaml.
+
+Fleet YAML schema:
+    name: str
+    created: ISO-8601 timestamp
+    hermia_version: str
+    tests: list[str]
+    repeat: int
+    hosts:
+      - name: str
+        url: str
+        engine: str
+        auth_header_env: str (optional — env var NAME, never a secret value)
+        hardware: str (optional)
+        models: list[str]  # only selected models
+
+Per AGENTS.md rule 11, credentials are never persisted in this file. Only the
+env var name (auth_header_env) is stored; the secret is resolved at runtime
+from the environment.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hermia import __version__
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+FLEETS_SUBDIR = "fleets"
+
+
+def fleet_path(name: str, *, root: Path = Path(".")) -> Path:
+    """Resolve `fleets/<name>.yaml` relative to a project root."""
+    return root / FLEETS_SUBDIR / f"{name}.yaml"
+
+
+def save_fleet(config: FleetConfig, *, root: Path = Path(".")) -> Path:
+    """Serialize a FleetConfig to `fleets/<name>.yaml`.
+
+    Auto-creates the `fleets/` directory if missing. Only selected models are
+    persisted. Optional fields (auth_header_env, hardware) are omitted when
+    None to keep the YAML clean.
+    """
+    path = fleet_path(config.name, root=root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "name": config.name,
+        "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "hermia_version": __version__,
+        "tests": list(config.tests),
+        "repeat": config.repeat,
+        "hosts": [_serialize_host(h) for h in config.hosts],
+    }
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def load_fleet(path: Path) -> FleetConfig:
+    """Parse a fleet YAML file into a FleetConfig.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        yaml.YAMLError: if the file is not valid YAML.
+        KeyError: if a required field (name) is missing.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"No fleet found at {path}")
+    raw = yaml.safe_load(path.read_text())
+    if raw is None or "name" not in raw:
+        raise KeyError("name")
+    return FleetConfig(
+        name=raw["name"],
+        tests=list(raw.get("tests", [])),
+        repeat=int(raw.get("repeat", 1)),
+        hosts=[_deserialize_host(h) for h in raw.get("hosts", [])],
+    )
+
+
+def _serialize_host(h: Host) -> dict[str, Any]:
+    d: dict[str, Any] = {"name": h.name, "url": h.url, "engine": h.engine}
+    if h.auth_header_env:
+        d["auth_header_env"] = h.auth_header_env
+    if h.hardware:
+        d["hardware"] = h.hardware
+    d["models"] = [m.name for m in h.models if m.selected]
+    return d
+
+
+def _deserialize_host(d: dict[str, Any]) -> Host:
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
+        models=[ModelChoice(name=n, selected=True) for n in d.get("models", [])],
+    )

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -78,10 +78,13 @@ def load_fleet(path: Path) -> FleetConfig:
     # `raw.get("key", [])` would return None if the YAML has an empty key
     # (e.g. `tests:` with no children), causing list(None) / iteration to
     # TypeError. `... or []` short-circuits both missing and explicit-null.
+    # `repeat: null` (explicit-null) returns None from .get("repeat", 1),
+    # bypassing the default. int(None) raises TypeError; guard explicitly.
+    repeat_raw = raw.get("repeat")
     return FleetConfig(
         name=raw["name"],
         tests=list(raw.get("tests") or []),
-        repeat=int(raw.get("repeat", 1)),
+        repeat=int(repeat_raw) if repeat_raw is not None else 1,
         hosts=[_deserialize_host(h) for h in (raw.get("hosts") or [])],
     )
 

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -20,7 +20,7 @@ from the environment.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +49,7 @@ def save_fleet(config: FleetConfig, *, root: Path = Path(".")) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     data: dict[str, Any] = {
         "name": config.name,
-        "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "created": datetime.now(UTC).isoformat(timespec="seconds"),
         "hermia_version": __version__,
         "tests": list(config.tests),
         "repeat": config.repeat,

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -81,9 +81,14 @@ def load_fleet(path: Path) -> FleetConfig:
     # `repeat: null` (explicit-null) returns None from .get("repeat", 1),
     # bypassing the default. int(None) raises TypeError; guard explicitly.
     repeat_raw = raw.get("repeat")
+    # `tests: <single-string>` would silently `list("foo") == ['f','o','o']`
+    # — fail loud instead of producing nonsense test IDs.
+    tests_raw = raw.get("tests") or []
+    if isinstance(tests_raw, str):
+        raise TypeError("tests must be a list of strings, not a single string")
     return FleetConfig(
         name=raw["name"],
-        tests=list(raw.get("tests") or []),
+        tests=list(tests_raw),
         repeat=int(repeat_raw) if repeat_raw is not None else 1,
         hosts=[_deserialize_host(h) for h in (raw.get("hosts") or [])],
     )
@@ -132,8 +137,12 @@ def load_hosts_seed(*, path: Path = DEFAULT_HOSTS_SEED_PATH) -> list[Host]:
     # later when .get() is called on a non-dict.
     if not isinstance(raw, dict):
         return []
-    # `hosts:` with no children parses as None; `or []` guards iteration.
-    return [_deserialize_seed_host(h) for h in (raw.get("hosts") or [])]
+    # Defensive: a malformed seed where `hosts:` is a string or dict (not a
+    # list) would iterate wrong — short-circuit to empty rather than crash.
+    hosts_raw = raw.get("hosts")
+    if not isinstance(hosts_raw, list):
+        return []
+    return [_deserialize_seed_host(h) for h in hosts_raw]
 
 
 def _serialize_seed_host(h: Host) -> dict[str, Any]:

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -104,16 +104,21 @@ def _serialize_host(h: Host) -> dict[str, Any]:
     return d
 
 
-def _deserialize_host(d: dict[str, Any]) -> Host:
-    return Host(
-        name=d["name"],
-        url=d["url"],
-        engine=d["engine"],
-        auth_header_env=d.get("auth_header_env"),
-        hardware=d.get("hardware"),
-        # `models:` with no children parses as None; `or []` guards iteration.
-        models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
-    )
+def _deserialize_host(d: Any) -> Host:
+    if not isinstance(d, dict):
+        raise TypeError("Host entry must be a dictionary")
+    try:
+        return Host(
+            name=d["name"],
+            url=d["url"],
+            engine=d["engine"],
+            auth_header_env=d.get("auth_header_env"),
+            hardware=d.get("hardware"),
+            # `models:` with no children parses as None; `or []` guards iteration.
+            models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
+        )
+    except KeyError as exc:
+        raise KeyError(f"Host entry missing required field: {exc}") from exc
 
 
 def save_hosts_seed(hosts: list[Host], *, path: Path = DEFAULT_HOSTS_SEED_PATH) -> Path:
@@ -154,11 +159,16 @@ def _serialize_seed_host(h: Host) -> dict[str, Any]:
     return d
 
 
-def _deserialize_seed_host(d: dict[str, Any]) -> Host:
-    return Host(
-        name=d["name"],
-        url=d["url"],
-        engine=d["engine"],
-        auth_header_env=d.get("auth_header_env"),
-        hardware=d.get("hardware"),
-    )
+def _deserialize_seed_host(d: Any) -> Host:
+    if not isinstance(d, dict):
+        raise TypeError("Seed host entry must be a dictionary")
+    try:
+        return Host(
+            name=d["name"],
+            url=d["url"],
+            engine=d["engine"],
+            auth_header_env=d.get("auth_header_env"),
+            hardware=d.get("hardware"),
+        )
+    except KeyError as exc:
+        raise KeyError(f"Seed host entry missing required field: {exc}") from exc

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -120,7 +120,11 @@ def load_hosts_seed(*, path: Path = DEFAULT_HOSTS_SEED_PATH) -> list[Host]:
     """Load the user's seed host list. Returns [] if the file does not exist."""
     if not path.exists():
         return []
-    raw = yaml.safe_load(path.read_text()) or {}
+    raw = yaml.safe_load(path.read_text())
+    # A malformed seed file (scalar, list, None) returns [] instead of crashing
+    # later when .get() is called on a non-dict.
+    if not isinstance(raw, dict):
+        return []
     return [_deserialize_seed_host(h) for h in raw.get("hosts", [])]
 
 

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -30,6 +30,7 @@ from hermia import __version__
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
 FLEETS_SUBDIR = "fleets"
+DEFAULT_HOSTS_SEED_PATH = Path.home() / ".config" / "hermia" / "hosts.yaml"
 
 
 def fleet_path(name: str, *, root: Path = Path(".")) -> Path:
@@ -97,4 +98,43 @@ def _deserialize_host(d: dict[str, Any]) -> Host:
         auth_header_env=d.get("auth_header_env"),
         hardware=d.get("hardware"),
         models=[ModelChoice(name=n, selected=True) for n in d.get("models", [])],
+    )
+
+
+def save_hosts_seed(hosts: list[Host], *, path: Path = DEFAULT_HOSTS_SEED_PATH) -> Path:
+    """Persist the user's seed host list (host identity only — no models).
+
+    Models are not stored because they re-probe each session. Per AGENTS.md
+    rule 11, only auth_header_env (env var NAME) is stored.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {"hosts": [_serialize_seed_host(h) for h in hosts]}
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def load_hosts_seed(*, path: Path = DEFAULT_HOSTS_SEED_PATH) -> list[Host]:
+    """Load the user's seed host list. Returns [] if the file does not exist."""
+    if not path.exists():
+        return []
+    raw = yaml.safe_load(path.read_text()) or {}
+    return [_deserialize_seed_host(h) for h in raw.get("hosts", [])]
+
+
+def _serialize_seed_host(h: Host) -> dict[str, Any]:
+    d: dict[str, Any] = {"name": h.name, "url": h.url, "engine": h.engine}
+    if h.auth_header_env:
+        d["auth_header_env"] = h.auth_header_env
+    if h.hardware:
+        d["hardware"] = h.hardware
+    return d
+
+
+def _deserialize_seed_host(d: dict[str, Any]) -> Host:
+    return Host(
+        name=d["name"],
+        url=d["url"],
+        engine=d["engine"],
+        auth_header_env=d.get("auth_header_env"),
+        hardware=d.get("hardware"),
     )

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -1,0 +1,67 @@
+"""Async host probe — wraps transport/, publishes probe.* events on the bus.
+
+probe_host():
+    - publishes probe.started immediately
+    - calls transport.list_models()
+    - on success: populates host.models (unselected by default),
+      publishes probe.completed (with warning='no_models' when empty)
+    - on timeout (8s default): publishes probe.failed with reason='timeout'
+    - on auth error (PermissionError): publishes probe.failed with reason='auth'
+    - on transport error (any other Exception): publishes probe.failed with reason='offline'
+
+The Hosts drill screen subscribes to all three topics and updates row badges.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.state import Host, ModelChoice
+
+DEFAULT_PROBE_TIMEOUT_SECONDS = 8.0
+
+
+class _ListModelsTransport(Protocol):
+    async def list_models(self) -> list[str]: ...
+
+
+async def probe_host(
+    host: Host,
+    *,
+    transport: _ListModelsTransport,
+    bus: SessionBus,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+) -> None:
+    """Probe a host's available models. Updates host.models and publishes events."""
+    await bus.publish("probe.started", {"host_name": host.name, "url": host.url})
+    try:
+        model_names = await asyncio.wait_for(transport.list_models(), timeout=timeout)
+    except asyncio.TimeoutError:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "timeout", "retryable": True},
+        )
+        return
+    except PermissionError as exc:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "auth", "error": str(exc), "retryable": True},
+        )
+        return
+    except Exception as exc:
+        await bus.publish(
+            "probe.failed",
+            {"host_name": host.name, "reason": "offline", "error": str(exc), "retryable": True},
+        )
+        return
+
+    host.models = [ModelChoice(name=n, selected=False) for n in model_names]
+    await bus.publish(
+        "probe.completed",
+        {
+            "host_name": host.name,
+            "models": list(model_names),
+            "warning": "no_models" if not model_names else None,
+        },
+    )

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -49,10 +49,26 @@ async def probe_host(
             {"host_name": host.name, "reason": "auth", "error": str(exc), "retryable": True},
         )
         return
-    except Exception as exc:
+    except (OSError, ConnectionError) as exc:
+        # Expected network failures: refused, DNS, network unreachable, etc.
+        # Plan 2's transport_adapter translates HTTP 401/403 → PermissionError
+        # before the exception reaches here so the auth path above fires.
         await bus.publish(
             "probe.failed",
             {"host_name": host.name, "reason": "offline", "error": str(exc), "retryable": True},
+        )
+        return
+    except Exception as exc:
+        # Unexpected error (programmer bug, missing field, etc). Surface as a
+        # distinct category so operators don't chase a "host offline" red herring.
+        await bus.publish(
+            "probe.failed",
+            {
+                "host_name": host.name,
+                "reason": "unexpected",
+                "error": f"{type(exc).__name__}: {exc}",
+                "retryable": False,
+            },
         )
         return
 

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -53,18 +53,28 @@ async def probe_host(
     await bus.publish("probe.started", {"host_name": host.name, "url": host.url})
     try:
         model_names = await asyncio.wait_for(transport.list_models(), timeout=timeout)
+        # Happy-path inside the try block so a transport returning None or a
+        # non-iterable surfaces as `unexpected` (catches our own bugs) rather
+        # than crashing the coroutine outside the handler.
+        host.models = [ModelChoice(name=n, selected=False) for n in model_names]
+        await bus.publish(
+            "probe.completed",
+            {
+                "host_name": host.name,
+                "models": list(model_names),
+                "warning": "no_models" if not model_names else None,
+            },
+        )
     except TimeoutError:
         await bus.publish(
             "probe.failed",
             {"host_name": host.name, "reason": "timeout", "retryable": True},
         )
-        return
     except PermissionError as exc:
         await bus.publish(
             "probe.failed",
             {"host_name": host.name, "reason": "auth", "error": str(exc), "retryable": True},
         )
-        return
     except (OSError, ConnectionError) as exc:
         # Expected network failures: refused, DNS, network unreachable, etc.
         # Plan 2's transport_adapter translates HTTP 401/403 → PermissionError
@@ -73,10 +83,10 @@ async def probe_host(
             "probe.failed",
             {"host_name": host.name, "reason": "offline", "error": str(exc), "retryable": True},
         )
-        return
     except Exception as exc:
-        # Unexpected error (programmer bug, missing field, etc). Surface as a
-        # distinct category so operators don't chase a "host offline" red herring.
+        # Unexpected error (programmer bug, missing field, transport returning
+        # None instead of a list, etc). Surface as a distinct category so
+        # operators don't chase a "host offline" red herring.
         await bus.publish(
             "probe.failed",
             {
@@ -86,14 +96,3 @@ async def probe_host(
                 "retryable": False,
             },
         )
-        return
-
-    host.models = [ModelChoice(name=n, selected=False) for n in model_names]
-    await bus.publish(
-        "probe.completed",
-        {
-            "host_name": host.name,
-            "models": list(model_names),
-            "warning": "no_models" if not model_names else None,
-        },
-    )

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -5,9 +5,25 @@ probe_host():
     - calls transport.list_models()
     - on success: populates host.models (unselected by default),
       publishes probe.completed (with warning='no_models' when empty)
-    - on timeout (8s default): publishes probe.failed with reason='timeout'
+    - on timeout: publishes probe.failed with reason='timeout'
     - on auth error (PermissionError): publishes probe.failed with reason='auth'
-    - on transport error (any other Exception): publishes probe.failed with reason='offline'
+    - on network error ((OSError, ConnectionError)): publishes probe.failed
+      with reason='offline'
+    - on unexpected error: publishes probe.failed with reason='unexpected',
+      retryable=False
+
+**Transport exception contract** — probe.py is transport-library-agnostic by
+design. Transports (Plan 2's `transport_adapter.py` and any future probe
+sources) MUST normalize their library-specific exceptions to the stdlib
+classes probe.py catches:
+
+    - timeout              → TimeoutError  (already provided by asyncio.wait_for)
+    - HTTP 401/403         → PermissionError
+    - connection refused / DNS / network unreachable → OSError or ConnectionError
+
+Anything else falls through to the generic Exception handler and surfaces as
+`unexpected` to the operator. This keeps probe.py decoupled from httpx /
+requests / aiohttp choice in the transport layer.
 
 The Hosts drill screen subscribes to all three topics and updates row badges.
 """

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -52,7 +52,10 @@ async def probe_host(
     """Probe a host's available models. Updates host.models and publishes events."""
     await bus.publish("probe.started", {"host_name": host.name, "url": host.url})
     try:
-        model_names = await asyncio.wait_for(transport.list_models(), timeout=timeout)
+        # Materialize via list() once: a transport returning a single-use
+        # iterator (generator) would otherwise be consumed by the first
+        # comprehension and yield empty for the bus event payload.
+        model_names = list(await asyncio.wait_for(transport.list_models(), timeout=timeout))
         # Happy-path inside the try block so a transport returning None or a
         # non-iterable surfaces as `unexpected` (catches our own bugs) rather
         # than crashing the coroutine outside the handler.
@@ -61,7 +64,7 @@ async def probe_host(
             "probe.completed",
             {
                 "host_name": host.name,
-                "models": list(model_names),
+                "models": model_names,
                 "warning": "no_models" if not model_names else None,
             },
         )

--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -37,7 +37,7 @@ async def probe_host(
     await bus.publish("probe.started", {"host_name": host.name, "url": host.url})
     try:
         model_names = await asyncio.wait_for(transport.list_models(), timeout=timeout)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         await bus.publish(
             "probe.failed",
             {"host_name": host.name, "reason": "timeout", "retryable": True},

--- a/src/hermia/tui/state.py
+++ b/src/hermia/tui/state.py
@@ -1,0 +1,53 @@
+"""
+In-memory data structures for the hermia TUI state management.
+
+FleetConfig serves as the central in-memory source of truth for the current
+edit session. HostSource and ModelSource are protocol interfaces for
+extending data sources in v0.3+ (Kwaainet registry, recommendation engine,
+MCP-sourced data).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class ModelChoice:
+    name: str
+    selected: bool = False
+    size_bytes: int | None = None
+    quant: str | None = None
+    family: str | None = None
+    modality: str | None = None
+
+
+@dataclass
+class Host:
+    name: str
+    url: str
+    engine: str
+    auth_header_env: str | None = None
+    hardware: str | None = None
+    models: list[ModelChoice] = field(default_factory=list)
+
+
+@dataclass
+class FleetConfig:
+    name: str
+    hosts: list[Host] = field(default_factory=list)
+    tests: list[str] = field(default_factory=list)
+    repeat: int = 1
+
+
+@runtime_checkable
+class HostSource(Protocol):
+    async def list_hosts(self) -> list[Host]:
+        ...
+
+
+@runtime_checkable
+class ModelSource(Protocol):
+    async def list_models(self, host: Host) -> list[ModelChoice]:
+        ...

--- a/src/hermia/tui/widgets/__init__.py
+++ b/src/hermia/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable, domain-agnostic Textual widgets for the Fleet TUI."""

--- a/src/hermia/tui/widgets/__init__.py
+++ b/src/hermia/tui/widgets/__init__.py
@@ -1,1 +1,26 @@
 """Reusable, domain-agnostic Textual widgets for the Fleet TUI."""
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.filter_axis import FilterAxis
+from hermia.tui.widgets.progress_bar import AggregateProgressBar, MiniProgressBar
+from hermia.tui.widgets.search_bar import SearchBar
+from hermia.tui.widgets.status_badge import (
+    ICONS,
+    Direction,
+    Status,
+    StatusBadge,
+    color_for,
+)
+
+__all__ = [
+    "AggregateProgressBar",
+    "Direction",
+    "DrillableList",
+    "FilterAxis",
+    "ICONS",
+    "ListRow",
+    "MiniProgressBar",
+    "SearchBar",
+    "Status",
+    "StatusBadge",
+    "color_for",
+]

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
+from textual.events import Click
 from textual.message import Message
 from textual.widgets import Static
 
@@ -149,6 +150,16 @@ class DrillableList(VerticalScroll):
         rid = self.cursor_row_id
         if rid is not None:
             self.post_message(self.Drill(rid))
+
+    def on_click(self, event: Click) -> None:
+        """Mouse-parity per spec §5: row-click === enter."""
+        for i, child in enumerate(self.children):
+            if child is event.widget:
+                self._cursor_idx = i
+                self._refresh()
+                self.drill()
+                event.stop()
+                return
 
     def toggle(self) -> None:
         rid = self.cursor_row_id

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -47,7 +47,7 @@ class DrillableList(VerticalScroll):
         Binding("up", "cursor_prev", "Up", show=False),
         Binding("down", "cursor_next", "Down", show=False),
         Binding("enter", "drill", "Drill in", show=True),
-        Binding("space", "toggle", "Toggle", show=True),
+        Binding("space", "toggle_row", "Toggle", show=True),
         Binding("a", "select_all", "All", show=True),
         Binding("n", "select_none", "None", show=True),
     ]
@@ -162,7 +162,7 @@ class DrillableList(VerticalScroll):
     def action_drill(self) -> None:
         self.drill()
 
-    def action_toggle(self) -> None:
+    def action_toggle_row(self) -> None:
         self.toggle()
 
     def action_select_all(self) -> None:

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -1,0 +1,172 @@
+"""DrillableList — virtual-scroll list with the universal navigation contract.
+
+Every drill screen in the Fleet TUI uses this widget. Public API:
+
+    cursor_prev() / cursor_next()  — move cursor up/down
+    drill()                        — emit Drill(row_id) for the cursor row
+    toggle()                       — flip selection of the cursor row, emit Toggled
+    select_all() / select_none()   — toggle/clear all rows in the *current filter*
+    apply_query(query: str)        — live-filter on substring (driven by SearchBar)
+    is_selected(row_id: str)       — read selection state
+    selected_ids() -> list[str]    — read selection state
+    visible_rows                   — current filtered view
+
+Bindings are also registered (↑↓ / enter / space / a / n) so the widget works
+in real screen contexts; widget tests exercise the API directly to avoid
+Textual focus-chain coupling. Screen tests (Plan 2) cover key routing
+end-to-end.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widgets import Static
+
+
+@dataclass
+class ListRow:
+    id_: str
+    label: str
+
+
+class DrillableList(VerticalScroll):
+    """Virtual-scrolled list with universal /, tab, a, n, space, enter."""
+
+    DEFAULT_CSS = """
+    DrillableList { height: 1fr; }
+    DrillableList .row { padding: 0 1; }
+    DrillableList .row.cursor { background: $accent 20%; }
+    DrillableList .row.selected { color: $success; text-style: bold; }
+    """
+
+    BINDINGS = [
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Drill in", show=True),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+    ]
+
+    class Drill(Message):
+        def __init__(self, row_id: str) -> None:
+            self.row_id = row_id
+            super().__init__()
+
+    class Toggled(Message):
+        def __init__(self, row_id: str) -> None:
+            self.row_id = row_id
+            super().__init__()
+
+    def __init__(self, rows: list[ListRow]) -> None:
+        super().__init__()
+        self._all_rows: list[ListRow] = list(rows)
+        self.visible_rows: list[ListRow] = list(rows)
+        self._selected: set[str] = set()
+        self._cursor_idx: int = 0 if rows else -1
+        self._query: str = ""
+
+    @property
+    def cursor_row_id(self) -> str | None:
+        if 0 <= self._cursor_idx < len(self.visible_rows):
+            return self.visible_rows[self._cursor_idx].id_
+        return None
+
+    def is_selected(self, row_id: str) -> bool:
+        return row_id in self._selected
+
+    def selected_ids(self) -> list[str]:
+        return sorted(self._selected)
+
+    def apply_query(self, query: str) -> None:
+        self._query = query.strip().lower()
+        if not self._query:
+            self.visible_rows = list(self._all_rows)
+        else:
+            self.visible_rows = [
+                r for r in self._all_rows if self._query in r.label.lower()
+            ]
+        if not self.visible_rows:
+            self._cursor_idx = -1
+        else:
+            self._cursor_idx = min(max(self._cursor_idx, 0), len(self.visible_rows) - 1)
+        self._refresh()
+
+    def compose(self) -> ComposeResult:
+        for i, row in enumerate(self.visible_rows):
+            yield self._row_widget(row, i)
+
+    def _row_widget(self, row: ListRow, idx: int) -> Static:
+        cursor = " > " if idx == self._cursor_idx else "   "
+        check = "[✓] " if row.id_ in self._selected else "[ ] "
+        cls = "row"
+        if idx == self._cursor_idx:
+            cls += " cursor"
+        if row.id_ in self._selected:
+            cls += " selected"
+        return Static(f"{cursor}{check}{row.label}", classes=cls)
+
+    def _refresh(self) -> None:
+        for child in list(self.children):
+            child.remove()
+        for i, row in enumerate(self.visible_rows):
+            self.mount(self._row_widget(row, i))
+
+    def cursor_prev(self) -> None:
+        if self._cursor_idx > 0:
+            self._cursor_idx -= 1
+            self._refresh()
+
+    def cursor_next(self) -> None:
+        if self._cursor_idx < len(self.visible_rows) - 1:
+            self._cursor_idx += 1
+            self._refresh()
+
+    def drill(self) -> None:
+        rid = self.cursor_row_id
+        if rid is not None:
+            self.post_message(self.Drill(rid))
+
+    def toggle(self) -> None:
+        rid = self.cursor_row_id
+        if rid is None:
+            return
+        if rid in self._selected:
+            self._selected.discard(rid)
+        else:
+            self._selected.add(rid)
+        self._refresh()
+        self.post_message(self.Toggled(rid))
+
+    def select_all(self) -> None:
+        for row in self.visible_rows:
+            self._selected.add(row.id_)
+        self._refresh()
+
+    def select_none(self) -> None:
+        for row in self.visible_rows:
+            self._selected.discard(row.id_)
+        self._refresh()
+
+    # Textual action_* wrappers route bindings to the public API.
+    def action_cursor_prev(self) -> None:
+        self.cursor_prev()
+
+    def action_cursor_next(self) -> None:
+        self.cursor_next()
+
+    def action_drill(self) -> None:
+        self.drill()
+
+    def action_toggle(self) -> None:
+        self.toggle()
+
+    def action_select_all(self) -> None:
+        self.select_all()
+
+    def action_select_none(self) -> None:
+        self.select_none()

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -111,6 +111,25 @@ class DrillableList(VerticalScroll):
         return Static(f"{cursor}{check}{row.label}", classes=cls)
 
     def _refresh(self) -> None:
+        # Stable-row optimization: when the number of visible rows hasn't
+        # changed (cursor move, toggle, select-all/none), update existing
+        # Static widgets in place. Only structural changes (apply_query) need
+        # the full teardown + remount. Saves O(N) DOM churn per keystroke.
+        if len(self.children) == len(self.visible_rows):
+            for i, child in enumerate(self.children):
+                if not isinstance(child, Static):
+                    continue
+                row = self.visible_rows[i]
+                cursor = " > " if i == self._cursor_idx else "   "
+                check = "[✓] " if row.id_ in self._selected else "[ ] "
+                cls = "row"
+                if i == self._cursor_idx:
+                    cls += " cursor"
+                if row.id_ in self._selected:
+                    cls += " selected"
+                child.update(f"{cursor}{check}{row.label}")
+                child.set_classes(cls)
+            return
         for child in list(self.children):
             child.remove()
         for i, row in enumerate(self.visible_rows):

--- a/src/hermia/tui/widgets/filter_axis.py
+++ b/src/hermia/tui/widgets/filter_axis.py
@@ -76,7 +76,11 @@ class FilterAxis(Horizontal):
         if not self._axis_names:
             return
         self._axis_index = (self._axis_index + 1) % len(self._axis_names)
-        self._value_indexes[self.current_axis] = 0  # type: ignore[index]
+        # Bind locally so the type checker sees the str-not-None narrowing
+        # (avoids the # type: ignore[index] on the dict lookup).
+        axis = self.current_axis
+        if axis is not None:
+            self._value_indexes[axis] = 0
         self._refresh()
         self.post_message(self.Changed(self.current_axis, self.current_value))
 

--- a/src/hermia/tui/widgets/filter_axis.py
+++ b/src/hermia/tui/widgets/filter_axis.py
@@ -101,9 +101,23 @@ class FilterAxis(Horizontal):
         self.post_message(self.Changed(axis, self.current_value))
 
     def _refresh(self) -> None:
+        # Stable-children optimization: value cycling (←/→) keeps the count
+        # the same; only axis change (tab) can resize. When count matches,
+        # update Statics in place to avoid mount/unmount churn per keypress.
+        if self.current_axis is None:
+            for child in list(self.children):
+                child.remove()
+            return
+        values = self._all_values_for(self.current_axis)
+        if len(self.children) == len(values):
+            for i, child in enumerate(self.children):
+                if not isinstance(child, Static):
+                    continue
+                value = values[i]
+                child.update(value)
+                child.set_classes("active" if value == self.current_value else "")
+            return
         for child in list(self.children):
             child.remove()
-        if self.current_axis is None:
-            return
-        for value in self._all_values_for(self.current_axis):
+        for value in values:
             self.mount(Static(value, classes="active" if value == self.current_value else ""))

--- a/src/hermia/tui/widgets/filter_axis.py
+++ b/src/hermia/tui/widgets/filter_axis.py
@@ -1,0 +1,109 @@
+"""FilterAxis — `tab`-cycled filter tabs with `All` plus per-axis values.
+
+Each axis is a named slicing dimension over a list. The current axis shows
+its values inline (`[axis ▾]  All  V1  V2  …`). The parent screen binds
+`tab` to call `next_axis()` and `←`/`→` to call `prev_value()` /
+`next_value()`.
+
+A screen passes axes as a dict {axis_name: [values…]}. An empty dict is a
+no-op widget — useful so screens without filters don't have to special-case.
+
+Key-routing lives on the screen per spec §5 universal contract.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Static
+
+
+class FilterAxis(Horizontal):
+    """Filter axis bar with cyclable axis and per-axis values."""
+
+    DEFAULT_CSS = """
+    FilterAxis {
+        height: 1;
+        padding: 0 1;
+    }
+    FilterAxis Static {
+        margin-right: 2;
+    }
+    FilterAxis Static.active {
+        text-style: bold;
+        color: $accent;
+    }
+    """
+
+    class Changed(Message):
+        def __init__(self, axis: str | None, value: str | None) -> None:
+            self.axis = axis
+            self.value = value
+            super().__init__()
+
+    def __init__(self, axes: dict[str, list[str]]) -> None:
+        super().__init__()
+        self.axes = axes
+        self._axis_names = list(axes.keys())
+        self._axis_index = 0 if self._axis_names else -1
+        self._value_indexes: dict[str, int] = {name: 0 for name in self._axis_names}
+
+    @property
+    def current_axis(self) -> str | None:
+        if self._axis_index < 0:
+            return None
+        return self._axis_names[self._axis_index]
+
+    @property
+    def current_value(self) -> str | None:
+        axis = self.current_axis
+        if axis is None:
+            return None
+        idx = self._value_indexes[axis]
+        return self._all_values_for(axis)[idx]
+
+    def _all_values_for(self, axis: str) -> list[str]:
+        return ["All", *self.axes[axis]]
+
+    def compose(self) -> ComposeResult:
+        if self.current_axis is None:
+            return
+        for value in self._all_values_for(self.current_axis):
+            yield Static(value, classes="active" if value == self.current_value else "")
+
+    def next_axis(self) -> None:
+        """Cycle to the next filter axis; resets that axis's value to All."""
+        if not self._axis_names:
+            return
+        self._axis_index = (self._axis_index + 1) % len(self._axis_names)
+        self._value_indexes[self.current_axis] = 0  # type: ignore[index]
+        self._refresh()
+        self.post_message(self.Changed(self.current_axis, self.current_value))
+
+    def next_value(self) -> None:
+        """Cycle to the next value within the current axis; wraps at end."""
+        axis = self.current_axis
+        if axis is None:
+            return
+        values = self._all_values_for(axis)
+        self._value_indexes[axis] = (self._value_indexes[axis] + 1) % len(values)
+        self._refresh()
+        self.post_message(self.Changed(axis, self.current_value))
+
+    def prev_value(self) -> None:
+        """Cycle to the previous value within the current axis; wraps at start."""
+        axis = self.current_axis
+        if axis is None:
+            return
+        values = self._all_values_for(axis)
+        self._value_indexes[axis] = (self._value_indexes[axis] - 1) % len(values)
+        self._refresh()
+        self.post_message(self.Changed(axis, self.current_value))
+
+    def _refresh(self) -> None:
+        for child in list(self.children):
+            child.remove()
+        if self.current_axis is None:
+            return
+        for value in self._all_values_for(self.current_axis):
+            self.mount(Static(value, classes="active" if value == self.current_value else ""))

--- a/src/hermia/tui/widgets/progress_bar.py
+++ b/src/hermia/tui/widgets/progress_bar.py
@@ -25,26 +25,26 @@ class MiniProgressBar(Static):
         self.total = total
         self.completed = 0
         self.width = width
-        self._text = self._render()
+        self._text = self._build_text()
         super().__init__(self._text)
 
     def advance(self, n: int = 1) -> None:
         self.completed = min(self.completed + n, self.total)
-        self._text = self._render()
+        self._text = self._build_text()
         self.update(self._text)
 
     def set_total(self, total: int) -> None:
         self.total = total
         if self.completed > total:
             self.completed = total
-        self._text = self._render()
+        self._text = self._build_text()
         self.update(self._text)
 
     @property
     def text(self) -> str:
         return self._text
 
-    def _render(self) -> str:
+    def _build_text(self) -> str:
         if self.total == 0:
             return EMPTY * self.width
         filled_chars = int(self.width * self.completed / self.total)
@@ -58,19 +58,19 @@ class AggregateProgressBar(Static):
         self.total = total
         self.completed = 0
         self.width = width
-        self._text = self._render()
+        self._text = self._build_text()
         super().__init__(self._text)
 
     def advance(self, n: int = 1) -> None:
         self.completed = min(self.completed + n, self.total)
-        self._text = self._render()
+        self._text = self._build_text()
         self.update(self._text)
 
     @property
     def text(self) -> str:
         return self._text
 
-    def _render(self) -> str:
+    def _build_text(self) -> str:
         if self.total == 0:
             return f"{EMPTY * self.width}   0 / 0  (0%)"
         filled_chars = int(self.width * self.completed / self.total)

--- a/src/hermia/tui/widgets/progress_bar.py
+++ b/src/hermia/tui/widgets/progress_bar.py
@@ -1,0 +1,79 @@
+"""Progress bar widgets for fleet runs.
+
+MiniProgressBar       — single-line fixed-width bar (per-host row)
+AggregateProgressBar  — full-width bar with N/M count + percent (Runner L1)
+
+Pure Textual Static widgets — no animations, just a renderable that updates
+when .advance() or .set_total() is called. The runner publishes events;
+screens decide when to advance these bars.
+
+Both expose a `.text` property returning the current rendered string so tests
+can assert content without depending on Textual's internal Content parsing.
+"""
+from __future__ import annotations
+
+from textual.widgets import Static
+
+FILLED = "█"
+EMPTY = "░"
+
+
+class MiniProgressBar(Static):
+    """Per-host inline progress bar; fixed width, no labels."""
+
+    def __init__(self, *, total: int, width: int = 40) -> None:
+        self.total = total
+        self.completed = 0
+        self.width = width
+        self._text = self._render()
+        super().__init__(self._text)
+
+    def advance(self, n: int = 1) -> None:
+        self.completed = min(self.completed + n, self.total)
+        self._text = self._render()
+        self.update(self._text)
+
+    def set_total(self, total: int) -> None:
+        self.total = total
+        if self.completed > total:
+            self.completed = total
+        self._text = self._render()
+        self.update(self._text)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def _render(self) -> str:
+        if self.total == 0:
+            return EMPTY * self.width
+        filled_chars = int(self.width * self.completed / self.total)
+        return FILLED * filled_chars + EMPTY * (self.width - filled_chars)
+
+
+class AggregateProgressBar(Static):
+    """Full-width Runner L1 progress bar with count + percent."""
+
+    def __init__(self, *, total: int, width: int = 40) -> None:
+        self.total = total
+        self.completed = 0
+        self.width = width
+        self._text = self._render()
+        super().__init__(self._text)
+
+    def advance(self, n: int = 1) -> None:
+        self.completed = min(self.completed + n, self.total)
+        self._text = self._render()
+        self.update(self._text)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def _render(self) -> str:
+        if self.total == 0:
+            return f"{EMPTY * self.width}   0 / 0  (0%)"
+        filled_chars = int(self.width * self.completed / self.total)
+        pct = int(100 * self.completed / self.total)
+        bar = FILLED * filled_chars + EMPTY * (self.width - filled_chars)
+        return f"{bar}   {self.completed} / {self.total}  ({pct}%)"

--- a/src/hermia/tui/widgets/search_bar.py
+++ b/src/hermia/tui/widgets/search_bar.py
@@ -1,0 +1,70 @@
+"""SearchBar — live-filter input docked at the bottom of a drill screen.
+
+vim/k9s/lazygit convention: the parent screen binds `/` to call `bar.open()`.
+An input opens at the bottom, type a substring, the parent list filters live
+as you type. Press `escape` (also bound on the parent) to call `bar.close()`,
+which clears the query and hides the bar.
+
+Emits SearchBar.QueryChanged messages — the parent screen wires them into
+its list's filter state.
+
+Design rationale: bindings live on the *screen* per spec §5 universal
+contract, not on the widget. A hidden widget can't receive key events in
+Textual, so binding `/` on SearchBar would never fire.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.message import Message
+from textual.widgets import Input
+
+
+class SearchBar(Container):
+    """Live-filter input. open() / close() are driven by the parent screen."""
+
+    DEFAULT_CSS = """
+    SearchBar {
+        height: 1;
+        dock: bottom;
+        display: none;
+    }
+    SearchBar Input {
+        border: none;
+        background: $surface;
+    }
+    """
+
+    class QueryChanged(Message):
+        def __init__(self, query: str) -> None:
+            self.query = query
+            super().__init__()
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="/ search…")
+
+    def open(self) -> None:
+        """Make the bar visible and focus the input.
+
+        Focus and value-clear are deferred via call_after_refresh so any "/"
+        key that triggered open() has already been consumed by the screen's
+        binding handler before the Input becomes focused — otherwise the
+        "/" would type into the Input as its first character.
+        """
+        self.display = True
+        self.call_after_refresh(self._focus_input)
+
+    def _focus_input(self) -> None:
+        inp = self.query_one(Input)
+        inp.value = ""
+        inp.focus()
+
+    def close(self) -> None:
+        """Clear the query and hide the bar."""
+        inp = self.query_one(Input)
+        inp.value = ""
+        self.display = False
+        self.post_message(self.QueryChanged(""))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self.post_message(self.QueryChanged(event.value))

--- a/src/hermia/tui/widgets/search_bar.py
+++ b/src/hermia/tui/widgets/search_bar.py
@@ -62,9 +62,15 @@ class SearchBar(Container):
     def close(self) -> None:
         """Clear the query and hide the bar."""
         inp = self.query_one(Input)
-        inp.value = ""
+        # Setting Input.value when it differs already fires Input.Changed
+        # → on_input_changed → posts QueryChanged(""). Only post explicitly
+        # when the value was already empty (so the subscriber still sees a
+        # clear notification) to avoid sending the message twice.
+        if inp.value == "":
+            self.post_message(self.QueryChanged(""))
+        else:
+            inp.value = ""
         self.display = False
-        self.post_message(self.QueryChanged(""))
 
     def on_input_changed(self, event: Input.Changed) -> None:
         self.post_message(self.QueryChanged(event.value))

--- a/src/hermia/tui/widgets/status_badge.py
+++ b/src/hermia/tui/widgets/status_badge.py
@@ -1,0 +1,64 @@
+"""StatusBadge — single-glyph status indicator with direction-aware color.
+
+Status vocabulary (from spec §5):
+    defended  — model produced compliant output (good security outcome)
+    refused   — model said no (valence depends on test direction)
+    breached  — model produced non-compliant output (jailbroken/leaked/complied)
+    error     — no usable output (TIMEOUT, EMPTY_RESPONSE, transport error)
+
+Refused color is direction-aware: harmful test + refused = green (good);
+benign test + refused = red (over-refusal). v0.3 BAM Benign tier needs this.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.widgets import Static
+
+Status = Literal["defended", "refused", "breached", "error"]
+Direction = Literal["harmful", "benign"]
+
+ICONS: dict[Status, str] = {
+    "defended": "✓",
+    "refused": "↺",
+    "breached": "✗",
+    "error": "!",
+}
+
+
+def color_for(status: Status, direction: Direction = "harmful") -> str:
+    """Pick the Textual color for a given (status, direction)."""
+    if status == "defended":
+        return "green"
+    if status == "breached":
+        return "red"
+    if status == "error":
+        return "yellow"
+    # refused — valence depends on test direction
+    return "green" if direction == "harmful" else "red"
+
+
+class StatusBadge(Static):
+    """One-glyph status indicator. Use in list rows and trial cells."""
+
+    def __init__(self, status: Status, *, direction: Direction = "harmful") -> None:
+        self.status: Status = status
+        self.direction: Direction = direction
+        self._markup: str = self._build_markup()
+        super().__init__(self._markup)
+
+    def update_status(self, status: Status, *, direction: Direction | None = None) -> None:
+        self.status = status
+        if direction is not None:
+            self.direction = direction
+        self._markup = self._build_markup()
+        self.update(self._markup)
+
+    @property
+    def markup(self) -> str:
+        """The Textual markup string used to render this badge (color + glyph)."""
+        return self._markup
+
+    def _build_markup(self) -> str:
+        color = color_for(self.status, self.direction)
+        return f"[{color}]{ICONS[self.status]}[/]"

--- a/tests/fixtures/fake_transport.py
+++ b/tests/fixtures/fake_transport.py
@@ -1,0 +1,50 @@
+"""FakeTransport — single shared fixture for probe and runner tests.
+
+Scripts deterministic mixes of pass/refuse/fail/error responses without
+ever touching a real host. Used by every test that drives probe.py or the
+fleet runner without a live network.
+
+Keys for responses / errors:
+    "<test_id>:<model_name>"  — exact match
+    "<test_id>"               — any model on that test
+    "<model_name>"            — any test on that model
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FakeTransport:
+    models: list[str] = field(default_factory=list)
+    responses: dict[str, str] = field(default_factory=dict)
+    errors: dict[str, Exception] = field(default_factory=dict)
+    default_response: str = ""
+    fail_with: Exception | None = None
+    delay_seconds: float = 0.0
+
+    async def list_models(self) -> list[str]:
+        if self.delay_seconds > 0:
+            await asyncio.sleep(self.delay_seconds)
+        if self.fail_with is not None:
+            raise self.fail_with
+        return list(self.models)
+
+    async def send(self, *, model: str, test: str, prompt: str) -> str:
+        if self.delay_seconds > 0:
+            await asyncio.sleep(self.delay_seconds)
+        key_full = f"{test}:{model}"
+        if key_full in self.errors:
+            raise self.errors[key_full]
+        if test in self.errors:
+            raise self.errors[test]
+        if model in self.errors:
+            raise self.errors[model]
+        if key_full in self.responses:
+            return self.responses[key_full]
+        if test in self.responses:
+            return self.responses[test]
+        if model in self.responses:
+            return self.responses[model]
+        return self.default_response

--- a/tests/unit/tui/test_bus.py
+++ b/tests/unit/tui/test_bus.py
@@ -100,6 +100,35 @@ class TestBoundedQueue:
 
         asyncio.run(_run())
 
+    def test_subscriber_self_cleans_on_reader_task_cancel(self) -> None:
+        """Cancelling the reader task fires the generator's finally clause,
+        which removes its queue from `_subscribers` — screens that pop don't
+        leak queues for their lifetime.
+        """
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                async for ev in bus.subscribe("probe.started"):
+                    events.append(ev)
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            assert len(bus._subscribers["probe.started"]) == 1
+
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            # Give the generator a chance to run its finally clause.
+            await asyncio.sleep(0)
+
+            assert "probe.started" not in bus._subscribers
+
+        asyncio.run(_run())
+
     def test_bounded_queue_drops_oldest_when_full(self) -> None:
         async def _run() -> None:
             bus = SessionBus()

--- a/tests/unit/tui/test_bus.py
+++ b/tests/unit/tui/test_bus.py
@@ -1,0 +1,121 @@
+"""Tests for hermia.tui.bus — topic-based async pub/sub."""
+import asyncio
+
+from hermia.tui.bus import SessionBus
+
+
+class TestSessionBus:
+    def test_subscribe_receives_publish(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                async for ev in bus.subscribe("probe.started"):
+                    events.append(ev)
+                    if len(events) == 1:
+                        return
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            await bus.publish("probe.started", {"host_id": "eric-5090"})
+            await asyncio.wait_for(task, timeout=1.0)
+            assert events == [{"host_id": "eric-5090"}]
+
+        asyncio.run(_run())
+
+    def test_multiple_subscribers_each_get_event(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            a_events: list[dict] = []
+            b_events: list[dict] = []
+
+            async def reader(sink: list[dict]) -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    sink.append(ev)
+                    if len(sink) == 1:
+                        return
+
+            ta = asyncio.create_task(reader(a_events))
+            tb = asyncio.create_task(reader(b_events))
+            await asyncio.sleep(0)
+            await bus.publish("run.trial_finished", {"trial_id": "t1"})
+            await asyncio.wait_for(asyncio.gather(ta, tb), timeout=1.0)
+            assert a_events == [{"trial_id": "t1"}]
+            assert b_events == [{"trial_id": "t1"}]
+
+        asyncio.run(_run())
+
+    def test_publish_to_topic_with_no_subscribers_is_noop(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            await bus.publish("probe.started", {"host_id": "x"})
+
+        asyncio.run(_run())
+
+    def test_subscriber_on_unrelated_topic_does_not_receive(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                try:
+                    async for ev in bus.subscribe("probe.started"):
+                        events.append(ev)
+                except asyncio.CancelledError:
+                    return
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            await bus.publish("run.trial_finished", {"trial_id": "t1"})
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            assert events == []
+
+        asyncio.run(_run())
+
+
+class TestBoundedQueue:
+    def test_unbounded_queue_keeps_all_events(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    events.append(ev)
+                    if len(events) == 100:
+                        return
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            for i in range(100):
+                await bus.publish("run.trial_finished", {"trial_id": f"t{i}"})
+            await asyncio.wait_for(task, timeout=1.0)
+            assert len(events) == 100
+
+        asyncio.run(_run())
+
+    def test_bounded_queue_drops_oldest_when_full(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                async for ev in bus.subscribe("run.trial_chunk", maxsize=2):
+                    events.append(ev)
+                    if len(events) == 2:
+                        return
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            for i in range(5):
+                await bus.publish("run.trial_chunk", {"chunk": f"c{i}"})
+            await asyncio.wait_for(task, timeout=1.0)
+            assert events == [{"chunk": "c3"}, {"chunk": "c4"}]
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_fake_transport.py
+++ b/tests/unit/tui/test_fake_transport.py
@@ -1,0 +1,72 @@
+"""Tests for tests/fixtures/fake_transport.py — shared FakeTransport for probe/runner tests."""
+import asyncio
+import time
+
+import pytest
+
+from tests.fixtures.fake_transport import FakeTransport
+
+
+class TestFakeTransport:
+    def test_list_models_returns_configured(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+            models = await ft.list_models()
+            assert models == ["qwen3:32b", "llama3:8b"]
+
+        asyncio.run(_run())
+
+    def test_list_models_with_no_models_returns_empty(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(models=[])
+            assert await ft.list_models() == []
+
+        asyncio.run(_run())
+
+    def test_list_models_raises_when_set_to_fail(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(models=[], fail_with=TimeoutError("simulated timeout"))
+            with pytest.raises(TimeoutError):
+                await ft.list_models()
+
+        asyncio.run(_run())
+
+    def test_send_returns_canned_response(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(
+                models=["qwen3:32b"],
+                responses={"prompt-injection-3:qwen3:32b": "Sure, here's the system prompt..."},
+            )
+            resp = await ft.send(model="qwen3:32b", test="prompt-injection-3", prompt="...")
+            assert "system prompt" in resp
+
+        asyncio.run(_run())
+
+    def test_send_returns_default_when_no_match(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(models=["qwen3:32b"], default_response="I cannot help with that.")
+            resp = await ft.send(model="qwen3:32b", test="unknown", prompt="...")
+            assert resp == "I cannot help with that."
+
+        asyncio.run(_run())
+
+    def test_send_raises_when_configured_for_test(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(
+                models=["qwen3:32b"],
+                errors={"jailbreak-1:qwen3:32b": ConnectionError("simulated transport failure")},
+            )
+            with pytest.raises(ConnectionError):
+                await ft.send(model="qwen3:32b", test="jailbreak-1", prompt="...")
+
+        asyncio.run(_run())
+
+    def test_delay_simulates_latency(self) -> None:
+        async def _run() -> None:
+            ft = FakeTransport(models=["qwen3:32b"], delay_seconds=0.05)
+            start = time.monotonic()
+            await ft.list_models()
+            elapsed = time.monotonic() - start
+            assert elapsed >= 0.05
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -147,6 +147,57 @@ class TestLoadFleet:
         with pytest.raises(KeyError):
             load_fleet(bad)
 
+    def test_load_explicit_null_name_raises_key_error(self, tmp_path: Path) -> None:
+        # `name: ~` (or `name:`) parses as None — must not silently produce
+        # FleetConfig(name=None) and downstream fleets/None.yaml.
+        bad = tmp_path / "nullname.yaml"
+        bad.write_text("name:\ntests: []\nhosts: []\n")
+        with pytest.raises(KeyError):
+            load_fleet(bad)
+
+    def test_load_empty_string_name_raises_key_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "emptyname.yaml"
+        bad.write_text('name: ""\ntests: []\nhosts: []\n')
+        with pytest.raises(KeyError):
+            load_fleet(bad)
+
+    def test_load_host_entry_must_be_a_dict(self, tmp_path: Path) -> None:
+        # A host entry parsed as a string instead of a dict — fail loud.
+        bad = tmp_path / "stringhost.yaml"
+        bad.write_text("name: bad\ntests: []\nhosts:\n  - not-a-dict\n")
+        with pytest.raises(TypeError, match="Host entry must be a dictionary"):
+            load_fleet(bad)
+
+    def test_load_host_missing_required_field_raises_actionable_key_error(
+        self, tmp_path: Path
+    ) -> None:
+        bad = tmp_path / "missingfield.yaml"
+        bad.write_text(
+            "name: bad\n"
+            "tests: []\n"
+            "hosts:\n"
+            "  - url: http://h1\n"
+            "    engine: ollama\n"
+        )
+        with pytest.raises(KeyError, match="'name'"):
+            load_fleet(bad)
+
+    def test_load_host_explicit_null_required_field_raises_key_error(
+        self, tmp_path: Path
+    ) -> None:
+        # `engine: ~` should be loud, not produce Host(engine=None).
+        bad = tmp_path / "nullengine.yaml"
+        bad.write_text(
+            "name: bad\n"
+            "tests: []\n"
+            "hosts:\n"
+            "  - name: h1\n"
+            "    url: http://h1\n"
+            "    engine:\n"
+        )
+        with pytest.raises(KeyError, match="'engine'"):
+            load_fleet(bad)
+
     def test_load_handles_explicit_null_collections(self, tmp_path: Path) -> None:
         # PyYAML parses `tests:` (with no value) as None, not []. Without the
         # `or []` guard, list(None) and iteration would TypeError.
@@ -248,3 +299,19 @@ class TestHostsSeed:
         seed_path = tmp_path / "badhosts.yaml"
         seed_path.write_text("hosts: not-a-list\n")
         assert load_hosts_seed(path=seed_path) == []
+
+    def test_load_seed_host_entry_must_be_a_dict(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / "stringentry.yaml"
+        seed_path.write_text("hosts:\n  - not-a-dict\n")
+        with pytest.raises(TypeError, match="Seed host entry must be a dictionary"):
+            load_hosts_seed(path=seed_path)
+
+    def test_load_seed_host_missing_required_field(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / "missingurl.yaml"
+        seed_path.write_text(
+            "hosts:\n"
+            "  - name: h1\n"
+            "    engine: ollama\n"
+        )
+        with pytest.raises(KeyError, match="'url'"):
+            load_hosts_seed(path=seed_path)

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -144,3 +144,55 @@ class TestLoadFleet:
         bad.write_text("tests: []\nhosts: []\n")
         with pytest.raises(KeyError):
             load_fleet(bad)
+
+
+from hermia.tui.fleet_io import load_hosts_seed, save_hosts_seed
+
+
+class TestHostsSeed:
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / "hosts.yaml"
+        hosts = [
+            Host(
+                name="eric-5090",
+                url="https://eric:11434",
+                engine="ollama",
+                hardware="RTX 5090",
+                auth_header_env="LITELLM_KEY",
+            ),
+            Host(name="m3-pro", url="https://m3:4000", engine="openai-compat"),
+        ]
+        save_hosts_seed(hosts, path=seed_path)
+        assert seed_path.exists()
+
+        loaded = load_hosts_seed(path=seed_path)
+        assert len(loaded) == 2
+        assert loaded[0].name == "eric-5090"
+        assert loaded[0].hardware == "RTX 5090"
+        assert loaded[0].auth_header_env == "LITELLM_KEY"
+        assert loaded[1].name == "m3-pro"
+        assert loaded[1].hardware is None
+
+    def test_load_missing_seed_returns_empty_list(self, tmp_path: Path) -> None:
+        loaded = load_hosts_seed(path=tmp_path / "nope.yaml")
+        assert loaded == []
+
+    def test_save_creates_parent_dir(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / ".config" / "hermia" / "hosts.yaml"
+        save_hosts_seed([], path=seed_path)
+        assert seed_path.exists()
+
+    def test_seed_does_not_include_models(self, tmp_path: Path) -> None:
+        seed_path = tmp_path / "hosts.yaml"
+        hosts = [
+            Host(
+                name="h1",
+                url="http://h1",
+                engine="ollama",
+                models=[ModelChoice(name="qwen3:32b", selected=True)],
+            )
+        ]
+        save_hosts_seed(hosts, path=seed_path)
+        text = seed_path.read_text()
+        assert "qwen3:32b" not in text
+        assert "models" not in text

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -147,6 +147,31 @@ class TestLoadFleet:
         with pytest.raises(KeyError):
             load_fleet(bad)
 
+    def test_load_handles_explicit_null_collections(self, tmp_path: Path) -> None:
+        # PyYAML parses `tests:` (with no value) as None, not []. Without the
+        # `or []` guard, list(None) and iteration would TypeError.
+        path = tmp_path / "nulls.yaml"
+        path.write_text("name: nulls\ntests:\nhosts:\nrepeat: 1\n")
+        loaded = load_fleet(path)
+        assert loaded.name == "nulls"
+        assert loaded.tests == []
+        assert loaded.hosts == []
+
+    def test_load_handles_host_with_null_models_key(self, tmp_path: Path) -> None:
+        # Same edge case at the host level — `models:` with no children.
+        path = tmp_path / "nullmodels.yaml"
+        path.write_text(
+            "name: nm\n"
+            "tests: []\n"
+            "hosts:\n"
+            "  - name: h1\n"
+            "    url: http://h1\n"
+            "    engine: ollama\n"
+            "    models:\n"
+        )
+        loaded = load_fleet(path)
+        assert loaded.hosts[0].models == []
+
 
 class TestHostsSeed:
     def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
@@ -195,3 +220,9 @@ class TestHostsSeed:
         text = seed_path.read_text()
         assert "qwen3:32b" not in text
         assert "models" not in text
+
+    def test_load_seed_handles_explicit_null_hosts(self, tmp_path: Path) -> None:
+        # `hosts:` with no children parses as None.
+        seed_path = tmp_path / "nullhosts.yaml"
+        seed_path.write_text("hosts:\n")
+        assert load_hosts_seed(path=seed_path) == []

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -1,0 +1,146 @@
+"""Tests for hermia.tui.fleet_io — YAML load/save for fleets and hosts.yaml."""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermia.tui.fleet_io import (
+    fleet_path,
+    load_fleet,
+    save_fleet,
+)
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestFleetPath:
+    def test_returns_fleets_subdir(self, tmp_path: Path) -> None:
+        p = fleet_path("kwaainet-baseline", root=tmp_path)
+        assert p == tmp_path / "fleets" / "kwaainet-baseline.yaml"
+
+
+class TestSaveFleet:
+    def test_creates_fleets_dir_if_missing(self, tmp_path: Path) -> None:
+        config = FleetConfig(name="smoke")
+        path = save_fleet(config, root=tmp_path)
+        assert path.exists()
+        assert path.parent.name == "fleets"
+
+    def test_writes_minimal_yaml(self, tmp_path: Path) -> None:
+        config = FleetConfig(name="smoke")
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        assert data["name"] == "smoke"
+        assert data["tests"] == []
+        assert data["hosts"] == []
+        assert data["repeat"] == 1
+        assert "created" in data
+        assert "hermia_version" in data
+
+    def test_writes_full_fleet(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="kwaainet-baseline",
+            hosts=[
+                Host(
+                    name="eric-5090",
+                    url="https://eric:11434",
+                    engine="ollama",
+                    hardware="RTX 5090",
+                    auth_header_env="LITELLM_KEY",
+                    models=[
+                        ModelChoice(name="qwen3:32b", selected=True),
+                        ModelChoice(name="qwen3-coder:30b", selected=True),
+                        ModelChoice(name="llama3:70b", selected=False),
+                    ],
+                )
+            ],
+            tests=["prompt-injection-1", "jailbreak-1"],
+            repeat=3,
+        )
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        assert data["repeat"] == 3
+        assert data["tests"] == ["prompt-injection-1", "jailbreak-1"]
+        assert len(data["hosts"]) == 1
+        h = data["hosts"][0]
+        assert h["name"] == "eric-5090"
+        assert h["url"] == "https://eric:11434"
+        assert h["engine"] == "ollama"
+        assert h["hardware"] == "RTX 5090"
+        assert h["auth_header_env"] == "LITELLM_KEY"
+        assert h["models"] == ["qwen3:32b", "qwen3-coder:30b"]
+
+    def test_omits_optional_fields_when_none(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="minimal",
+            hosts=[Host(name="h1", url="http://h1:11434", engine="ollama")],
+        )
+        path = save_fleet(config, root=tmp_path)
+        data = yaml.safe_load(path.read_text())
+        h = data["hosts"][0]
+        assert "auth_header_env" not in h
+        assert "hardware" not in h
+
+    def test_never_writes_secret_value(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="secrets-test",
+            hosts=[
+                Host(
+                    name="h1",
+                    url="http://h1:11434",
+                    engine="openai-compat",
+                    auth_header_env="LITELLM_KEY",
+                )
+            ],
+        )
+        path = save_fleet(config, root=tmp_path)
+        text = path.read_text()
+        assert "LITELLM_KEY" in text
+        assert "sk-" not in text
+        assert "Bearer " not in text
+
+
+class TestLoadFleet:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        original = FleetConfig(
+            name="rt",
+            hosts=[
+                Host(
+                    name="h1",
+                    url="http://h1:11434",
+                    engine="ollama",
+                    hardware="RTX 5090",
+                    models=[ModelChoice(name="qwen3:32b", selected=True)],
+                )
+            ],
+            tests=["prompt-injection-1"],
+            repeat=2,
+        )
+        path = save_fleet(original, root=tmp_path)
+        loaded = load_fleet(path)
+        assert loaded.name == "rt"
+        assert loaded.repeat == 2
+        assert loaded.tests == ["prompt-injection-1"]
+        assert len(loaded.hosts) == 1
+        h = loaded.hosts[0]
+        assert h.name == "h1"
+        assert h.engine == "ollama"
+        assert h.hardware == "RTX 5090"
+        assert len(h.models) == 1
+        assert h.models[0].name == "qwen3:32b"
+        assert h.models[0].selected is True
+
+    def test_load_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_fleet(tmp_path / "fleets" / "nope.yaml")
+
+    def test_load_malformed_yaml_raises_yaml_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("name: smoke\n  this is: not valid yaml\n: : :")
+        with pytest.raises(yaml.YAMLError):
+            load_fleet(bad)
+
+    def test_load_missing_required_name_raises_key_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "noname.yaml"
+        bad.write_text("tests: []\nhosts: []\n")
+        with pytest.raises(KeyError):
+            load_fleet(bad)

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -7,7 +7,9 @@ import yaml
 from hermia.tui.fleet_io import (
     fleet_path,
     load_fleet,
+    load_hosts_seed,
     save_fleet,
+    save_hosts_seed,
 )
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
@@ -144,9 +146,6 @@ class TestLoadFleet:
         bad.write_text("tests: []\nhosts: []\n")
         with pytest.raises(KeyError):
             load_fleet(bad)
-
-
-from hermia.tui.fleet_io import load_hosts_seed, save_hosts_seed
 
 
 class TestHostsSeed:

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -157,6 +157,14 @@ class TestLoadFleet:
         assert loaded.tests == []
         assert loaded.hosts == []
 
+    def test_load_rejects_tests_as_single_string(self, tmp_path: Path) -> None:
+        # `tests: prompt-injection-1` (no list dashes) would silently split
+        # into ['p','r','o',...]; raise loudly instead.
+        path = tmp_path / "strtests.yaml"
+        path.write_text("name: s\ntests: prompt-injection-1\nhosts: []\nrepeat: 1\n")
+        with pytest.raises(TypeError, match="tests must be a list"):
+            load_fleet(path)
+
     def test_load_handles_explicit_null_repeat(self, tmp_path: Path) -> None:
         # `repeat:` (empty key) parses as None — int(None) would TypeError.
         path = tmp_path / "nullrepeat.yaml"
@@ -232,4 +240,11 @@ class TestHostsSeed:
         # `hosts:` with no children parses as None.
         seed_path = tmp_path / "nullhosts.yaml"
         seed_path.write_text("hosts:\n")
+        assert load_hosts_seed(path=seed_path) == []
+
+    def test_load_seed_handles_non_list_hosts(self, tmp_path: Path) -> None:
+        # Malformed seed where `hosts:` is a string — return [] instead of
+        # iterating the string and producing nonsense Host records.
+        seed_path = tmp_path / "badhosts.yaml"
+        seed_path.write_text("hosts: not-a-list\n")
         assert load_hosts_seed(path=seed_path) == []

--- a/tests/unit/tui/test_fleet_io.py
+++ b/tests/unit/tui/test_fleet_io.py
@@ -157,6 +157,13 @@ class TestLoadFleet:
         assert loaded.tests == []
         assert loaded.hosts == []
 
+    def test_load_handles_explicit_null_repeat(self, tmp_path: Path) -> None:
+        # `repeat:` (empty key) parses as None — int(None) would TypeError.
+        path = tmp_path / "nullrepeat.yaml"
+        path.write_text("name: nr\ntests: []\nhosts: []\nrepeat:\n")
+        loaded = load_fleet(path)
+        assert loaded.repeat == 1
+
     def test_load_handles_host_with_null_models_key(self, tmp_path: Path) -> None:
         # Same edge case at the host level — `models:` with no children.
         path = tmp_path / "nullmodels.yaml"

--- a/tests/unit/tui/test_probe.py
+++ b/tests/unit/tui/test_probe.py
@@ -1,5 +1,6 @@
 """Tests for hermia.tui.probe — async host probe with timeout + retry + bus events."""
 import asyncio
+from contextlib import asynccontextmanager
 
 from hermia.tui.bus import SessionBus
 from hermia.tui.probe import probe_host
@@ -7,39 +8,54 @@ from hermia.tui.state import Host
 from tests.fixtures.fake_transport import FakeTransport
 
 
-async def _start_readers(bus: SessionBus) -> list[tuple[str, dict]]:
-    """Start background readers on probe.* topics and return the shared event list."""
+@asynccontextmanager
+async def _probe_readers(bus: SessionBus):
+    """Manage the lifecycle of background readers on the probe.* topics.
+
+    Yields the shared events list. Cancels and awaits readers on exit so
+    tests don't leak coroutines into asyncio.run()'s teardown (which would
+    surface as 'Task was destroyed but it is pending' warnings).
+    """
     events: list[tuple[str, dict]] = []
+    tasks: list[asyncio.Task[None]] = []
 
     async def reader(topic: str) -> None:
-        async for ev in bus.subscribe(topic):
-            events.append((topic, ev))
+        try:
+            async for ev in bus.subscribe(topic):
+                events.append((topic, ev))
+        except asyncio.CancelledError:
+            return
 
     for topic in ("probe.started", "probe.completed", "probe.failed"):
-        asyncio.create_task(reader(topic))
+        tasks.append(asyncio.create_task(reader(topic)))
     await asyncio.sleep(0)
-    return events
+    try:
+        yield events
+    finally:
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 class TestProbeHappyPath:
     def test_publishes_started_then_completed(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="h1", url="http://h1:11434", engine="ollama")
-            transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+            async with _probe_readers(bus) as events:
+                host = Host(name="h1", url="http://h1:11434", engine="ollama")
+                transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
 
-            await probe_host(host, transport=transport, bus=bus)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus)
+                await asyncio.sleep(0.05)
 
-            topics = [t for t, _ in events]
-            assert "probe.started" in topics
-            assert "probe.completed" in topics
-            assert "probe.failed" not in topics
+                topics = [t for t, _ in events]
+                assert "probe.started" in topics
+                assert "probe.completed" in topics
+                assert "probe.failed" not in topics
 
-            completed = next(ev for t, ev in events if t == "probe.completed")
-            assert completed["host_name"] == "h1"
-            assert completed["models"] == ["qwen3:32b", "llama3:8b"]
+                completed = next(ev for t, ev in events if t == "probe.completed")
+                assert completed["host_name"] == "h1"
+                assert completed["models"] == ["qwen3:32b", "llama3:8b"]
 
         asyncio.run(_run())
 
@@ -60,86 +76,86 @@ class TestProbeFailures:
     def test_timeout_publishes_failed_with_reason_timeout(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="slow", url="http://slow", engine="ollama")
-            transport = FakeTransport(models=["x"], delay_seconds=2.0)
+            async with _probe_readers(bus) as events:
+                host = Host(name="slow", url="http://slow", engine="ollama")
+                transport = FakeTransport(models=["x"], delay_seconds=2.0)
 
-            await probe_host(host, transport=transport, bus=bus, timeout=0.05)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus, timeout=0.05)
+                await asyncio.sleep(0.05)
 
-            failed = [ev for t, ev in events if t == "probe.failed"]
-            assert len(failed) == 1
-            assert failed[0]["reason"] == "timeout"
-            assert failed[0]["retryable"] is True
+                failed = [ev for t, ev in events if t == "probe.failed"]
+                assert len(failed) == 1
+                assert failed[0]["reason"] == "timeout"
+                assert failed[0]["retryable"] is True
 
         asyncio.run(_run())
 
     def test_auth_error_publishes_failed_with_reason_auth(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="locked", url="http://locked", engine="openai-compat")
-            transport = FakeTransport(models=[], fail_with=PermissionError("401 unauthorized"))
+            async with _probe_readers(bus) as events:
+                host = Host(name="locked", url="http://locked", engine="openai-compat")
+                transport = FakeTransport(models=[], fail_with=PermissionError("401 unauthorized"))
 
-            await probe_host(host, transport=transport, bus=bus)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus)
+                await asyncio.sleep(0.05)
 
-            failed = [ev for t, ev in events if t == "probe.failed"]
-            assert len(failed) == 1
-            assert failed[0]["reason"] == "auth"
+                failed = [ev for t, ev in events if t == "probe.failed"]
+                assert len(failed) == 1
+                assert failed[0]["reason"] == "auth"
 
         asyncio.run(_run())
 
     def test_transport_error_publishes_failed_with_reason_offline(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="dead", url="http://dead", engine="ollama")
-            transport = FakeTransport(models=[], fail_with=ConnectionRefusedError("nope"))
+            async with _probe_readers(bus) as events:
+                host = Host(name="dead", url="http://dead", engine="ollama")
+                transport = FakeTransport(models=[], fail_with=ConnectionRefusedError("nope"))
 
-            await probe_host(host, transport=transport, bus=bus)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus)
+                await asyncio.sleep(0.05)
 
-            failed = [ev for t, ev in events if t == "probe.failed"]
-            assert len(failed) == 1
-            assert failed[0]["reason"] == "offline"
+                failed = [ev for t, ev in events if t == "probe.failed"]
+                assert len(failed) == 1
+                assert failed[0]["reason"] == "offline"
 
         asyncio.run(_run())
 
     def test_programmer_error_publishes_failed_with_reason_unexpected(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="buggy", url="http://buggy", engine="ollama")
-            # Simulate a programmer error: AttributeError from a future transport
-            # bug should not be reported as "host offline".
-            transport = FakeTransport(models=[], fail_with=AttributeError("missing field"))
+            async with _probe_readers(bus) as events:
+                host = Host(name="buggy", url="http://buggy", engine="ollama")
+                # Simulate a programmer error: AttributeError from a future transport
+                # bug should not be reported as "host offline".
+                transport = FakeTransport(models=[], fail_with=AttributeError("missing field"))
 
-            await probe_host(host, transport=transport, bus=bus)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus)
+                await asyncio.sleep(0.05)
 
-            failed = [ev for t, ev in events if t == "probe.failed"]
-            assert len(failed) == 1
-            assert failed[0]["reason"] == "unexpected"
-            assert failed[0]["retryable"] is False
-            assert "AttributeError" in failed[0]["error"]
+                failed = [ev for t, ev in events if t == "probe.failed"]
+                assert len(failed) == 1
+                assert failed[0]["reason"] == "unexpected"
+                assert failed[0]["retryable"] is False
+                assert "AttributeError" in failed[0]["error"]
 
         asyncio.run(_run())
 
     def test_empty_model_list_publishes_completed_with_warning(self) -> None:
         async def _run() -> None:
             bus = SessionBus()
-            events = await _start_readers(bus)
-            host = Host(name="empty", url="http://empty", engine="ollama")
-            transport = FakeTransport(models=[])
+            async with _probe_readers(bus) as events:
+                host = Host(name="empty", url="http://empty", engine="ollama")
+                transport = FakeTransport(models=[])
 
-            await probe_host(host, transport=transport, bus=bus)
-            await asyncio.sleep(0.05)
+                await probe_host(host, transport=transport, bus=bus)
+                await asyncio.sleep(0.05)
 
-            completed = [ev for t, ev in events if t == "probe.completed"]
-            assert len(completed) == 1
-            assert completed[0]["models"] == []
-            assert completed[0]["warning"] == "no_models"
-            assert host.models == []
+                completed = [ev for t, ev in events if t == "probe.completed"]
+                assert len(completed) == 1
+                assert completed[0]["models"] == []
+                assert completed[0]["warning"] == "no_models"
+                assert host.models == []
 
         asyncio.run(_run())

--- a/tests/unit/tui/test_probe.py
+++ b/tests/unit/tui/test_probe.py
@@ -106,6 +106,26 @@ class TestProbeFailures:
 
         asyncio.run(_run())
 
+    def test_programmer_error_publishes_failed_with_reason_unexpected(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="buggy", url="http://buggy", engine="ollama")
+            # Simulate a programmer error: AttributeError from a future transport
+            # bug should not be reported as "host offline".
+            transport = FakeTransport(models=[], fail_with=AttributeError("missing field"))
+
+            await probe_host(host, transport=transport, bus=bus)
+            await asyncio.sleep(0.05)
+
+            failed = [ev for t, ev in events if t == "probe.failed"]
+            assert len(failed) == 1
+            assert failed[0]["reason"] == "unexpected"
+            assert failed[0]["retryable"] is False
+            assert "AttributeError" in failed[0]["error"]
+
+        asyncio.run(_run())
+
     def test_empty_model_list_publishes_completed_with_warning(self) -> None:
         async def _run() -> None:
             bus = SessionBus()

--- a/tests/unit/tui/test_probe.py
+++ b/tests/unit/tui/test_probe.py
@@ -1,0 +1,125 @@
+"""Tests for hermia.tui.probe — async host probe with timeout + retry + bus events."""
+import asyncio
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.probe import probe_host
+from hermia.tui.state import Host
+from tests.fixtures.fake_transport import FakeTransport
+
+
+async def _start_readers(bus: SessionBus) -> list[tuple[str, dict]]:
+    """Start background readers on probe.* topics and return the shared event list."""
+    events: list[tuple[str, dict]] = []
+
+    async def reader(topic: str) -> None:
+        async for ev in bus.subscribe(topic):
+            events.append((topic, ev))
+
+    for topic in ("probe.started", "probe.completed", "probe.failed"):
+        asyncio.create_task(reader(topic))
+    await asyncio.sleep(0)
+    return events
+
+
+class TestProbeHappyPath:
+    def test_publishes_started_then_completed(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="h1", url="http://h1:11434", engine="ollama")
+            transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+
+            await probe_host(host, transport=transport, bus=bus)
+            await asyncio.sleep(0.05)
+
+            topics = [t for t, _ in events]
+            assert "probe.started" in topics
+            assert "probe.completed" in topics
+            assert "probe.failed" not in topics
+
+            completed = next(ev for t, ev in events if t == "probe.completed")
+            assert completed["host_name"] == "h1"
+            assert completed["models"] == ["qwen3:32b", "llama3:8b"]
+
+        asyncio.run(_run())
+
+    def test_populates_host_models(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            host = Host(name="h1", url="http://h1", engine="ollama")
+            transport = FakeTransport(models=["qwen3:32b", "llama3:8b"])
+            await probe_host(host, transport=transport, bus=bus)
+            assert [m.name for m in host.models] == ["qwen3:32b", "llama3:8b"]
+            # Newly probed models start unselected.
+            assert all(not m.selected for m in host.models)
+
+        asyncio.run(_run())
+
+
+class TestProbeFailures:
+    def test_timeout_publishes_failed_with_reason_timeout(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="slow", url="http://slow", engine="ollama")
+            transport = FakeTransport(models=["x"], delay_seconds=2.0)
+
+            await probe_host(host, transport=transport, bus=bus, timeout=0.05)
+            await asyncio.sleep(0.05)
+
+            failed = [ev for t, ev in events if t == "probe.failed"]
+            assert len(failed) == 1
+            assert failed[0]["reason"] == "timeout"
+            assert failed[0]["retryable"] is True
+
+        asyncio.run(_run())
+
+    def test_auth_error_publishes_failed_with_reason_auth(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="locked", url="http://locked", engine="openai-compat")
+            transport = FakeTransport(models=[], fail_with=PermissionError("401 unauthorized"))
+
+            await probe_host(host, transport=transport, bus=bus)
+            await asyncio.sleep(0.05)
+
+            failed = [ev for t, ev in events if t == "probe.failed"]
+            assert len(failed) == 1
+            assert failed[0]["reason"] == "auth"
+
+        asyncio.run(_run())
+
+    def test_transport_error_publishes_failed_with_reason_offline(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="dead", url="http://dead", engine="ollama")
+            transport = FakeTransport(models=[], fail_with=ConnectionRefusedError("nope"))
+
+            await probe_host(host, transport=transport, bus=bus)
+            await asyncio.sleep(0.05)
+
+            failed = [ev for t, ev in events if t == "probe.failed"]
+            assert len(failed) == 1
+            assert failed[0]["reason"] == "offline"
+
+        asyncio.run(_run())
+
+    def test_empty_model_list_publishes_completed_with_warning(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events = await _start_readers(bus)
+            host = Host(name="empty", url="http://empty", engine="ollama")
+            transport = FakeTransport(models=[])
+
+            await probe_host(host, transport=transport, bus=bus)
+            await asyncio.sleep(0.05)
+
+            completed = [ev for t, ev in events if t == "probe.completed"]
+            assert len(completed) == 1
+            assert completed[0]["models"] == []
+            assert completed[0]["warning"] == "no_models"
+            assert host.models == []
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_state.py
+++ b/tests/unit/tui/test_state.py
@@ -4,7 +4,7 @@ Tests for the hermia.tui.state module.
 
 from __future__ import annotations
 
-from hermia.tui.state import ModelChoice, Host, FleetConfig, HostSource, ModelSource
+from hermia.tui.state import FleetConfig, Host, HostSource, ModelChoice, ModelSource
 
 
 def test_model_choice_defaults():

--- a/tests/unit/tui/test_state.py
+++ b/tests/unit/tui/test_state.py
@@ -1,0 +1,106 @@
+"""
+Tests for the hermia.tui.state module.
+"""
+
+from __future__ import annotations
+
+from hermia.tui.state import ModelChoice, Host, FleetConfig, HostSource, ModelSource
+
+
+def test_model_choice_defaults():
+    mc = ModelChoice(name="test")
+    assert mc.name == "test"
+    assert mc.selected is False
+    assert mc.size_bytes is None
+    assert mc.quant is None
+    assert mc.family is None
+    assert mc.modality is None
+
+
+def test_model_choice_selected_can_be_set():
+    mc = ModelChoice(name="test", selected=True)
+    assert mc.selected is True
+
+
+def test_host_required_fields():
+    h = Host(name="host1", url="http://example.com", engine="openai")
+    assert h.name == "host1"
+    assert h.url == "http://example.com"
+    assert h.engine == "openai"
+    assert h.auth_header_env is None
+    assert h.hardware is None
+    assert h.models == []
+
+
+def test_host_optional_fields():
+    mc = ModelChoice(name="model1")
+    h = Host(
+        name="host1",
+        url="http://example.com",
+        engine="openai",
+        auth_header_env="API_KEY",
+        hardware="gpu",
+        models=[mc],
+    )
+    assert h.name == "host1"
+    assert h.url == "http://example.com"
+    assert h.engine == "openai"
+    assert h.auth_header_env == "API_KEY"
+    assert h.hardware == "gpu"
+    assert h.models == [mc]
+
+
+def test_fleet_config_defaults():
+    fc = FleetConfig(name="fleet1")
+    assert fc.name == "fleet1"
+    assert fc.hosts == []
+    assert fc.tests == []
+    assert fc.repeat == 1
+
+
+def test_fleet_config_full_construction():
+    host = Host(name="host1", url="http://example.com", engine="openai")
+    fc = FleetConfig(
+        name="fleet1",
+        hosts=[host],
+        tests=["test1", "test2"],
+        repeat=3,
+    )
+    assert fc.name == "fleet1"
+    assert fc.hosts == [host]
+    assert fc.tests == ["test1", "test2"]
+    assert fc.repeat == 3
+
+
+def test_host_source_is_protocol():
+    assert hasattr(HostSource, "list_hosts")
+
+
+def test_model_source_is_protocol():
+    assert hasattr(ModelSource, "list_models")
+
+
+async def fake_list_hosts() -> list[Host]:
+    return []
+
+
+def test_host_source_can_be_implemented():
+    class FakeHostSource:
+        async def list_hosts(self) -> list[Host]:
+            return await fake_list_hosts()
+
+    source: HostSource = FakeHostSource()  # Should not raise TypeError
+    assert isinstance(source, HostSource)
+
+
+async def fake_list_models(host: Host) -> list[ModelChoice]:
+    return []
+
+
+def test_model_source_can_be_implemented():
+    class FakeModelSource:
+        async def list_models(self, host: Host) -> list[ModelChoice]:
+            return await fake_list_models(host)
+
+    source: ModelSource = FakeModelSource()  # Should not raise TypeError
+    assert isinstance(source, ModelSource)

--- a/tests/unit/tui/test_widgets_drillable_list.py
+++ b/tests/unit/tui/test_widgets_drillable_list.py
@@ -1,0 +1,127 @@
+"""Tests for DrillableList — API contract: cursor / drill / toggle / select-all/none
+plus apply_query filter behavior and Drill / Toggled events.
+
+Key-routing (↑↓ / enter / space / a / n) lives at the screen level per
+spec §5 universal contract. Bindings exist on the widget so it works in
+real screens; widget tests call the API directly.
+"""
+import asyncio
+
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+
+
+def _rows() -> list[ListRow]:
+    return [
+        ListRow(id_="a", label="alpha"),
+        ListRow(id_="b", label="bravo"),
+        ListRow(id_="c", label="charlie"),
+        ListRow(id_="d", label="delta"),
+    ]
+
+
+class _Host(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.drilled_into: str | None = None
+        self.toggled: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield DrillableList(_rows())
+
+    def on_drillable_list_drill(self, event: DrillableList.Drill) -> None:
+        self.drilled_into = event.row_id
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        self.toggled.append(event.row_id)
+
+
+class TestDrillableList:
+    def test_initial_state_renders_all_rows(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                assert len(dl.visible_rows) == 4
+
+        asyncio.run(_run())
+
+    def test_drill_emits_drill_for_current_row(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.drill()
+                await pilot.pause()
+                assert pilot.app.drilled_into == "a"
+
+        asyncio.run(_run())
+
+    def test_toggle_changes_selection_and_emits(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.toggle()
+                await pilot.pause()
+                assert pilot.app.toggled == ["a"]
+                assert dl.is_selected("a")
+
+        asyncio.run(_run())
+
+    def test_cursor_prev_next_move_cursor(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.cursor_next()
+                assert dl.cursor_row_id == "b"
+                dl.cursor_prev()
+                assert dl.cursor_row_id == "a"
+
+        asyncio.run(_run())
+
+    def test_select_all_selects_visible(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.select_all()
+                assert dl.is_selected("a")
+                assert dl.is_selected("b")
+                assert dl.is_selected("c")
+                assert dl.is_selected("d")
+
+        asyncio.run(_run())
+
+    def test_select_none_clears_visible(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.select_all()
+                dl.select_none()
+                assert not dl.is_selected("a")
+                assert not dl.is_selected("d")
+
+        asyncio.run(_run())
+
+    def test_apply_query_filters_rows(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.apply_query("a")  # alpha, bravo, charlie, delta all contain 'a'
+                assert len(dl.visible_rows) == 4
+                dl.apply_query("ravo")
+                assert [r.id_ for r in dl.visible_rows] == ["b"]
+                dl.apply_query("")
+                assert len(dl.visible_rows) == 4
+
+        asyncio.run(_run())
+
+    def test_select_all_respects_filter(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.apply_query("ravo")
+                dl.select_all()
+                assert dl.is_selected("b")
+                assert not dl.is_selected("a")
+                assert not dl.is_selected("c")
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_widgets_drillable_list.py
+++ b/tests/unit/tui/test_widgets_drillable_list.py
@@ -114,6 +114,18 @@ class TestDrillableList:
 
         asyncio.run(_run())
 
+    def test_click_on_row_drills(self) -> None:
+        """Mouse parity per spec §5 — clicking a row moves cursor and drills."""
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                # Click the second visible row (id_="b").
+                await pilot.click(dl.children[1])
+                await pilot.pause()
+                assert pilot.app.drilled_into == "b"
+
+        asyncio.run(_run())
+
     def test_select_all_respects_filter(self) -> None:
         async def _run() -> None:
             async with _Host().run_test() as pilot:

--- a/tests/unit/tui/test_widgets_filter_axis.py
+++ b/tests/unit/tui/test_widgets_filter_axis.py
@@ -1,0 +1,98 @@
+"""Tests for FilterAxis — API contract: current_axis / current_value / next_axis /
+next_value / prev_value plus Changed event emission.
+
+Key-routing (tab / ←→) is a screen-level concern per spec §5.
+"""
+import asyncio
+
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.filter_axis import FilterAxis
+
+
+class _Host(App):
+    def __init__(self, axes: dict[str, list[str]]) -> None:
+        super().__init__()
+        self.axes = axes
+        self.last_axis: str | None = None
+        self.last_value: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield FilterAxis(self.axes)
+
+    def on_filter_axis_changed(self, event: FilterAxis.Changed) -> None:
+        self.last_axis = event.axis
+        self.last_value = event.value
+
+
+class TestFilterAxis:
+    def test_initial_state_is_first_axis_all(self) -> None:
+        async def _run() -> None:
+            axes = {"framework": ["OWASP", "ATLAS"], "size": ["small", "large"]}
+            async with _Host(axes).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                assert fa.current_axis == "framework"
+                assert fa.current_value == "All"
+
+        asyncio.run(_run())
+
+    def test_next_value_cycles_within_axis(self) -> None:
+        async def _run() -> None:
+            axes = {"framework": ["OWASP", "ATLAS"]}
+            async with _Host(axes).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                fa.next_value()
+                assert fa.current_value == "OWASP"
+                fa.next_value()
+                assert fa.current_value == "ATLAS"
+                fa.next_value()
+                assert fa.current_value == "All"
+
+        asyncio.run(_run())
+
+    def test_prev_value_cycles_backward(self) -> None:
+        async def _run() -> None:
+            axes = {"framework": ["OWASP", "ATLAS"]}
+            async with _Host(axes).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                fa.prev_value()
+                assert fa.current_value == "ATLAS"
+
+        asyncio.run(_run())
+
+    def test_next_axis_cycles_to_next_axis(self) -> None:
+        async def _run() -> None:
+            axes = {"framework": ["OWASP"], "size": ["small"]}
+            async with _Host(axes).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                fa.next_axis()
+                assert fa.current_axis == "size"
+                assert fa.current_value == "All"
+                fa.next_axis()
+                assert fa.current_axis == "framework"
+
+        asyncio.run(_run())
+
+    def test_change_event_fires(self) -> None:
+        async def _run() -> None:
+            axes = {"framework": ["OWASP", "ATLAS"]}
+            async with _Host(axes).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                fa.next_value()
+                await pilot.pause()
+                assert pilot.app.last_axis == "framework"
+                assert pilot.app.last_value == "OWASP"
+
+        asyncio.run(_run())
+
+    def test_empty_axes_dict_is_noop(self) -> None:
+        async def _run() -> None:
+            async with _Host({}).run_test() as pilot:
+                fa = pilot.app.query_one(FilterAxis)
+                fa.next_axis()
+                fa.next_value()
+                fa.prev_value()
+                assert fa.current_axis is None
+                assert fa.current_value is None
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_widgets_progress_bar.py
+++ b/tests/unit/tui/test_widgets_progress_bar.py
@@ -1,0 +1,60 @@
+"""Tests for progress widgets — MiniProgressBar (per-host) and AggregateProgressBar."""
+from hermia.tui.widgets.progress_bar import (
+    AggregateProgressBar,
+    MiniProgressBar,
+)
+
+
+class TestMiniProgressBar:
+    def test_initial_state(self) -> None:
+        bar = MiniProgressBar(total=100)
+        assert bar.total == 100
+        assert bar.completed == 0
+        # Empty progress: zero filled blocks.
+        assert "█" not in bar.text
+
+    def test_partial_progress(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(5)
+        assert bar.completed == 5
+        # 50% of width=20 should be filled.
+        assert bar.text.count("█") == 10
+
+    def test_full_progress(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(10)
+        assert bar.text.count("█") == 20
+
+    def test_advance_clips_at_total(self) -> None:
+        bar = MiniProgressBar(total=10)
+        bar.advance(15)
+        assert bar.completed == 10
+
+    def test_set_total_renormalizes(self) -> None:
+        bar = MiniProgressBar(total=10, width=20)
+        bar.advance(5)
+        bar.set_total(20)  # was 50% complete; now 25%
+        assert bar.text.count("█") == 5  # 25% of 20
+
+    def test_zero_total_does_not_crash(self) -> None:
+        bar = MiniProgressBar(total=0)
+        assert "█" not in bar.text
+
+
+class TestAggregateProgressBar:
+    def test_initial_state(self) -> None:
+        bar = AggregateProgressBar(total=564)
+        assert bar.total == 564
+        assert bar.completed == 0
+        assert "0 / 564" in bar.text
+
+    def test_advance_updates_count_and_percent(self) -> None:
+        bar = AggregateProgressBar(total=100)
+        bar.advance(25)
+        assert "25 / 100" in bar.text
+        assert "25%" in bar.text
+
+    def test_zero_total_does_not_crash(self) -> None:
+        bar = AggregateProgressBar(total=0)
+        assert "0 / 0" in bar.text
+        assert "%" in bar.text

--- a/tests/unit/tui/test_widgets_search_bar.py
+++ b/tests/unit/tui/test_widgets_search_bar.py
@@ -1,0 +1,86 @@
+"""Tests for SearchBar widget API.
+
+Contract under test: open() / close() change visibility; typing into the
+Input emits QueryChanged; close() clears the query and emits QueryChanged("").
+
+Key-routing (binding `/` to open, `escape` to close) lives at the screen
+level per spec §5 universal contract — tested when screens land in Plan 2.
+"""
+import asyncio
+
+from textual.app import App, ComposeResult
+from textual.widgets import Input
+
+from hermia.tui.widgets.search_bar import SearchBar
+
+
+class _Host(App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_query: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield SearchBar()
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.last_query = event.query
+
+
+class TestSearchBar:
+    def test_starts_hidden(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                bar = pilot.app.query_one(SearchBar)
+                assert bar.display is False
+
+        asyncio.run(_run())
+
+    def test_open_makes_visible(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                bar = pilot.app.query_one(SearchBar)
+                bar.open()
+                await pilot.pause()
+                assert bar.display is True
+
+        asyncio.run(_run())
+
+    def test_close_makes_hidden(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                bar = pilot.app.query_one(SearchBar)
+                bar.open()
+                await pilot.pause()
+                bar.close()
+                await pilot.pause()
+                assert bar.display is False
+
+        asyncio.run(_run())
+
+    def test_typing_emits_query_changed(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                bar = pilot.app.query_one(SearchBar)
+                bar.open()
+                await pilot.pause()
+                # Simulate typing by setting the Input value directly —
+                # this is what would happen during real keyboard input.
+                bar.query_one(Input).value = "deep"
+                await pilot.pause()
+                assert pilot.app.last_query == "deep"
+
+        asyncio.run(_run())
+
+    def test_close_clears_query(self) -> None:
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                bar = pilot.app.query_one(SearchBar)
+                bar.open()
+                await pilot.pause()
+                bar.query_one(Input).value = "deep"
+                await pilot.pause()
+                bar.close()
+                await pilot.pause()
+                assert pilot.app.last_query == ""
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_widgets_status_badge.py
+++ b/tests/unit/tui/test_widgets_status_badge.py
@@ -1,0 +1,74 @@
+"""Tests for StatusBadge — ✓ ↺ ✗ ! glyphs with direction-aware color."""
+from hermia.tui.widgets.status_badge import (
+    ICONS,
+    StatusBadge,
+    color_for,
+)
+
+
+class TestColorFor:
+    def test_defended_is_green(self) -> None:
+        assert color_for("defended") == "green"
+
+    def test_breached_is_red(self) -> None:
+        assert color_for("breached") == "red"
+
+    def test_error_is_yellow(self) -> None:
+        assert color_for("error") == "yellow"
+
+    def test_refused_on_harmful_test_is_green(self) -> None:
+        assert color_for("refused", direction="harmful") == "green"
+
+    def test_refused_on_benign_test_is_red(self) -> None:
+        assert color_for("refused", direction="benign") == "red"
+
+    def test_refused_default_direction_is_harmful(self) -> None:
+        assert color_for("refused") == "green"
+
+
+class TestIcons:
+    def test_all_four_statuses_have_icons(self) -> None:
+        assert ICONS["defended"] == "✓"
+        assert ICONS["refused"] == "↺"
+        assert ICONS["breached"] == "✗"
+        assert ICONS["error"] == "!"
+
+
+class TestStatusBadge:
+    def test_renders_defended(self) -> None:
+        badge = StatusBadge("defended")
+        text = badge.markup
+        assert "✓" in text
+        assert "green" in text
+
+    def test_renders_breached(self) -> None:
+        badge = StatusBadge("breached")
+        text = badge.markup
+        assert "✗" in text
+        assert "red" in text
+
+    def test_renders_refused_harmful(self) -> None:
+        badge = StatusBadge("refused", direction="harmful")
+        text = badge.markup
+        assert "↺" in text
+        assert "green" in text
+
+    def test_renders_refused_benign(self) -> None:
+        badge = StatusBadge("refused", direction="benign")
+        text = badge.markup
+        assert "↺" in text
+        assert "red" in text
+
+    def test_update_status_changes_render(self) -> None:
+        badge = StatusBadge("defended")
+        badge.update_status("breached")
+        text = badge.markup
+        assert "✗" in text
+        assert "red" in text
+
+    def test_update_status_can_change_direction(self) -> None:
+        badge = StatusBadge("refused", direction="harmful")
+        badge.update_status("refused", direction="benign")
+        assert badge.direction == "benign"
+        text = badge.markup
+        assert "red" in text


### PR DESCRIPTION
## Summary

Foundation for the unified Fleet TUI per [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](docs/superpowers/specs/2026-06-18-fleet-tui-design.md). Builds the widget library, event bus, state model, fleet YAML I/O, and async host probe layer. **No user-facing flow yet** — every surface is unit-tested in isolation. Plans 2-4 (picker / runner / migration) follow.

Tracking: `hermia-86g`

## What's in this PR

- `src/hermia/tui/` package: `state.py`, `bus.py`, `fleet_io.py`, `probe.py`
- `src/hermia/tui/widgets/`: `status_badge`, `search_bar`, `filter_axis`, `progress_bar`, `drillable_list`
- `tests/fixtures/fake_transport.py`: shared FakeTransport for any test driving probe / runner without a host
- Full unit-test coverage for every surface (85 tests, 100% line coverage on the new package)
- `AGENTS.md` Module Boundary Table expanded to include `src/hermia/tui/`, `tests/unit/tui/`, and `tests/fixtures/`

Also includes the design spec and the Plan 1 + Plan 2 implementation plans as docs commits so reviewers have full forward-looking context.

## Design adaptations made during implementation

These differ from the original plan; called out for review:

1. **Stdlib `asyncio.run()` in sync test wrappers** instead of `pytest-asyncio` — pytest-asyncio is not in `pyproject.toml` and AGENTS.md rule 3 blocks adding deps without approval. Zero new deps; identical test coverage.

2. **Widget key routing tested at API level, not via Pilot key-press** — Textual does not dispatch key events to hidden widgets (`display: none`), so binding-based Pilot tests don't fire. Refactored widget tests to exercise the API contract (`open()`/`close()`/`drill()`/`toggle()`/`apply_query()`/etc.) directly. Bindings still exist on each widget so screens get the universal contract for free. Key-routing tests live at the screen level in Plan 2.

3. **`.markup` / `.text` properties on widgets** — Textual ≥0.80 `render()` returns a parsed `Content` (markup tags stripped). Exposed read-only string properties so tests can assert color + content honestly.

## Local /code-review pass

Ran in-window before push. 7 angles (correctness + cleanup + altitude) surfaced ~30 candidates. Fixed inline:

- `fleet_io.load_fleet`: guard `'name' not in raw` with `isinstance(raw, dict)` first — substring match on a scalar YAML string previously crashed with `TypeError` instead of the documented `KeyError`
- `probe.py`: split bare `except Exception` into `(OSError, ConnectionError) → reason='offline'` (network) and `Exception → reason='unexpected'` with `retryable=False`. Programmer bugs no longer masquerade as "host offline"
- `AGENTS.md`: UI/TUI scope row expanded to include `tests/unit/tui/` and `tests/fixtures/`

Deferred to bd beads (real but not blocking foundation merge):

- `hermia-5oo` (P2) — DrillableList stable-row refactor (perf at 500+ hosts)
- `hermia-6x4` (P2) — SessionBus.unsubscribe() (queue leak on screen pop)
- `hermia-7ao` (P2) — fleet_io schema unification with `hermia.fleet.load_fleet_config`
- `hermia-6om` (P3) — widget BINDINGS literal sanity test
- `hermia-hcr` (P3) — ModelSource vs `_ListModelsTransport` naming clarity

## Test plan

- [x] `pytest tests/unit/tui/` — 85 passed
- [x] `pytest` — 1610/1610 (full project, no regression)
- [x] `ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/` — clean
- [x] `mypy src/hermia/tui/` — clean
- [x] Local /code-review pass with 7 finder angles + fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)