### PR TITLE
feat(tui): picker screens — Launch / Config / Hosts / Models / Tests

### DIFF
--- a/src/hermia/tui/__main__.py
+++ b/src/hermia/tui/__main__.py
@@ -1,0 +1,15 @@
+"""`python -m hermia.tui` — launches the unified Fleet TUI.
+
+Separate from the existing `hermia` CLI (src/hermia/app.py:main) during
+Plan 2 development. Plan 4 rewires the main entry to point here and deletes
+src/hermia/screens.py.
+"""
+from hermia.tui.app import HermiaApp
+
+
+def main() -> None:
+    HermiaApp().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -1,0 +1,24 @@
+"""HermiaApp — Textual App for the unified Fleet TUI.
+
+Holds the shared FleetConfig as a mutable attribute. Picker screens read
+and write directly to `app.config`. Plan 3 adds `app.bus = SessionBus()`
+for runner ↔ screen communication.
+"""
+from __future__ import annotations
+
+from textual.app import App
+
+from hermia.tui.state import FleetConfig
+
+
+class HermiaApp(App[None]):
+    CSS_PATH = None  # widgets define their own DEFAULT_CSS
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config: FleetConfig = FleetConfig(name="")
+
+    def on_mount(self) -> None:
+        # Import here to avoid a circular import — screens.launch imports HermiaApp.
+        from hermia.tui.screens.launch import LaunchScreen
+        self.push_screen(LaunchScreen())

--- a/src/hermia/tui/screens/__init__.py
+++ b/src/hermia/tui/screens/__init__.py
@@ -1,0 +1,1 @@
+"""Picker + runner screens for the Fleet TUI."""

--- a/src/hermia/tui/screens/_dirty.py
+++ b/src/hermia/tui/screens/_dirty.py
@@ -1,0 +1,22 @@
+"""Shared helper: propagate `mark_dirty()` up the screen stack.
+
+Picker screens (HostsScreen / HostModelsScreen / TestsScreen) mutate
+app.config when the user toggles selections or adds hosts. The parent
+FleetConfigScreen owns the [unsaved changes] indicator — child screens
+walk the stack and call mark_dirty() on any screen that supports it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _mark_dirty_in_stack(app: Any) -> None:
+    """Call mark_dirty() on every screen in the stack that supports it.
+
+    Typically only FleetConfigScreen does; future screens with their own
+    unsaved-state indicators get the same propagation for free.
+    """
+    for screen in app.screen_stack:
+        marker = getattr(screen, "mark_dirty", None)
+        if callable(marker):
+            marker()

--- a/src/hermia/tui/screens/_dirty.py
+++ b/src/hermia/tui/screens/_dirty.py
@@ -16,7 +16,10 @@ def _mark_dirty_in_stack(app: Any) -> None:
     Typically only FleetConfigScreen does; future screens with their own
     unsaved-state indicators get the same propagation for free.
     """
-    for screen in app.screen_stack:
+    # Snapshot the stack — a screen's mark_dirty might trigger a push/pop
+    # (or a future runner event might mutate the stack mid-walk), and
+    # iterating live would raise RuntimeError: list changed size.
+    for screen in list(app.screen_stack):
         marker = getattr(screen, "mark_dirty", None)
         if callable(marker):
             marker()

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -108,7 +108,9 @@ class FleetConfigScreen(Screen[None]):
         if self.cursor_row == 0:
             from hermia.tui.screens.hosts import HostsScreen
             self.app.push_screen(HostsScreen())
-        # Tests drill lands in Task 13.
+        elif self.cursor_row == 1:
+            from hermia.tui.screens.tests import TestsScreen
+            self.app.push_screen(TestsScreen())
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -12,6 +12,7 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Static
 
+from hermia.tui.state import FleetConfig
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
 
@@ -39,8 +40,8 @@ class FleetConfigScreen(Screen[None]):
         self._run_plan_str: str = ""
 
     @property
-    def app_config(self):
-        return self.app.config  # type: ignore[attr-defined]
+    def app_config(self) -> FleetConfig:
+        return self.app.config  # type: ignore[attr-defined,no-any-return]
 
     @property
     def breadcrumb_text(self) -> str:

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -65,6 +65,12 @@ class FleetConfigScreen(Screen[None]):
     def on_mount(self) -> None:
         self._refresh()
 
+    def on_screen_resume(self) -> None:
+        # Pop-back from a child drill (Hosts / Tests) may have toggled
+        # selections; mark_dirty() propagation handles inline updates, but
+        # this is the belt-and-braces refresh per spec §5 lifecycle.
+        self._refresh()
+
     def _breadcrumb_segments(self) -> list[str]:
         name = self.app_config.name or "(unnamed)"
         suffix = " [unsaved changes]" if self.dirty else ""

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -105,8 +105,10 @@ class FleetConfigScreen(Screen[None]):
             self._refresh()
 
     def action_drill(self) -> None:
-        # Hosts and Tests screens land in Tasks 10 and 13.
-        pass
+        if self.cursor_row == 0:
+            from hermia.tui.screens.hosts import HostsScreen
+            self.app.push_screen(HostsScreen())
+        # Tests drill lands in Task 13.
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -112,8 +112,21 @@ class FleetConfigScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_save(self) -> None:
-        # Wired in Task 9.
-        pass
+        from hermia.tui.fleet_io import save_fleet
+        from hermia.tui.screens.modals import FleetNameModal
+        if not self.app_config.name:
+            self.app.push_screen(FleetNameModal(), self._on_name_chosen)
+            return
+        save_fleet(self.app_config)
+        self.dirty = False
+        self._refresh()
+
+    def _on_name_chosen(self, name: str | None) -> None:
+        if not name:
+            return
+        self.app_config.name = name
+        # Recurse — name is now set so the save branch runs.
+        self.action_save()
 
     def action_load(self) -> None:
         # Pop back to Launch and re-enter Load mode (Task 9-ish behavior).

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -1,0 +1,124 @@
+"""Fleet Config screen — home base of the picker drill.
+
+Shows two drillable rows (Hosts, Tests), a run-plan trial estimate, and
+the breadcrumb header. Future tasks (10, 13) wire enter-on-row to push the
+child drills; Task 9 wires save / unsaved-changes indicator.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class FleetConfigScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Drill", show=True),
+        Binding("s", "save", "Save", show=True),
+        Binding("l", "load", "Load", show=False),
+        Binding("r", "run", "Run", show=False),
+    ]
+
+    ROWS = [("hosts", "Hosts"), ("tests", "Tests")]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cursor_row: int = 0
+        self.dirty: bool = False
+        # Cached rendered text so test properties don't depend on Textual's
+        # internal Static.renderable API (which changed between versions).
+        self._hosts_summary_str: str = ""
+        self._tests_summary_str: str = ""
+        self._run_plan_str: str = ""
+
+    @property
+    def app_config(self):
+        return self.app.config  # type: ignore[attr-defined]
+
+    @property
+    def breadcrumb_text(self) -> str:
+        return self.query_one(Breadcrumb).text
+
+    @property
+    def summary_text(self) -> str:
+        return f"{self._hosts_summary_str} {self._tests_summary_str}"
+
+    @property
+    def run_plan_text(self) -> str:
+        return self._run_plan_str
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Breadcrumb(self._breadcrumb_segments())
+            yield Static("", id="config-summary-hosts")
+            yield Static("", id="config-summary-tests")
+            yield Static("", id="config-run-plan")
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def _breadcrumb_segments(self) -> list[str]:
+        name = self.app_config.name or "(unnamed)"
+        suffix = " [unsaved changes]" if self.dirty else ""
+        return ["hermia", "fleet", f"{name}{suffix}"]
+
+    def _refresh(self) -> None:
+        cfg = self.app_config
+        n_hosts = len(cfg.hosts)
+        n_models_total = sum(sum(1 for m in h.models if m.selected) for h in cfg.hosts)
+        n_tests = len(cfg.tests)
+        trials = n_models_total * n_tests
+        self.query_one(Breadcrumb).set_segments(self._breadcrumb_segments())
+        h_label = "host" if n_hosts == 1 else "hosts"
+        t_label = "test" if n_tests == 1 else "tests"
+        cursor = "▸" if self.cursor_row == 0 else " "
+        self._hosts_summary_str = (
+            f"{cursor} Hosts        {n_hosts} {h_label} · {n_models_total} model trials"
+        )
+        self.query_one("#config-summary-hosts", Static).update(self._hosts_summary_str)
+        cursor = "▸" if self.cursor_row == 1 else " "
+        self._tests_summary_str = f"{cursor} Tests        {n_tests} {t_label}"
+        self.query_one("#config-summary-tests", Static).update(self._tests_summary_str)
+        self._run_plan_str = f"Run plan: {trials} trials"
+        self.query_one("#config-run-plan", Static).update(self._run_plan_str)
+
+    def mark_dirty(self) -> None:
+        """Called by child screens when they mutate app.config."""
+        self.dirty = True
+        self._refresh()
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_row > 0:
+            self.cursor_row -= 1
+            self._refresh()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_row < len(self.ROWS) - 1:
+            self.cursor_row += 1
+            self._refresh()
+
+    def action_drill(self) -> None:
+        # Hosts and Tests screens land in Tasks 10 and 13.
+        pass
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_save(self) -> None:
+        # Wired in Task 9.
+        pass
+
+    def action_load(self) -> None:
+        # Pop back to Launch and re-enter Load mode (Task 9-ish behavior).
+        self.app.pop_screen()
+
+    def action_run(self) -> None:
+        # Plan 3 wires this to the runner.
+        pass

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -122,9 +122,16 @@ class FleetConfigScreen(Screen[None]):
         if not self.app_config.name:
             self.app.push_screen(FleetNameModal(), self._on_name_chosen)
             return
-        save_fleet(self.app_config)
+        # save_fleet can raise on permission denied, disk full, etc. Notify
+        # rather than crash the TUI — dirty stays set so the user can retry.
+        try:
+            save_fleet(self.app_config)
+        except Exception as exc:
+            self.app.notify(f"Failed to save fleet: {exc}", severity="error")
+            return
         self.dirty = False
         self._refresh()
+        self.app.notify(f"Fleet '{self.app_config.name}' saved.")
 
     def _on_name_chosen(self, name: str | None) -> None:
         if not name:

--- a/src/hermia/tui/screens/host_models.py
+++ b/src/hermia/tui/screens/host_models.py
@@ -22,7 +22,7 @@ class HostModelsScreen(Screen[None]):
         Binding("escape", "back", "Back", show=True),
         Binding("up", "cursor_prev", "Up", show=False),
         Binding("down", "cursor_next", "Down", show=False),
-        Binding("space", "toggle", "Toggle", show=True),
+        Binding("space", "toggle_model", "Toggle", show=True),
         Binding("a", "select_all", "All", show=True),
         Binding("n", "select_none", "None", show=True),
         Binding("slash", "search_open", "Search", show=False),
@@ -83,7 +83,7 @@ class HostModelsScreen(Screen[None]):
     def action_cursor_next(self) -> None:
         self.query_one(DrillableList).cursor_next()
 
-    def action_toggle(self) -> None:
+    def action_toggle_model(self) -> None:
         self.query_one(DrillableList).toggle()
 
     def action_select_all(self) -> None:

--- a/src/hermia/tui/screens/host_models.py
+++ b/src/hermia/tui/screens/host_models.py
@@ -47,12 +47,9 @@ class HostModelsScreen(Screen[None]):
             yield SearchBar()
 
     def on_mount(self) -> None:
-        dl = self.query_one(DrillableList)
-        # Pre-mark currently-selected models in the widget's selection set.
-        for m in self._host.models:
-            if m.selected:
-                dl._selected.add(m.name)
-        dl._refresh()
+        # Mirror host.models[].selected into the widget via its public API.
+        selected = [m.name for m in self._host.models if m.selected]
+        self.query_one(DrillableList).set_selected_ids(selected)
 
     # ── Event handlers ────────────────────────────────────────────────────
 

--- a/src/hermia/tui/screens/host_models.py
+++ b/src/hermia/tui/screens/host_models.py
@@ -11,6 +11,7 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
 
+from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.state import Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 from hermia.tui.widgets.drillable_list import DrillableList, ListRow
@@ -60,6 +61,7 @@ class HostModelsScreen(Screen[None]):
             if m.name == event.row_id:
                 m.selected = not m.selected
                 break
+        _mark_dirty_in_stack(self.app)
 
     def on_drillable_list_selection_changed(
         self, event: DrillableList.SelectionChanged
@@ -68,6 +70,7 @@ class HostModelsScreen(Screen[None]):
         selected = set(event.selected_ids)
         for m in self._host.models:
             m.selected = m.name in selected
+        _mark_dirty_in_stack(self.app)
 
     def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
         self.query_one(DrillableList).apply_query(event.query)
@@ -87,18 +90,12 @@ class HostModelsScreen(Screen[None]):
         self.query_one(DrillableList).toggle()
 
     def action_select_all(self) -> None:
-        dl = self.query_one(DrillableList)
-        dl.select_all()
-        # Sync state to host.models.
-        for m in self._host.models:
-            if m.name in dl._selected:
-                m.selected = True
+        # dl.select_all() posts SelectionChanged which our handler picks up
+        # and syncs to host.models — no manual mutation needed here.
+        self.query_one(DrillableList).select_all()
 
     def action_select_none(self) -> None:
-        dl = self.query_one(DrillableList)
-        dl.select_none()
-        for m in self._host.models:
-            m.selected = False
+        self.query_one(DrillableList).select_none()
 
     def action_search_open(self) -> None:
         self.query_one(SearchBar).open()

--- a/src/hermia/tui/screens/host_models.py
+++ b/src/hermia/tui/screens/host_models.py
@@ -1,0 +1,104 @@
+"""Single host's model picker — uses DrillableList + SearchBar.
+
+Mounts a DrillableList of the host's currently-probed models. Toggling a
+row flips host.models[].selected; the parent FleetConfigScreen's run-plan
+trial count updates when the user pops back.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+
+from hermia.tui.state import Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.search_bar import SearchBar
+
+
+class HostModelsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+        Binding("slash", "search_open", "Search", show=False),
+    ]
+
+    def __init__(self, *, host: Host) -> None:
+        super().__init__()
+        self._host = host
+
+    @property
+    def visible_model_names(self) -> list[str]:
+        dl = self.query_one(DrillableList)
+        return [r.label for r in dl.visible_rows]
+
+    def compose(self) -> ComposeResult:
+        name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
+        with Vertical():
+            yield Breadcrumb(["hermia", "fleet", name, "hosts", self._host.name])
+            rows = [ListRow(id_=m.name, label=m.name) for m in self._host.models]
+            yield DrillableList(rows)
+            yield SearchBar()
+
+    def on_mount(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Pre-mark currently-selected models in the widget's selection set.
+        for m in self._host.models:
+            if m.selected:
+                dl._selected.add(m.name)
+        dl._refresh()
+
+    # ── Event handlers ────────────────────────────────────────────────────
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        for m in self._host.models:
+            if m.name == event.row_id:
+                m.selected = not m.selected
+                break
+
+    def on_drillable_list_selection_changed(
+        self, event: DrillableList.SelectionChanged
+    ) -> None:
+        # Bulk select_all / select_none in the widget — sync to host.models.
+        selected = set(event.selected_ids)
+        for m in self._host.models:
+            m.selected = m.name in selected
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.query_one(DrillableList).apply_query(event.query)
+
+    # ── Action wrappers ───────────────────────────────────────────────────
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_cursor_prev(self) -> None:
+        self.query_one(DrillableList).cursor_prev()
+
+    def action_cursor_next(self) -> None:
+        self.query_one(DrillableList).cursor_next()
+
+    def action_toggle(self) -> None:
+        self.query_one(DrillableList).toggle()
+
+    def action_select_all(self) -> None:
+        dl = self.query_one(DrillableList)
+        dl.select_all()
+        # Sync state to host.models.
+        for m in self._host.models:
+            if m.name in dl._selected:
+                m.selected = True
+
+    def action_select_none(self) -> None:
+        dl = self.query_one(DrillableList)
+        dl.select_none()
+        for m in self._host.models:
+            m.selected = False
+
+    def action_search_open(self) -> None:
+        self.query_one(SearchBar).open()

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -1,0 +1,107 @@
+"""Hosts drill — list, add, remove, probe state.
+
+Lists existing hosts in app.config. `+` opens AddHostModal; enter drills
+into the host's models (Task 12); escape pops back. Background probes for
+each host's models land in Task 11 and update probe_state per host.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.state import Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class HostsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("plus", "add_host", "Add host", show=True),
+        Binding("enter", "drill", "Models", show=True),
+    ]
+
+    def __init__(
+        self,
+        *,
+        transport_factory: Callable[[Host], Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.cursor_idx: int = 0
+        # probe_state[host.name] = "probing" | "ok" | "failed". Task 11 fills.
+        self.probe_state: dict[str, str] = {}
+        # Injected for tests; production uses transport_adapter.transport_for.
+        self._make_transport = transport_factory
+        self._render_seq: int = 0
+
+    @property
+    def app_config(self):
+        return self.app.config  # type: ignore[attr-defined]
+
+    @property
+    def host_names(self) -> list[str]:
+        return [h.name for h in self.app_config.hosts]
+
+    def compose(self) -> ComposeResult:
+        name = self.app_config.name or "(unnamed)"
+        with Vertical(id="hosts-root"):
+            yield Breadcrumb(["hermia", "fleet", name, "hosts"])
+
+    def on_mount(self) -> None:
+        self._rerender()
+
+    def _row_text(self, host: Host, idx: int) -> str:
+        cursor = "▸" if idx == self.cursor_idx else " "
+        state = self.probe_state.get(host.name, "")
+        state_str = f" [{state}]" if state else ""
+        return f"{cursor} {host.name}    {host.url}    [{host.engine}]{state_str}"
+
+    def _rerender(self) -> None:
+        root = self.query_one("#hosts-root", Vertical)
+        for child in list(root.children):
+            if isinstance(child, Breadcrumb):
+                continue
+            child.remove()
+        self._render_seq += 1
+        seq = self._render_seq
+        if not self.app_config.hosts:
+            root.mount(Static("No hosts yet — press '+' to add one.", id="hosts-empty-notice"))
+            return
+        for i, host in enumerate(self.app_config.hosts):
+            root.mount(Static(self._row_text(host, i), id=f"host-row-{seq}-{i}"))
+
+    # ── Navigation ────────────────────────────────────────────────────────
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_idx > 0:
+            self.cursor_idx -= 1
+            self._rerender()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_idx < len(self.app_config.hosts) - 1:
+            self.cursor_idx += 1
+            self._rerender()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_add_host(self) -> None:
+        from hermia.tui.screens.modals import AddHostModal
+        self.app.push_screen(AddHostModal(), self._on_host_added)
+
+    def action_drill(self) -> None:
+        # Task 12 wires the host-models screen push.
+        pass
+
+    def _on_host_added(self, host: Host | None) -> None:
+        if host is None:
+            return
+        self.app_config.hosts.append(host)
+        self._rerender()

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -20,7 +20,7 @@ from textual.widgets import Static
 
 from hermia.tui.bus import SessionBus
 from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
-from hermia.tui.state import Host
+from hermia.tui.state import FleetConfig, Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
 
@@ -53,8 +53,8 @@ class HostsScreen(Screen[None]):
         self._bus: SessionBus = SessionBus()
 
     @property
-    def app_config(self):
-        return self.app.config  # type: ignore[attr-defined]
+    def app_config(self) -> FleetConfig:
+        return self.app.config  # type: ignore[attr-defined,no-any-return]
 
     @property
     def host_names(self) -> list[str]:
@@ -148,9 +148,11 @@ class HostsScreen(Screen[None]):
             if host.name in self.probe_state:
                 continue
             transport = factory(host)
+            # The transport satisfies probe._ListModelsTransport structurally
+            # (Protocol checks); mypy can't always see through Callable wrap.
             await probe_host(
                 host,
-                transport=transport,
+                transport=transport,  # type: ignore[arg-type]
                 bus=self._bus,
                 timeout=self._probe_timeout,
             )

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -1,20 +1,25 @@
 """Hosts drill — list, add, remove, probe state.
 
 Lists existing hosts in app.config. `+` opens AddHostModal; enter drills
-into the host's models (Task 12); escape pops back. Background probes for
-each host's models land in Task 11 and update probe_state per host.
+into the host's models (Task 12); escape pops back. Background probes via
+SessionBus update probe_state per host (`probing` / `ok` / `failed`) which
+renders as inline `[state]` tags on each row.
 """
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import Any
 
+from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Static
 
+from hermia.tui.bus import SessionBus
+from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
 from hermia.tui.state import Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
@@ -32,14 +37,20 @@ class HostsScreen(Screen[None]):
         self,
         *,
         transport_factory: Callable[[Host], Any] | None = None,
+        probe_timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
     ) -> None:
         super().__init__()
         self.cursor_idx: int = 0
-        # probe_state[host.name] = "probing" | "ok" | "failed". Task 11 fills.
+        # probe_state[host.name] = "probing" | "ok" | "failed".
         self.probe_state: dict[str, str] = {}
-        # Injected for tests; production uses transport_adapter.transport_for.
+        # Injected for tests; production uses transport_adapter.transport_for
+        # (resolved at probe time so the import stays lazy).
         self._make_transport = transport_factory
+        self._probe_timeout = probe_timeout
         self._render_seq: int = 0
+        # Per-screen bus so probe events don't bleed into Plan 3's app.bus
+        # when the runner lands.
+        self._bus: SessionBus = SessionBus()
 
     @property
     def app_config(self):
@@ -56,6 +67,7 @@ class HostsScreen(Screen[None]):
 
     def on_mount(self) -> None:
         self._rerender()
+        self._start_probes()
 
     def _row_text(self, host: Host, idx: int) -> str:
         cursor = "▸" if idx == self.cursor_idx else " "
@@ -105,3 +117,48 @@ class HostsScreen(Screen[None]):
             return
         self.app_config.hosts.append(host)
         self._rerender()
+        # Kick a probe for the new host.
+        self._start_probes()
+
+    # ── Probe wiring ──────────────────────────────────────────────────────
+
+    @work
+    async def _start_probes(self) -> None:
+        """Background worker: subscribe to probe events, then fire probes.
+
+        Started in on_mount and after any host is added. Idempotent — probes
+        are skipped for hosts that already have a recorded probe_state.
+        """
+        # Subscribe first so events fired during probe_host land in our queues.
+        asyncio.create_task(self._listen("probe.started", "probing"))
+        asyncio.create_task(self._listen("probe.completed", "ok"))
+        asyncio.create_task(self._listen("probe.failed", "failed"))
+        await asyncio.sleep(0)
+
+        # Resolve transport factory lazily so unit tests don't import urllib
+        # paths unless a real probe runs.
+        factory = self._make_transport
+        if factory is None:
+            from hermia.tui.transport_adapter import transport_for
+            factory = transport_for
+
+        for host in list(self.app_config.hosts):
+            if host.name in self.probe_state:
+                continue
+            transport = factory(host)
+            await probe_host(
+                host,
+                transport=transport,
+                bus=self._bus,
+                timeout=self._probe_timeout,
+            )
+
+    async def _listen(self, topic: str, final_state: str) -> None:
+        async for ev in self._bus.subscribe(topic):
+            self.probe_state[ev["host_name"]] = final_state
+            # Re-render so the row's [state] tag updates.
+            try:
+                self._rerender()
+            except Exception:
+                # Screen may be unmounting — swallow late events.
+                return

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -20,6 +20,7 @@ from textual.widgets import Static
 
 from hermia.tui.bus import SessionBus
 from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
+from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.state import FleetConfig, Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
@@ -51,6 +52,9 @@ class HostsScreen(Screen[None]):
         # Per-screen bus so probe events don't bleed into Plan 3's app.bus
         # when the runner lands.
         self._bus: SessionBus = SessionBus()
+        # Listener tasks — created once on first probe and reused, so
+        # re-firing _start_probes (after add-host) doesn't subscribe twice.
+        self._listener_tasks: list[asyncio.Task[None]] = []
 
     @property
     def app_config(self) -> FleetConfig:
@@ -77,9 +81,22 @@ class HostsScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#hosts-root", Vertical)
-        for child in list(root.children):
-            if isinstance(child, Breadcrumb):
-                continue
+        existing_rows = [c for c in root.children if not isinstance(c, Breadcrumb)]
+        # Stable-row optimization (Plan 1 lesson): when host count is unchanged
+        # and we're not transitioning to/from empty state, update Statics in
+        # place. Cursor moves and probe-state updates take this path.
+        if (
+            self.app_config.hosts
+            and len(existing_rows) == len(self.app_config.hosts)
+            and all(isinstance(c, Static) for c in existing_rows)
+        ):
+            for i, host in enumerate(self.app_config.hosts):
+                existing_rows[i].update(self._row_text(host, i))  # type: ignore[attr-defined]
+            return
+        # Structural change (add-host, first mount, mode transition) — full
+        # remount with seq-bumped IDs so AwaitRemove can't collide with new
+        # mount IDs.
+        for child in existing_rows:
             child.remove()
         self._render_seq += 1
         seq = self._render_seq
@@ -119,6 +136,7 @@ class HostsScreen(Screen[None]):
             return
         self.app_config.hosts.append(host)
         self._rerender()
+        _mark_dirty_in_stack(self.app)
         # Kick a probe for the new host.
         self._start_probes()
 
@@ -128,14 +146,20 @@ class HostsScreen(Screen[None]):
     async def _start_probes(self) -> None:
         """Background worker: subscribe to probe events, then fire probes.
 
-        Started in on_mount and after any host is added. Idempotent — probes
-        are skipped for hosts that already have a recorded probe_state.
+        Started in on_mount and after any host is added. Idempotent on two
+        axes: per-host (probes skipped for hosts with recorded probe_state)
+        and per-screen (listener tasks created once and reused).
         """
-        # Subscribe first so events fired during probe_host land in our queues.
-        asyncio.create_task(self._listen("probe.started", "probing"))
-        asyncio.create_task(self._listen("probe.completed", "ok"))
-        asyncio.create_task(self._listen("probe.failed", "failed"))
-        await asyncio.sleep(0)
+        # Subscribe first so events fired during probe_host land in queues.
+        # Listeners are screen-lifetime singletons — multiple _start_probes
+        # calls reuse the same subscribers (no duplicate event handling).
+        if not self._listener_tasks:
+            self._listener_tasks = [
+                asyncio.create_task(self._listen("probe.started", "probing")),
+                asyncio.create_task(self._listen("probe.completed", "ok")),
+                asyncio.create_task(self._listen("probe.failed", "failed")),
+            ]
+            await asyncio.sleep(0)  # give subscribers a tick to register
 
         # Resolve transport factory lazily so unit tests don't import urllib
         # paths unless a real probe runs.
@@ -144,9 +168,7 @@ class HostsScreen(Screen[None]):
             from hermia.tui.transport_adapter import transport_for
             factory = transport_for
 
-        for host in list(self.app_config.hosts):
-            if host.name in self.probe_state:
-                continue
+        async def _probe(host: Host) -> None:
             transport = factory(host)
             # The transport satisfies probe._ListModelsTransport structurally
             # (Protocol checks); mypy can't always see through Callable wrap.
@@ -156,6 +178,17 @@ class HostsScreen(Screen[None]):
                 bus=self._bus,
                 timeout=self._probe_timeout,
             )
+
+        # Probe all unprobed hosts concurrently — sequential gather would
+        # serialize a slow host's timeout across the entire fleet.
+        to_probe = [h for h in list(self.app_config.hosts) if h.name not in self.probe_state]
+        if to_probe:
+            await asyncio.gather(*[_probe(h) for h in to_probe])
+
+    def on_unmount(self) -> None:
+        # Cancel listener tasks so they don't outlive the screen.
+        for t in self._listener_tasks:
+            t.cancel()
 
     async def _listen(self, topic: str, final_state: str) -> None:
         async for ev in self._bus.subscribe(topic):

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -204,6 +204,11 @@ class HostsScreen(Screen[None]):
         # Cancel listener tasks so they don't outlive the screen.
         for t in self._listener_tasks:
             t.cancel()
+        # Also cancel any @work probe workers still in flight — Textual's
+        # default cleanup is not guaranteed to drop them synchronously, and
+        # an orphan probe writing to host.models after the screen tears down
+        # would race the next mount. workers.cancel_all() is sync + safe.
+        self.workers.cancel_all()
 
     async def _listen(self, topic: str, final_state: str) -> None:
         async for ev in self._bus.subscribe(topic):

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -185,10 +185,20 @@ class HostsScreen(Screen[None]):
         # probe_host doesn't catch) doesn't abort the other in-flight probes.
         to_probe = [h for h in list(self.app_config.hosts) if h.name not in self.probe_state]
         if to_probe:
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *[_probe(h) for h in to_probe],
                 return_exceptions=True,
             )
+            # Any host whose probe raised an unexpected exception (one that
+            # probe_host didn't catch and translate into a bus event) would
+            # otherwise stay stuck in "probing" forever. Mark them failed.
+            any_failed = False
+            for host, result in zip(to_probe, results, strict=True):
+                if isinstance(result, BaseException):
+                    self.probe_state[host.name] = "failed"
+                    any_failed = True
+            if any_failed and self.is_mounted:
+                self._rerender()
 
     def on_unmount(self) -> None:
         # Cancel listener tasks so they don't outlive the screen.

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -181,9 +181,14 @@ class HostsScreen(Screen[None]):
 
         # Probe all unprobed hosts concurrently — sequential gather would
         # serialize a slow host's timeout across the entire fleet.
+        # return_exceptions=True ensures one host blowing up (with a class
+        # probe_host doesn't catch) doesn't abort the other in-flight probes.
         to_probe = [h for h in list(self.app_config.hosts) if h.name not in self.probe_state]
         if to_probe:
-            await asyncio.gather(*[_probe(h) for h in to_probe])
+            await asyncio.gather(
+                *[_probe(h) for h in to_probe],
+                return_exceptions=True,
+            )
 
     def on_unmount(self) -> None:
         # Cancel listener tasks so they don't outlive the screen.
@@ -193,9 +198,9 @@ class HostsScreen(Screen[None]):
     async def _listen(self, topic: str, final_state: str) -> None:
         async for ev in self._bus.subscribe(topic):
             self.probe_state[ev["host_name"]] = final_state
-            # Re-render so the row's [state] tag updates.
-            try:
+            # Re-render so the row's [state] tag updates. Skip if unmounting
+            # — on_unmount cancels these tasks but a late event may sneak in.
+            # Avoid a bare `except Exception` which would silently mask real
+            # bugs in _rerender / _row_text.
+            if self.is_mounted:
                 self._rerender()
-            except Exception:
-                # Screen may be unmounting — swallow late events.
-                return

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -109,8 +109,10 @@ class HostsScreen(Screen[None]):
         self.app.push_screen(AddHostModal(), self._on_host_added)
 
     def action_drill(self) -> None:
-        # Task 12 wires the host-models screen push.
-        pass
+        from hermia.tui.screens.host_models import HostModelsScreen
+        hosts = self.app_config.hosts
+        if 0 <= self.cursor_idx < len(hosts):
+            self.app.push_screen(HostModelsScreen(host=hosts[self.cursor_idx]))
 
     def _on_host_added(self, host: Host | None) -> None:
         if host is None:

--- a/src/hermia/tui/screens/launch.py
+++ b/src/hermia/tui/screens/launch.py
@@ -1,0 +1,72 @@
+"""Launch screen — three entries: Load existing fleet / New fleet / Quick local run.
+
+Quick local run pre-fills a single-host config (http://localhost:11434) and
+jumps to the Fleet Config screen on that host. New fleet opens an empty
+Fleet Config. Load enters a sub-mode listing fleets/*.yaml and loads the
+selected one on enter.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+
+@dataclass
+class LaunchEntry:
+    id: str
+    label: str
+
+
+class LaunchScreen(Screen[None]):
+    BINDINGS = [
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "select", "Select", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entries: list[LaunchEntry] = [
+            LaunchEntry(id="load", label="Load existing fleet"),
+            LaunchEntry(id="new", label="New fleet"),
+            LaunchEntry(id="quick", label="Quick local run"),
+        ]
+        self.cursor_index: int = 0
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static("Welcome to hermia fleet", id="launch-title")
+            for entry in self.entries:
+                yield Static(self._row_text(entry), id=f"launch-{entry.id}")
+
+    def _row_text(self, entry: LaunchEntry) -> str:
+        cursor = "▸ " if entry == self.entries[self.cursor_index] else "  "
+        return f"  {cursor}{entry.label}"
+
+    def _refresh_rows(self) -> None:
+        for entry in self.entries:
+            self.query_one(f"#launch-{entry.id}", Static).update(self._row_text(entry))
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_index > 0:
+            self.cursor_index -= 1
+            self._refresh_rows()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_index < len(self.entries) - 1:
+            self.cursor_index += 1
+            self._refresh_rows()
+
+    def action_select(self) -> None:
+        # Subsequent tasks fill in each branch. For Task 5, no-op.
+        entry = self.entries[self.cursor_index]
+        _ = entry  # noqa: F841
+
+    def action_quit(self) -> None:
+        self.app.exit()

--- a/src/hermia/tui/screens/launch.py
+++ b/src/hermia/tui/screens/launch.py
@@ -84,7 +84,9 @@ class LaunchScreen(Screen[None]):
 
     def _scan_fleets(self) -> list[LaunchEntry]:
         fleets_dir = Path("fleets")
-        if not fleets_dir.exists():
+        # `is_dir()` over `exists()` — defensive against a regular file named
+        # `fleets` shadowing the expected directory.
+        if not fleets_dir.is_dir():
             return []
         return [LaunchEntry(id=f.stem, label=f.stem) for f in sorted(fleets_dir.glob("*.yaml"))]
 
@@ -137,7 +139,14 @@ class LaunchScreen(Screen[None]):
         from hermia.tui.screens.config import FleetConfigScreen
         entry = self.entries[self.cursor_index]
         path = fleet_path(entry.id)
-        self.app.config = load_fleet(path)  # type: ignore[attr-defined]
+        # load_fleet can raise FileNotFoundError, yaml.YAMLError, KeyError,
+        # TypeError on malformed YAML or missing fields. Notify rather than
+        # crash the TUI — user stays on the Launch screen and can pick again.
+        try:
+            self.app.config = load_fleet(path)  # type: ignore[attr-defined]
+        except Exception as exc:
+            self.app.notify(f"Failed to load fleet '{entry.id}': {exc}", severity="error")
+            return
         self.app.push_screen(FleetConfigScreen())
 
     def _enter_new_fleet(self) -> None:

--- a/src/hermia/tui/screens/launch.py
+++ b/src/hermia/tui/screens/launch.py
@@ -1,19 +1,24 @@
 """Launch screen — three entries: Load existing fleet / New fleet / Quick local run.
 
-Quick local run pre-fills a single-host config (http://localhost:11434) and
-jumps to the Fleet Config screen on that host. New fleet opens an empty
-Fleet Config. Load enters a sub-mode listing fleets/*.yaml and loads the
-selected one on enter.
+Load existing scans fleets/*.yaml and lists them; enter on a fleet loads it
+into app.config and pushes FleetConfigScreen.
+New fleet resets app.config to an empty FleetConfig(name="") and pushes
+FleetConfigScreen.
+Quick local run pre-fills app.config with localhost:11434 (engine=ollama)
+and the default test set (all TEST_IDS), then pushes FleetConfigScreen.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Static
+
+from hermia.tui.state import FleetConfig, Host
 
 
 @dataclass
@@ -27,46 +32,125 @@ class LaunchScreen(Screen[None]):
         Binding("up", "cursor_prev", "Up", show=False),
         Binding("down", "cursor_next", "Down", show=False),
         Binding("enter", "select", "Select", show=True),
+        Binding("escape", "back_to_home", "Back", show=False),
         Binding("q", "quit", "Quit", show=True),
+    ]
+
+    HOME_ENTRIES: list[LaunchEntry] = [
+        LaunchEntry(id="load", label="Load existing fleet"),
+        LaunchEntry(id="new", label="New fleet"),
+        LaunchEntry(id="quick", label="Quick local run"),
     ]
 
     def __init__(self) -> None:
         super().__init__()
-        self.entries: list[LaunchEntry] = [
-            LaunchEntry(id="load", label="Load existing fleet"),
-            LaunchEntry(id="new", label="New fleet"),
-            LaunchEntry(id="quick", label="Quick local run"),
-        ]
+        self.mode: str = "home"  # "home" or "load"
+        self.entries: list[LaunchEntry] = list(self.HOME_ENTRIES)
         self.cursor_index: int = 0
+        # Render counter — appended to dynamic IDs so a pending AwaitRemove
+        # from the previous render doesn't clash with the new mount.
+        self._render_seq: int = 0
 
     def compose(self) -> ComposeResult:
-        with Vertical():
+        with Vertical(id="launch-root"):
             yield Static("Welcome to hermia fleet", id="launch-title")
-            for entry in self.entries:
-                yield Static(self._row_text(entry), id=f"launch-{entry.id}")
 
-    def _row_text(self, entry: LaunchEntry) -> str:
-        cursor = "▸ " if entry == self.entries[self.cursor_index] else "  "
+    def on_mount(self) -> None:
+        self._rerender()
+
+    def _row_text(self, entry: LaunchEntry, idx: int) -> str:
+        cursor = "▸ " if idx == self.cursor_index else "  "
         return f"  {cursor}{entry.label}"
 
-    def _refresh_rows(self) -> None:
-        for entry in self.entries:
-            self.query_one(f"#launch-{entry.id}", Static).update(self._row_text(entry))
+    def _rerender(self) -> None:
+        root = self.query_one("#launch-root", Vertical)
+        # Update title in place rather than re-mounting.
+        title = root.query_one("#launch-title", Static)
+        title.update("Welcome to hermia fleet" if self.mode == "home" else "Load fleet")
+        # Remove old dynamic children (everything except the title).
+        for child in list(root.children):
+            if child.id == "launch-title":
+                continue
+            child.remove()
+        # Mount fresh dynamic children with seq-bumped IDs so any AwaitRemove
+        # in flight from the previous _rerender can't collide.
+        self._render_seq += 1
+        seq = self._render_seq
+        if not self.entries:
+            root.mount(Static("No saved fleets in fleets/", id="launch-empty-notice"))
+            return
+        for i, entry in enumerate(self.entries):
+            root.mount(Static(self._row_text(entry, i), id=f"launch-row-{seq}-{i}"))
+
+    def _scan_fleets(self) -> list[LaunchEntry]:
+        fleets_dir = Path("fleets")
+        if not fleets_dir.exists():
+            return []
+        return [LaunchEntry(id=f.stem, label=f.stem) for f in sorted(fleets_dir.glob("*.yaml"))]
+
+    # ── Navigation ────────────────────────────────────────────────────────
 
     def action_cursor_prev(self) -> None:
         if self.cursor_index > 0:
             self.cursor_index -= 1
-            self._refresh_rows()
+            self._rerender()
 
     def action_cursor_next(self) -> None:
         if self.cursor_index < len(self.entries) - 1:
             self.cursor_index += 1
-            self._refresh_rows()
+            self._rerender()
 
     def action_select(self) -> None:
-        # Subsequent tasks fill in each branch. For Task 5, no-op.
-        entry = self.entries[self.cursor_index]
-        _ = entry  # noqa: F841
+        if self.mode == "home":
+            entry = self.entries[self.cursor_index]
+            if entry.id == "load":
+                self._enter_load_mode()
+            elif entry.id == "new":
+                self._enter_new_fleet()
+            elif entry.id == "quick":
+                self._enter_quick_local()
+        elif self.mode == "load":
+            self._load_selected_fleet()
+
+    def action_back_to_home(self) -> None:
+        if self.mode == "load":
+            self.mode = "home"
+            self.entries = list(self.HOME_ENTRIES)
+            self.cursor_index = 0
+            self._rerender()
 
     def action_quit(self) -> None:
         self.app.exit()
+
+    # ── Mode transitions ──────────────────────────────────────────────────
+
+    def _enter_load_mode(self) -> None:
+        self.mode = "load"
+        self.entries = self._scan_fleets()
+        self.cursor_index = 0 if self.entries else -1
+        self._rerender()
+
+    def _load_selected_fleet(self) -> None:
+        if self.cursor_index < 0:
+            return
+        from hermia.tui.fleet_io import fleet_path, load_fleet
+        from hermia.tui.screens.config import FleetConfigScreen
+        entry = self.entries[self.cursor_index]
+        path = fleet_path(entry.id)
+        self.app.config = load_fleet(path)  # type: ignore[attr-defined]
+        self.app.push_screen(FleetConfigScreen())
+
+    def _enter_new_fleet(self) -> None:
+        from hermia.tui.screens.config import FleetConfigScreen
+        self.app.config = FleetConfig(name="")  # type: ignore[attr-defined]
+        self.app.push_screen(FleetConfigScreen())
+
+    def _enter_quick_local(self) -> None:
+        from hermia.schemas import TEST_IDS
+        from hermia.tui.screens.config import FleetConfigScreen
+        self.app.config = FleetConfig(  # type: ignore[attr-defined]
+            name="quick-local",
+            hosts=[Host(name="local", url="http://localhost:11434", engine="ollama")],
+            tests=list(TEST_IDS),
+        )
+        self.app.push_screen(FleetConfigScreen())

--- a/src/hermia/tui/screens/modals.py
+++ b/src/hermia/tui/screens/modals.py
@@ -93,8 +93,14 @@ class AddHostModal(ModalScreen[Host | None]):
         name = self.query_one("#addhost-name", Input).value.strip()
         url = self.query_one("#addhost-url", Input).value.strip()
         engine = self.query_one("#addhost-engine", Input).value.strip() or "ollama"
-        if not name or not url:
-            return  # silently no-op; user can fix and resubmit
+        # If a required field is empty, refocus it instead of silently
+        # ignoring submission (user otherwise wonders why nothing happened).
+        if not name:
+            self.query_one("#addhost-name", Input).focus()
+            return
+        if not url:
+            self.query_one("#addhost-url", Input).focus()
+            return
         self.dismiss(Host(name=name, url=url, engine=engine))
 
     def action_cancel(self) -> None:

--- a/src/hermia/tui/screens/modals.py
+++ b/src/hermia/tui/screens/modals.py
@@ -79,7 +79,15 @@ class AddHostModal(ModalScreen[Host | None]):
         self.query_one("#addhost-name", Input).focus()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        # Submit when the engine field is finished — it's the last in the form.
+        # Enter on name → url; on url → engine; on engine → submit form.
+        # Without this, Enter on the first two fields does nothing, which is
+        # counter-intuitive.
+        if event.input.id == "addhost-name":
+            self.query_one("#addhost-url", Input).focus()
+            return
+        if event.input.id == "addhost-url":
+            self.query_one("#addhost-engine", Input).focus()
+            return
         if event.input.id != "addhost-engine":
             return
         name = self.query_one("#addhost-name", Input).value.strip()

--- a/src/hermia/tui/screens/modals.py
+++ b/src/hermia/tui/screens/modals.py
@@ -1,0 +1,93 @@
+"""Modal dialogs used by picker screens.
+
+FleetNameModal      — prompt for a fleet name when saving an unnamed fleet (Task 9).
+AddHostModal        — add a new Host to the fleet (Task 10).
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, Label
+
+from hermia.tui.state import Host
+
+
+class FleetNameModal(ModalScreen[str | None]):
+    """Prompt for a fleet name. Returns the entered name, or None on cancel."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    DEFAULT_CSS = """
+    FleetNameModal {
+        align: center middle;
+    }
+    FleetNameModal Vertical {
+        width: 50;
+        height: auto;
+        background: $surface;
+        border: round $accent;
+        padding: 1 2;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Fleet name:")
+            yield Input(placeholder="kwaainet-baseline", id="modal-fleet-name")
+
+    def on_mount(self) -> None:
+        self.query_one(Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self.dismiss(event.value.strip() or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class AddHostModal(ModalScreen[Host | None]):
+    """Add a new Host to the fleet. Returns the new Host or None on cancel."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    DEFAULT_CSS = """
+    AddHostModal {
+        align: center middle;
+    }
+    AddHostModal Vertical {
+        width: 60;
+        height: auto;
+        background: $surface;
+        border: round $accent;
+        padding: 1 2;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Add host:")
+            yield Input(placeholder="name (eric-5090)", id="addhost-name")
+            yield Input(placeholder="url (http://eric:11434)", id="addhost-url")
+            yield Input(
+                placeholder="engine (ollama / openai-compat) — defaults to ollama",
+                id="addhost-engine",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#addhost-name", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Submit when the engine field is finished — it's the last in the form.
+        if event.input.id != "addhost-engine":
+            return
+        name = self.query_one("#addhost-name", Input).value.strip()
+        url = self.query_one("#addhost-url", Input).value.strip()
+        engine = self.query_one("#addhost-engine", Input).value.strip() or "ollama"
+        if not name or not url:
+            return  # silently no-op; user can fix and resubmit
+        self.dismiss(Host(name=name, url=url, engine=engine))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -1,0 +1,147 @@
+"""Fleet-scoped test picker with framework filter axis.
+
+Mounts a DrillableList of all TEST_IDS plus a FilterAxis for OWASP / ATLAS
+/ MAESTRO / NIST and a SearchBar. Selections write to app.config.tests so
+the FleetConfigScreen's run-plan trial count updates on pop-back.
+"""
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+
+from hermia.tui.test_catalog import FRAMEWORKS, load_test_catalog
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+from hermia.tui.widgets.drillable_list import DrillableList, ListRow
+from hermia.tui.widgets.filter_axis import FilterAxis
+from hermia.tui.widgets.search_bar import SearchBar
+
+
+class TestsScreen(Screen[None]):
+    # Tell pytest not to collect this class — name starts with "Test" but
+    # it's a Screen, not a test class.
+    __test__ = False
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("space", "toggle", "Toggle", show=True),
+        Binding("a", "select_all", "All", show=True),
+        Binding("n", "select_none", "None", show=True),
+        Binding("slash", "search_open", "Search", show=False),
+        Binding("tab", "next_axis", "Filter axis", show=False),
+        Binding("right", "next_value", "Next value", show=False),
+        Binding("left", "prev_value", "Prev value", show=False),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._catalog = load_test_catalog()
+        self._query: str = ""
+        self._framework_filter: str = "All"
+
+    @property
+    def visible_test_ids(self) -> list[str]:
+        dl = self.query_one(DrillableList)
+        return [r.id_ for r in dl.visible_rows]
+
+    def compose(self) -> ComposeResult:
+        name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
+        with Vertical():
+            yield Breadcrumb(["hermia", "fleet", name, "tests"])
+            yield FilterAxis({"framework": FRAMEWORKS})
+            rows = [ListRow(id_=r.id, label=r.id) for r in self._catalog]
+            yield DrillableList(rows)
+            yield SearchBar()
+
+    def on_mount(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Mirror app.config.tests as the initial selection.
+        for tid in self.app.config.tests:  # type: ignore[attr-defined]
+            dl._selected.add(tid)
+        dl._refresh()
+
+    # ── Filter combiner ────────────────────────────────────────────────────
+
+    def apply_query(self, q: str) -> None:
+        """Public hook so tests can drive query without typing keystrokes."""
+        self._query = q.strip().lower()
+        self._reapply()
+
+    def _reapply(self) -> None:
+        dl = self.query_one(DrillableList)
+        # Combine substring + framework membership.
+        rows: list[ListRow] = []
+        for rec in self._catalog:
+            if self._query and self._query not in rec.id.lower():
+                continue
+            if self._framework_filter != "All" and not rec.is_in_framework(self._framework_filter):
+                continue
+            rows.append(ListRow(id_=rec.id, label=rec.id))
+        dl._all_rows = rows
+        dl.visible_rows = rows
+        dl._cursor_idx = 0 if rows else -1
+        dl._refresh()
+
+    # ── Event handlers ────────────────────────────────────────────────────
+
+    def on_search_bar_query_changed(self, event: SearchBar.QueryChanged) -> None:
+        self.apply_query(event.query)
+
+    def on_filter_axis_changed(self, event: FilterAxis.Changed) -> None:
+        self._framework_filter = event.value or "All"
+        self._reapply()
+
+    def on_drillable_list_toggled(self, event: DrillableList.Toggled) -> None:
+        cfg_tests = list(self.app.config.tests)  # type: ignore[attr-defined]
+        if event.row_id in cfg_tests:
+            cfg_tests.remove(event.row_id)
+        else:
+            cfg_tests.append(event.row_id)
+        self.app.config.tests = cfg_tests  # type: ignore[attr-defined]
+
+    def on_drillable_list_selection_changed(
+        self, event: DrillableList.SelectionChanged
+    ) -> None:
+        # Bulk select_all / select_none from the widget — sync to app.config.tests.
+        # Preserve any selections for tests not currently visible (filter-respecting).
+        dl = self.query_one(DrillableList)
+        visible_ids = {r.id_ for r in dl.visible_rows}
+        cfg_tests = [t for t in self.app.config.tests  # type: ignore[attr-defined]
+                     if t not in visible_ids]
+        cfg_tests.extend(event.selected_ids)
+        self.app.config.tests = sorted(set(cfg_tests))  # type: ignore[attr-defined]
+
+    # ── Action wrappers ───────────────────────────────────────────────────
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_cursor_prev(self) -> None:
+        self.query_one(DrillableList).cursor_prev()
+
+    def action_cursor_next(self) -> None:
+        self.query_one(DrillableList).cursor_next()
+
+    def action_toggle(self) -> None:
+        self.query_one(DrillableList).toggle()
+
+    def action_select_all(self) -> None:
+        self.query_one(DrillableList).select_all()
+
+    def action_select_none(self) -> None:
+        self.query_one(DrillableList).select_none()
+
+    def action_search_open(self) -> None:
+        self.query_one(SearchBar).open()
+
+    def action_next_axis(self) -> None:
+        self.query_one(FilterAxis).next_axis()
+
+    def action_next_value(self) -> None:
+        self.query_one(FilterAxis).next_value()
+
+    def action_prev_value(self) -> None:
+        self.query_one(FilterAxis).prev_value()

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -27,7 +27,7 @@ class TestsScreen(Screen[None]):
         Binding("escape", "back", "Back", show=True),
         Binding("up", "cursor_prev", "Up", show=False),
         Binding("down", "cursor_next", "Down", show=False),
-        Binding("space", "toggle", "Toggle", show=True),
+        Binding("space", "toggle_test", "Toggle", show=True),
         Binding("a", "select_all", "All", show=True),
         Binding("n", "select_none", "None", show=True),
         Binding("slash", "search_open", "Search", show=False),
@@ -125,7 +125,7 @@ class TestsScreen(Screen[None]):
     def action_cursor_next(self) -> None:
         self.query_one(DrillableList).cursor_next()
 
-    def action_toggle(self) -> None:
+    def action_toggle_test(self) -> None:
         self.query_one(DrillableList).toggle()
 
     def action_select_all(self) -> None:

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -58,11 +58,10 @@ class TestsScreen(Screen[None]):
             yield SearchBar()
 
     def on_mount(self) -> None:
-        dl = self.query_one(DrillableList)
-        # Mirror app.config.tests as the initial selection.
-        for tid in self.app.config.tests:  # type: ignore[attr-defined]
-            dl._selected.add(tid)
-        dl._refresh()
+        # Mirror app.config.tests into the widget via its public API.
+        self.query_one(DrillableList).set_selected_ids(
+            list(self.app.config.tests),  # type: ignore[attr-defined]
+        )
 
     # ── Filter combiner ────────────────────────────────────────────────────
 

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -11,6 +11,7 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
 
+from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.test_catalog import FRAMEWORKS, load_test_catalog
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 from hermia.tui.widgets.drillable_list import DrillableList, ListRow
@@ -101,6 +102,7 @@ class TestsScreen(Screen[None]):
         else:
             cfg_tests.append(event.row_id)
         self.app.config.tests = cfg_tests  # type: ignore[attr-defined]
+        _mark_dirty_in_stack(self.app)
 
     def on_drillable_list_selection_changed(
         self, event: DrillableList.SelectionChanged
@@ -113,6 +115,7 @@ class TestsScreen(Screen[None]):
                      if t not in visible_ids]
         cfg_tests.extend(event.selected_ids)
         self.app.config.tests = sorted(set(cfg_tests))  # type: ignore[attr-defined]
+        _mark_dirty_in_stack(self.app)
 
     # ── Action wrappers ───────────────────────────────────────────────────
 

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -71,8 +71,8 @@ class TestsScreen(Screen[None]):
         self._reapply()
 
     def _reapply(self) -> None:
-        dl = self.query_one(DrillableList)
-        # Combine substring + framework membership.
+        # Combine substring + framework membership; DrillableList's own
+        # apply_query only handles substring, so we own the combined filter.
         rows: list[ListRow] = []
         for rec in self._catalog:
             if self._query and self._query not in rec.id.lower():
@@ -80,10 +80,9 @@ class TestsScreen(Screen[None]):
             if self._framework_filter != "All" and not rec.is_in_framework(self._framework_filter):
                 continue
             rows.append(ListRow(id_=rec.id, label=rec.id))
-        dl._all_rows = rows
-        dl.visible_rows = rows
-        dl._cursor_idx = 0 if rows else -1
-        dl._refresh()
+        # set_rows is the public API for this — replaces the older private
+        # `_all_rows = ...; visible_rows = ...; _refresh()` poke.
+        self.query_one(DrillableList).set_rows(rows)
 
     # ── Event handlers ────────────────────────────────────────────────────
 

--- a/src/hermia/tui/test_catalog.py
+++ b/src/hermia/tui/test_catalog.py
@@ -1,0 +1,62 @@
+"""Test catalog — pairs each schemas.TEST_IDS entry with its framework tags.
+
+Source of truth:
+    - schemas.TEST_IDS               — canonical ordered list of test IDs
+    - test-datasets/agentic-tasks.json[agentic_test_cases][*].frameworks
+      → dict with keys: owasp_llm_top10, mitre_atlas, csa_maestro, nist_ai_rmf
+      → non-empty list = test belongs to that framework
+
+The Tests drill uses TestRecord.is_in_framework() for the filter axis.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermia.schemas import TEST_IDS
+
+FRAMEWORKS: list[str] = ["OWASP", "ATLAS", "MAESTRO", "NIST"]
+
+_TASKS_JSON = Path(__file__).resolve().parent.parent / "test-datasets" / "agentic-tasks.json"
+
+_FRAMEWORK_KEY_MAP: dict[str, str] = {
+    "OWASP": "owasp_llm_top10",
+    "ATLAS": "mitre_atlas",
+    "MAESTRO": "csa_maestro",
+    "NIST": "nist_ai_rmf",
+}
+
+
+@dataclass
+class TestRecord:
+    # Tell pytest not to collect this class — name starts with "Test" but
+    # it's a data record, not a test class.
+    __test__ = False
+
+    id: str
+    frameworks: dict[str, bool]
+
+    def is_in_framework(self, framework: str) -> bool:
+        return self.frameworks.get(framework, False)
+
+
+def load_test_catalog() -> list[TestRecord]:
+    """Build a list of TestRecord — one per id in schemas.TEST_IDS.
+
+    Tests missing from agentic-tasks.json get a record with all framework
+    memberships False (their ID is still in the catalog so they appear in
+    the picker).
+    """
+    by_id: dict[str, dict[str, bool]] = {
+        tid: {f: False for f in FRAMEWORKS} for tid in TEST_IDS
+    }
+    raw = json.loads(_TASKS_JSON.read_text())
+    for case in raw.get("agentic_test_cases", []):
+        cid = case.get("id")
+        if cid not in by_id:
+            continue
+        f = case.get("frameworks", {}) or {}
+        for label, key in _FRAMEWORK_KEY_MAP.items():
+            by_id[cid][label] = bool(f.get(key))
+    return [TestRecord(id=tid, frameworks=by_id[tid]) for tid in TEST_IDS]

--- a/src/hermia/tui/test_catalog.py
+++ b/src/hermia/tui/test_catalog.py
@@ -60,7 +60,13 @@ def load_test_catalog() -> list[TestRecord]:
     by_id: dict[str, dict[str, bool]] = {
         tid: {f: False for f in FRAMEWORKS} for tid in TEST_IDS
     }
-    raw = json.loads(_TASKS_JSON.read_text())
+    # If the dataset file is missing (packaging glitch) or unreadable, fall
+    # back to all-False framework memberships — the TUI stays functional;
+    # tests just appear without framework tags.
+    try:
+        raw = json.loads(_TASKS_JSON.read_text())
+    except (OSError, json.JSONDecodeError):
+        raw = {}
     for case in raw.get("agentic_test_cases", []):
         cid = case.get("id")
         if cid not in by_id:

--- a/src/hermia/tui/test_catalog.py
+++ b/src/hermia/tui/test_catalog.py
@@ -41,13 +41,22 @@ class TestRecord:
         return self.frameworks.get(framework, False)
 
 
+_cached_catalog: list[TestRecord] | None = None
+
+
 def load_test_catalog() -> list[TestRecord]:
     """Build a list of TestRecord — one per id in schemas.TEST_IDS.
 
     Tests missing from agentic-tasks.json get a record with all framework
     memberships False (their ID is still in the catalog so they appear in
     the picker).
+
+    Cached after first call — the catalog is static and re-reading the
+    JSON file on every TestsScreen mount blocks the Textual main thread.
     """
+    global _cached_catalog
+    if _cached_catalog is not None:
+        return _cached_catalog
     by_id: dict[str, dict[str, bool]] = {
         tid: {f: False for f in FRAMEWORKS} for tid in TEST_IDS
     }
@@ -59,4 +68,5 @@ def load_test_catalog() -> list[TestRecord]:
         f = case.get("frameworks", {}) or {}
         for label, key in _FRAMEWORK_KEY_MAP.items():
             by_id[cid][label] = bool(f.get(key))
-    return [TestRecord(id=tid, frameworks=by_id[tid]) for tid in TEST_IDS]
+    _cached_catalog = [TestRecord(id=tid, frameworks=by_id[tid]) for tid in TEST_IDS]
+    return _cached_catalog

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -46,15 +46,25 @@ class _BaseProbeTransport:
     auth_header: str | None = None
 
     def _fetch_sync(self, path: str) -> dict[str, Any]:
-        # noqa-justified: the URL is built from a user-supplied host config
-        # (validated as http:// or https://); we are not opening arbitrary
-        # schemes like file://.
-        req = urllib.request.Request(f"{self.url.rstrip('/')}{path}")  # noqa: S310
+        # The S310/B310 suppressions below are justified: the URL is built
+        # from a user-supplied host config (http:// or https://); we are not
+        # opening arbitrary schemes like file://.
+        url = f"{self.url.rstrip('/')}{path}"
+        req = urllib.request.Request(url)  # noqa: S310
         if self.auth_header:
             req.add_header("Authorization", self.auth_header)
         try:
-            with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
-                data: dict[str, Any] = json.loads(resp.read())
+            with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310  # nosec B310
+                try:
+                    data: dict[str, Any] = json.loads(resp.read())
+                except json.JSONDecodeError as exc:
+                    # Non-JSON body (HTML error page from a misbehaving proxy,
+                    # truncated response, etc). Convert to URLError so probe.py's
+                    # (OSError, ConnectionError) handler treats it as offline
+                    # rather than letting it bubble as `unexpected`.
+                    raise urllib.error.URLError(
+                        f"Invalid JSON response from {self.url}"
+                    ) from exc
                 return data
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403):

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -45,6 +46,12 @@ from hermia.tui.state import Host
 # /api/tags (typical responses are <10 KiB).
 _MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
+# Anchored scheme match — only treats `^scheme://` as a real scheme.
+# A URL like `localhost:11434/proxy?upstream=http://other` has `://` in
+# the path but no leading scheme; this regex correctly says "no scheme",
+# so http:// gets prepended.
+_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.\-]*://", re.IGNORECASE)
+
 
 @dataclass
 class _BaseProbeTransport:
@@ -53,10 +60,12 @@ class _BaseProbeTransport:
 
     def _fetch_sync(self, path: str) -> dict[str, Any]:
         # User-friendly normalization: a bare `localhost:11434` (no scheme)
-        # is treated as http://. Detect via `://` presence — urlparse on a
-        # bare `host:port` mis-interprets `host` as the scheme.
+        # is treated as http://. The anchored regex correctly handles edge
+        # cases (e.g., `localhost:11434/proxy?upstream=http://other` has
+        # `://` in the path but no leading scheme — regex says "no scheme",
+        # so http:// gets prepended).
         raw_url = self.url
-        if "://" not in raw_url:
+        if not _SCHEME_RE.match(raw_url):
             raw_url = f"http://{raw_url}"
         # SSRF guard: urlopen supports `file://`, `ftp://`, etc. If a user
         # accidentally (or maliciously) sets host.url to file:///etc/passwd

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -33,11 +33,17 @@ import asyncio
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
 
 from hermia.tui.state import Host
+
+# Cap urlopen.read() so a misbehaving (or malicious) host cannot stream an
+# unbounded body and OOM the TUI. 10 MiB is generous for /v1/models or
+# /api/tags (typical responses are <10 KiB).
+_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
 
 @dataclass
@@ -46,9 +52,17 @@ class _BaseProbeTransport:
     auth_header: str | None = None
 
     def _fetch_sync(self, path: str) -> dict[str, Any]:
-        # The S310/B310 suppressions below are justified: the URL is built
-        # from a user-supplied host config (http:// or https://); we are not
-        # opening arbitrary schemes like file://.
+        # SSRF guard: urlopen supports `file://`, `ftp://`, etc. If a user
+        # accidentally (or maliciously) sets host.url to file:///etc/passwd
+        # we'd happily read it. Force http(s) only.
+        parsed = urllib.parse.urlparse(self.url)
+        if parsed.scheme not in ("http", "https"):
+            raise urllib.error.URLError(
+                f"Unsupported protocol scheme: {parsed.scheme!r} (only http/https allowed)"
+            )
+        # The S310/B310 suppressions below are justified: the URL scheme has
+        # been validated above as http(s); we are not opening arbitrary
+        # schemes like file://.
         url = f"{self.url.rstrip('/')}{path}"
         req = urllib.request.Request(url)  # noqa: S310
         if self.auth_header:
@@ -56,7 +70,10 @@ class _BaseProbeTransport:
         try:
             with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310  # nosec B310
                 try:
-                    data: dict[str, Any] = json.loads(resp.read())
+                    # Cap the read to _MAX_RESPONSE_BYTES — a malicious or
+                    # misbehaving host cannot OOM the TUI by streaming an
+                    # unbounded body.
+                    data: dict[str, Any] = json.loads(resp.read(_MAX_RESPONSE_BYTES))
                 except json.JSONDecodeError as exc:
                     # Non-JSON body (HTML error page from a misbehaving proxy,
                     # truncated response, etc). Convert to URLError so probe.py's

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -1,0 +1,81 @@
+"""Engine-aware transport factory for the Fleet TUI probe layer.
+
+Maps a Host to a transport object with `async list_models() -> list[str]`,
+which is what hermia.tui.probe.probe_host needs.
+
+For v0.2 we ship two probe shapes:
+    - Ollama         /api/tags     → list of {"name": str, ...}
+    - OpenAI-compat  /v1/models    → {"data": [{"id": str, ...}, ...]}
+
+vLLM / SGLang / LiteLLM all speak the OpenAI shape, so any non-"ollama"
+engine falls back to the openai-compat path.
+
+Implementation: uses stdlib `urllib.request` wrapped in `asyncio.to_thread`
+rather than `httpx`. `httpx` is NOT in pyproject.toml and AGENTS.md rule 3
+blocks adding deps without approval. urllib is stdlib; the thread offload
+keeps probe_host's async contract intact.
+
+Per spec §6 / probe.py docstring, this adapter normalizes transport
+exceptions to the stdlib classes probe.py catches:
+    - HTTP 401/403            → PermissionError
+    - timeout / network error → urllib.error.URLError (an OSError subclass)
+                                propagates and is caught by probe.py's
+                                (OSError, ConnectionError) handler.
+    - asyncio.wait_for timeout → TimeoutError (probe.py handles)
+
+Auth header is resolved from the environment variable named by
+host.auth_header_env. Per AGENTS.md rule 11, the secret value never appears
+in any saved config — only the env var name does.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from hermia.tui.state import Host
+
+
+@dataclass
+class _BaseProbeTransport:
+    url: str
+    auth_header: str | None = None
+
+    def _fetch_sync(self, path: str) -> dict[str, Any]:
+        req = urllib.request.Request(f"{self.url.rstrip('/')}{path}")
+        if self.auth_header:
+            req.add_header("Authorization", self.auth_header)
+        try:
+            with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise PermissionError(f"{exc.code} from {self.url}") from exc
+            raise
+
+
+class OllamaProbeTransport(_BaseProbeTransport):
+    async def list_models(self) -> list[str]:
+        data = await asyncio.to_thread(self._fetch_sync, "/api/tags")
+        return [m["name"] for m in data.get("models", [])]
+
+
+class OpenAICompatProbeTransport(_BaseProbeTransport):
+    async def list_models(self) -> list[str]:
+        data = await asyncio.to_thread(self._fetch_sync, "/v1/models")
+        return [m["id"] for m in data.get("data", [])]
+
+
+def transport_for(host: Host) -> _BaseProbeTransport:
+    """Return a probe transport for this host's engine + auth setup."""
+    auth_header: str | None = None
+    if host.auth_header_env:
+        token = os.environ.get(host.auth_header_env)
+        if token:
+            auth_header = f"Bearer {token}"
+    cls = OllamaProbeTransport if host.engine == "ollama" else OpenAICompatProbeTransport
+    return cls(url=host.url, auth_header=auth_header)

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -52,10 +52,16 @@ class _BaseProbeTransport:
     auth_header: str | None = None
 
     def _fetch_sync(self, path: str) -> dict[str, Any]:
+        # User-friendly normalization: a bare `localhost:11434` (no scheme)
+        # is treated as http://. Detect via `://` presence — urlparse on a
+        # bare `host:port` mis-interprets `host` as the scheme.
+        raw_url = self.url
+        if "://" not in raw_url:
+            raw_url = f"http://{raw_url}"
         # SSRF guard: urlopen supports `file://`, `ftp://`, etc. If a user
         # accidentally (or maliciously) sets host.url to file:///etc/passwd
         # we'd happily read it. Force http(s) only.
-        parsed = urllib.parse.urlparse(self.url)
+        parsed = urllib.parse.urlparse(raw_url)
         if parsed.scheme not in ("http", "https"):
             raise urllib.error.URLError(
                 f"Unsupported protocol scheme: {parsed.scheme!r} (only http/https allowed)"
@@ -63,7 +69,7 @@ class _BaseProbeTransport:
         # The S310/B310 suppressions below are justified: the URL scheme has
         # been validated above as http(s); we are not opening arbitrary
         # schemes like file://.
-        url = f"{self.url.rstrip('/')}{path}"
+        url = f"{raw_url.rstrip('/')}{path}"
         req = urllib.request.Request(url)  # noqa: S310
         if self.auth_header:
             req.add_header("Authorization", self.auth_header)

--- a/src/hermia/tui/transport_adapter.py
+++ b/src/hermia/tui/transport_adapter.py
@@ -46,12 +46,16 @@ class _BaseProbeTransport:
     auth_header: str | None = None
 
     def _fetch_sync(self, path: str) -> dict[str, Any]:
-        req = urllib.request.Request(f"{self.url.rstrip('/')}{path}")
+        # noqa-justified: the URL is built from a user-supplied host config
+        # (validated as http:// or https://); we are not opening arbitrary
+        # schemes like file://.
+        req = urllib.request.Request(f"{self.url.rstrip('/')}{path}")  # noqa: S310
         if self.auth_header:
             req.add_header("Authorization", self.auth_header)
         try:
             with urllib.request.urlopen(req, timeout=10.0) as resp:  # noqa: S310
-                return json.loads(resp.read())
+                data: dict[str, Any] = json.loads(resp.read())
+                return data
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403):
                 raise PermissionError(f"{exc.code} from {self.url}") from exc

--- a/src/hermia/tui/widgets/__init__.py
+++ b/src/hermia/tui/widgets/__init__.py
@@ -1,4 +1,5 @@
 """Reusable, domain-agnostic Textual widgets for the Fleet TUI."""
+from hermia.tui.widgets.breadcrumb import Breadcrumb
 from hermia.tui.widgets.drillable_list import DrillableList, ListRow
 from hermia.tui.widgets.filter_axis import FilterAxis
 from hermia.tui.widgets.progress_bar import AggregateProgressBar, MiniProgressBar
@@ -13,6 +14,7 @@ from hermia.tui.widgets.status_badge import (
 
 __all__ = [
     "AggregateProgressBar",
+    "Breadcrumb",
     "Direction",
     "DrillableList",
     "FilterAxis",

--- a/src/hermia/tui/widgets/breadcrumb.py
+++ b/src/hermia/tui/widgets/breadcrumb.py
@@ -1,0 +1,50 @@
+"""Breadcrumb — segmented drill-path header.
+
+`hermia ▸ fleet ▸ kwaainet-baseline ▸ hosts ▸ marcus`
+
+Each segment is clickable (mouse) and the host screen can call jump_to(i)
+to handle keyboard jumps. The widget emits Breadcrumb.Jumped(index) which
+the screen translates into pop_screen() calls per drill depth.
+"""
+from __future__ import annotations
+
+from textual.message import Message
+from textual.widgets import Static
+
+SEPARATOR = " ▸ "
+
+
+class Breadcrumb(Static):
+    """Inline segmented drill-path header."""
+
+    DEFAULT_CSS = """
+    Breadcrumb {
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    """
+
+    class Jumped(Message):
+        def __init__(self, index: int) -> None:
+            self.index = index
+            super().__init__()
+
+    def __init__(self, segments: list[str]) -> None:
+        self._segments = list(segments)
+        self._text = SEPARATOR.join(self._segments)
+        super().__init__(self._text)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def set_segments(self, segments: list[str]) -> None:
+        self._segments = list(segments)
+        self._text = SEPARATOR.join(self._segments)
+        self.update(self._text)
+
+    def jump_to(self, index: int) -> None:
+        """Programmatic jump — used by screen-level handlers."""
+        if 0 <= index < len(self._segments):
+            self.post_message(self.Jumped(index))

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -93,6 +93,17 @@ class DrillableList(VerticalScroll):
     def selected_ids(self) -> list[str]:
         return sorted(self._selected)
 
+    def set_selected_ids(self, row_ids: list[str]) -> None:
+        """Replace the selection set. Use to mirror the host screen's domain
+        model into the widget (e.g., re-opening a screen with pre-selected
+        models / tests).
+
+        Does NOT emit SelectionChanged — the screen is the source of truth
+        for the new state; re-emitting would loop on the screen's handler.
+        """
+        self._selected = set(row_ids)
+        self._refresh()
+
     def apply_query(self, query: str) -> None:
         self._query = query.strip().lower()
         if not self._query:

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -63,6 +63,16 @@ class DrillableList(VerticalScroll):
             self.row_id = row_id
             super().__init__()
 
+    class SelectionChanged(Message):
+        """Emitted after bulk selection ops (select_all / select_none) so the
+        host screen can sync the new selection set to its domain model.
+        Single-row toggles emit Toggled (above) instead — finer-grained.
+        """
+
+        def __init__(self, selected_ids: list[str]) -> None:
+            self.selected_ids = selected_ids
+            super().__init__()
+
     def __init__(self, rows: list[ListRow]) -> None:
         super().__init__()
         self._all_rows: list[ListRow] = list(rows)
@@ -176,11 +186,13 @@ class DrillableList(VerticalScroll):
         for row in self.visible_rows:
             self._selected.add(row.id_)
         self._refresh()
+        self.post_message(self.SelectionChanged(self.selected_ids()))
 
     def select_none(self) -> None:
         for row in self.visible_rows:
             self._selected.discard(row.id_)
         self._refresh()
+        self.post_message(self.SelectionChanged(self.selected_ids()))
 
     # Textual action_* wrappers route bindings to the public API.
     def action_cursor_prev(self) -> None:

--- a/src/hermia/tui/widgets/drillable_list.py
+++ b/src/hermia/tui/widgets/drillable_list.py
@@ -104,6 +104,22 @@ class DrillableList(VerticalScroll):
         self._selected = set(row_ids)
         self._refresh()
 
+    def set_rows(self, rows: list[ListRow]) -> None:
+        """Replace the underlying row list (used by screens that own a
+        combined filter — e.g. TestsScreen merges substring + framework).
+
+        Clips the cursor to the new row count; does NOT emit any message.
+        Selection set is preserved as-is — caller decides whether to also
+        call set_selected_ids().
+        """
+        self._all_rows = list(rows)
+        self.visible_rows = list(rows)
+        if not self.visible_rows:
+            self._cursor_idx = -1
+        else:
+            self._cursor_idx = min(max(self._cursor_idx, 0), len(self.visible_rows) - 1)
+        self._refresh()
+
     def apply_query(self, query: str) -> None:
         self._query = query.strip().lower()
         if not self._query:

--- a/tests/unit/tui/screens/test_config.py
+++ b/tests/unit/tui/screens/test_config.py
@@ -74,3 +74,54 @@ class TestFleetConfigSummary:
                 assert isinstance(pilot.app.screen, LaunchScreen)
 
         asyncio.run(_run())
+
+
+class TestSave:
+    def test_save_writes_fleet_file_when_name_set(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.fleet_io import fleet_path
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("s")
+                await pilot.pause()
+                assert fleet_path("smoke").exists()
+
+        asyncio.run(_run())
+
+    def test_save_clears_dirty_flag(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.mark_dirty()
+                await pilot.pause()
+                assert screen.dirty is True
+                await pilot.press("s")
+                await pilot.pause()
+                assert screen.dirty is False
+
+        asyncio.run(_run())
+
+    def test_save_with_no_name_opens_modal(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.screens.modals import FleetNameModal
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # No name set → save should push the FleetNameModal.
+                pilot.app.config.name = ""
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("s")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetNameModal)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_config.py
+++ b/tests/unit/tui/screens/test_config.py
@@ -1,0 +1,76 @@
+"""Tests for FleetConfigScreen — top-level summary + drill rows."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestFleetConfigSummary:
+    def test_renders_empty_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "0 hosts" in screen.summary_text
+                assert "0 tests" in screen.summary_text
+                assert "0 trials" in screen.run_plan_text
+
+        asyncio.run(_run())
+
+    def test_summary_with_hosts_and_tests(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = FleetConfig(
+                    name="smoke",
+                    hosts=[Host(name="h1", url="http://h1", engine="ollama",
+                                models=[ModelChoice(name="m1", selected=True),
+                                        ModelChoice(name="m2", selected=True)])],
+                    tests=["t1", "t2", "t3"],
+                )
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "1 host" in screen.summary_text
+                assert "3 tests" in screen.summary_text
+                # 2 selected models × 3 tests = 6 trials.
+                assert "6 trials" in screen.run_plan_text
+
+        asyncio.run(_run())
+
+    def test_breadcrumb_includes_fleet_name(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "smoke" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_breadcrumb_shows_unsaved_when_dirty(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.mark_dirty()
+                await pilot.pause()
+                assert "[unsaved changes]" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back_to_launch(self) -> None:
+        async def _run() -> None:
+            from hermia.tui.screens.launch import LaunchScreen
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, LaunchScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_config.py
+++ b/tests/unit/tui/screens/test_config.py
@@ -125,3 +125,47 @@ class TestSave:
                 assert isinstance(pilot.app.screen, FleetNameModal)
 
         asyncio.run(_run())
+
+
+class TestDirtyPropagation:
+    def test_test_toggle_marks_config_dirty(self) -> None:
+        from hermia.tui.screens.tests import TestsScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.name = "smoke"
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                config_screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                assert config_screen.dirty is False
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                # Toggle the first test via space — should propagate to dirty.
+                await pilot.press("space")
+                await pilot.pause()
+                assert config_screen.dirty is True
+
+        asyncio.run(_run())
+
+    def test_host_model_toggle_marks_config_dirty(self) -> None:
+        from hermia.tui.screens.host_models import HostModelsScreen
+        from hermia.tui.state import Host, ModelChoice
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = Host(
+                    name="h1", url="http://h1", engine="ollama",
+                    models=[ModelChoice(name="m1"), ModelChoice(name="m2")],
+                )
+                pilot.app.config.name = "smoke"
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                config_screen: FleetConfigScreen = pilot.app.screen  # type: ignore[assignment]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("space")
+                await pilot.pause()
+                assert config_screen.dirty is True
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_host_models.py
+++ b/tests/unit/tui/screens/test_host_models.py
@@ -1,0 +1,92 @@
+"""Tests for HostModelsScreen — model picker for one host."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.host_models import HostModelsScreen
+from hermia.tui.state import Host, ModelChoice
+
+
+def _host_with_models() -> Host:
+    return Host(
+        name="h1",
+        url="http://h1",
+        engine="ollama",
+        models=[ModelChoice(name="m1"), ModelChoice(name="m2")],
+    )
+
+
+class TestHostModelsScreen:
+    def test_renders_host_models(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                screen: HostModelsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert sorted(screen.visible_model_names) == ["m1", "m2"]
+
+        asyncio.run(_run())
+
+    def test_pre_selected_models_remain_selected_on_mount(self) -> None:
+        from hermia.tui.widgets.drillable_list import DrillableList
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                host.models[0].selected = True  # pre-select m1
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                dl = pilot.app.screen.query_one(DrillableList)
+                assert dl.is_selected("m1")
+                assert not dl.is_selected("m2")
+
+        asyncio.run(_run())
+
+    def test_space_toggles_selection(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("space")
+                await pilot.pause()
+                # First model is now selected on host.models.
+                assert host.models[0].selected is True
+
+        asyncio.run(_run())
+
+    def test_select_all_then_none(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("a")
+                await pilot.pause()
+                assert all(m.selected for m in host.models)
+                await pilot.press("n")
+                await pilot.pause()
+                assert not any(m.selected for m in host.models)
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back(self) -> None:
+        from hermia.tui.screens.hosts import HostsScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config.hosts = [host]
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                pilot.app.push_screen(HostModelsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, HostsScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -73,3 +73,70 @@ class TestHostsScreen:
                 assert isinstance(pilot.app.screen, HostsScreen)
 
         asyncio.run(_run())
+
+
+class TestHostsProbe:
+    def test_probe_populates_models_and_flips_to_ok(self) -> None:
+        from tests.fixtures.fake_transport import FakeTransport
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="h1", url="http://h1", engine="ollama"),
+                ]
+                screen = HostsScreen(
+                    transport_factory=lambda h: FakeTransport(models=["a", "b"]),
+                )
+                pilot.app.push_screen(screen)
+                # Give the worker a beat to finish.
+                for _ in range(30):
+                    if screen.probe_state.get("h1") == "ok":
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["h1"] == "ok"
+                assert [m.name for m in pilot.app.config.hosts[0].models] == ["a", "b"]
+
+        asyncio.run(_run())
+
+    def test_probe_timeout_flips_to_failed(self) -> None:
+        from tests.fixtures.fake_transport import FakeTransport
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="slow", url="http://slow", engine="ollama"),
+                ]
+                screen = HostsScreen(
+                    transport_factory=lambda h: FakeTransport(models=["x"], delay_seconds=2.0),
+                    probe_timeout=0.05,
+                )
+                pilot.app.push_screen(screen)
+                for _ in range(30):
+                    if screen.probe_state.get("slow") in ("ok", "failed"):
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["slow"] == "failed"
+
+        asyncio.run(_run())
+
+    def test_probe_auth_error_flips_to_failed(self) -> None:
+        from tests.fixtures.fake_transport import FakeTransport
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="locked", url="http://locked", engine="openai-compat"),
+                ]
+                screen = HostsScreen(
+                    transport_factory=lambda h: FakeTransport(
+                        models=[], fail_with=PermissionError("401 unauthorized")
+                    ),
+                )
+                pilot.app.push_screen(screen)
+                for _ in range(30):
+                    if screen.probe_state.get("locked") in ("ok", "failed"):
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["locked"] == "failed"
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -1,0 +1,75 @@
+"""Tests for HostsScreen — list + AddHostModal + escape back."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.screens.hosts import HostsScreen
+from hermia.tui.state import Host
+
+
+class TestHostsScreen:
+    def test_initial_render_shows_existing_hosts(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="eric-5090", url="http://e:11434", engine="ollama"),
+                    Host(name="m3-pro", url="http://m:4000", engine="openai-compat"),
+                ]
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                screen: HostsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.host_names == ["eric-5090", "m3-pro"]
+
+        asyncio.run(_run())
+
+    def test_empty_hosts_shows_notice(self) -> None:
+        from textual.widgets import Static
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                await pilot.pause()
+                screen: HostsScreen = pilot.app.screen  # type: ignore[assignment]
+                notice = screen.query_one("#hosts-empty-notice", Static)
+                assert notice is not None
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())
+
+    def test_plus_opens_add_modal(self) -> None:
+        from hermia.tui.screens.modals import AddHostModal
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(HostsScreen())
+                await pilot.pause()
+                await pilot.press("plus")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, AddHostModal)
+
+        asyncio.run(_run())
+
+    def test_config_drill_into_hosts_row_pushes_hosts_screen(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                # cursor starts on row 0 (Hosts); enter drills.
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, HostsScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -119,6 +119,26 @@ class TestHostsProbe:
 
         asyncio.run(_run())
 
+    def test_probe_unexpected_error_marks_host_failed(self) -> None:
+        # If a transport_factory itself raises (not the probe), gather catches
+        # via return_exceptions=True; the screen must mark the host failed so
+        # it doesn't stay stuck in "probing" forever.
+        def boom(host: Host) -> object:
+            raise RuntimeError("factory blew up")
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [Host(name="x", url="http://x", engine="ollama")]
+                screen = HostsScreen(transport_factory=boom)
+                pilot.app.push_screen(screen)
+                for _ in range(30):
+                    if screen.probe_state.get("x") in ("ok", "failed"):
+                        break
+                    await pilot.pause()
+                assert screen.probe_state["x"] == "failed"
+
+        asyncio.run(_run())
+
     def test_probe_auth_error_flips_to_failed(self) -> None:
         from tests.fixtures.fake_transport import FakeTransport
 

--- a/tests/unit/tui/screens/test_launch.py
+++ b/tests/unit/tui/screens/test_launch.py
@@ -116,7 +116,9 @@ class TestLoadExisting:
         # A YAML file with the right name but malformed contents should
         # surface as a notify(), not crash the TUI.
         (tmp_path / "fleets").mkdir()
-        (tmp_path / "fleets" / "broken.yaml").write_text("name: broken\nhosts: not-a-list-of-dicts\n  - this is bad yaml")
+        (tmp_path / "fleets" / "broken.yaml").write_text(
+            "name: broken\nhosts: not-a-list-of-dicts\n  - this is bad yaml"
+        )
         monkeypatch.chdir(tmp_path)
 
         async def _run() -> None:

--- a/tests/unit/tui/screens/test_launch.py
+++ b/tests/unit/tui/screens/test_launch.py
@@ -110,6 +110,26 @@ class TestLoadExisting:
 
         asyncio.run(_run())
 
+    def test_load_corrupt_fleet_notifies_and_stays_on_launch(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A YAML file with the right name but malformed contents should
+        # surface as a notify(), not crash the TUI.
+        (tmp_path / "fleets").mkdir()
+        (tmp_path / "fleets" / "broken.yaml").write_text("name: broken\nhosts: not-a-list-of-dicts\n  - this is bad yaml")
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                await pilot.press("enter")  # try to load 'broken'
+                await pilot.pause()
+                # Still on LaunchScreen (didn't push FleetConfigScreen).
+                assert isinstance(pilot.app.screen, LaunchScreen)
+
+        asyncio.run(_run())
+
     def test_load_with_no_fleets_shows_empty_notice(self, tmp_path, monkeypatch) -> None:
         from textual.widgets import Static
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/tui/screens/test_launch.py
+++ b/tests/unit/tui/screens/test_launch.py
@@ -1,0 +1,66 @@
+"""Tests for LaunchScreen — initial entries + cursor + key bindings."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.launch import LaunchScreen
+
+
+class TestLaunchEntries:
+    def test_three_entries_present(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                assert isinstance(pilot.app.screen, LaunchScreen)
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                labels = [e.label for e in screen.entries]
+                assert labels == ["Load existing fleet", "New fleet", "Quick local run"]
+
+        asyncio.run(_run())
+
+    def test_cursor_starts_on_first_entry(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 0
+
+        asyncio.run(_run())
+
+    def test_arrow_down_moves_cursor(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("down")
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 1
+
+        asyncio.run(_run())
+
+    def test_arrow_up_clamps_at_top(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("up")
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 0
+
+        asyncio.run(_run())
+
+    def test_arrow_down_clamps_at_bottom(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                for _ in range(5):
+                    await pilot.press("down")
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_index == 2  # 3 entries → max index 2
+
+        asyncio.run(_run())
+
+    def test_q_quits_app(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("q")
+                await pilot.pause()
+                # App is exiting; _exit flag flips True.
+                assert pilot.app._exit is True
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_launch.py
+++ b/tests/unit/tui/screens/test_launch.py
@@ -64,3 +64,123 @@ class TestLaunchEntries:
                 assert pilot.app._exit is True
 
         asyncio.run(_run())
+
+
+class TestLoadExisting:
+    def test_selecting_load_shows_fleet_list(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.fleet_io import save_fleet
+        from hermia.tui.state import FleetConfig
+        save_fleet(FleetConfig(name="alpha"), root=tmp_path)
+        save_fleet(FleetConfig(name="beta"), root=tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # selects Load
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                labels = [e.label for e in screen.entries]
+                assert labels == ["alpha", "beta"]
+
+        asyncio.run(_run())
+
+    def test_selecting_a_loaded_fleet_populates_config(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.fleet_io import save_fleet
+        from hermia.tui.screens.config import FleetConfigScreen
+        from hermia.tui.state import FleetConfig, Host, ModelChoice
+        cfg = FleetConfig(
+            name="alpha",
+            hosts=[Host(name="h1", url="http://h1", engine="ollama",
+                        models=[ModelChoice(name="qwen3:32b", selected=True)])],
+            tests=["security-boundary"],
+        )
+        save_fleet(cfg, root=tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                await pilot.press("enter")  # select alpha
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+                assert pilot.app.config.name == "alpha"
+                assert pilot.app.config.tests == ["security-boundary"]
+                assert pilot.app.config.hosts[0].name == "h1"
+
+        asyncio.run(_run())
+
+    def test_load_with_no_fleets_shows_empty_notice(self, tmp_path, monkeypatch) -> None:
+        from textual.widgets import Static
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                await pilot.pause()  # let _rerender mount() complete
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.entries == []
+                notice = screen.query_one("#launch-empty-notice", Static)
+                assert notice is not None
+
+        asyncio.run(_run())
+
+    def test_escape_from_load_returns_to_home(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("enter")  # Load
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.mode == "home"
+                assert [e.label for e in screen.entries] == [
+                    "Load existing fleet", "New fleet", "Quick local run",
+                ]
+
+        asyncio.run(_run())
+
+
+class TestNewFleet:
+    def test_new_fleet_resets_config_and_pushes_config_screen(self) -> None:
+        from hermia.tui.screens.config import FleetConfigScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Mutate config first so we can prove New resets it.
+                pilot.app.config.name = "stale"
+                await pilot.press("down")  # cursor → New
+                await pilot.press("enter")
+                await pilot.pause()
+                assert pilot.app.config.name == ""
+                assert pilot.app.config.hosts == []
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())
+
+
+class TestQuickLocalRun:
+    def test_quick_local_seeds_config_and_pushes_config_screen(self) -> None:
+        from hermia.schemas import TEST_IDS
+        from hermia.tui.screens.config import FleetConfigScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Quick
+                await pilot.press("enter")
+                await pilot.pause()
+                cfg = pilot.app.config
+                assert cfg.name == "quick-local"
+                assert len(cfg.hosts) == 1
+                h = cfg.hosts[0]
+                assert h.url == "http://localhost:11434"
+                assert h.engine == "ollama"
+                assert h.name == "local"
+                assert cfg.tests == list(TEST_IDS)
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_tests.py
+++ b/tests/unit/tui/screens/test_tests.py
@@ -1,0 +1,89 @@
+"""Tests for TestsScreen — fleet-scoped test multi-select with framework filter."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.tests import TestsScreen
+
+
+class TestTestsScreen:
+    def test_renders_all_tests_initially(self) -> None:
+        from hermia.schemas import TEST_IDS
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                screen: TestsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert set(screen.visible_test_ids) == set(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_select_all_populates_config_tests(self) -> None:
+        from hermia.schemas import TEST_IDS
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                await pilot.press("a")
+                await pilot.pause()
+                assert set(pilot.app.config.tests) == set(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_search_filters_visible_tests(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                screen: TestsScreen = pilot.app.screen  # type: ignore[assignment]
+                screen.apply_query("multiturn")
+                await pilot.pause()
+                ids = screen.visible_test_ids
+                assert all("multiturn" in t for t in ids)
+                assert len(ids) >= 1
+
+        asyncio.run(_run())
+
+    def test_pre_selected_tests_remain_selected_on_mount(self) -> None:
+        from hermia.tui.widgets.drillable_list import DrillableList
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.tests = ["security-boundary", "tool-calling-basic"]
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                dl = pilot.app.screen.query_one(DrillableList)
+                assert dl.is_selected("security-boundary")
+                assert dl.is_selected("tool-calling-basic")
+
+        asyncio.run(_run())
+
+    def test_config_drill_into_tests_row_pushes_tests_screen(self) -> None:
+        from hermia.tui.screens.config import FleetConfigScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("down")  # cursor → Tests
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, TestsScreen)
+
+        asyncio.run(_run())
+
+    def test_escape_pops_back(self) -> None:
+        from hermia.tui.screens.config import FleetConfigScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                pilot.app.push_screen(TestsScreen())
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -1,0 +1,31 @@
+"""Tests for HermiaApp — the unified Fleet TUI Textual App.
+
+LaunchScreen mount behavior is verified in tests/unit/tui/screens/test_launch.py
+once Task 5 lands the screen.
+"""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.state import FleetConfig
+
+
+class TestHermiaApp:
+    def test_starts_with_empty_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                app: HermiaApp = pilot.app  # type: ignore[assignment]
+                assert isinstance(app.config, FleetConfig)
+                assert app.config.name == ""
+                assert app.config.hosts == []
+                assert app.config.tests == []
+
+        asyncio.run(_run())
+
+    def test_config_is_mutable(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                app: HermiaApp = pilot.app  # type: ignore[assignment]
+                app.config.name = "smoke"
+                assert app.config.name == "smoke"
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_picker_e2e.py
+++ b/tests/unit/tui/test_picker_e2e.py
@@ -1,0 +1,70 @@
+"""End-to-end picker smoke — drives Launch ▸ Config ▸ drills via Pilot.
+
+Three flows: Quick local run, Load existing fleet, New fleet + save.
+"""
+import asyncio
+
+from hermia.schemas import TEST_IDS
+from hermia.tui.app import HermiaApp
+from hermia.tui.fleet_io import fleet_path, save_fleet
+from hermia.tui.screens.config import FleetConfigScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestPickerE2E:
+    def test_quick_local_flow_ends_in_config_screen_with_pre_populated_config(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Launch → Quick local run (third entry).
+                await pilot.press("down", "down", "enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+                cfg = pilot.app.config
+                assert cfg.name == "quick-local"
+                assert cfg.hosts[0].url == "http://localhost:11434"
+                assert cfg.tests == list(TEST_IDS)
+
+        asyncio.run(_run())
+
+    def test_load_existing_flow_into_config(self, tmp_path, monkeypatch) -> None:
+        save_fleet(
+            FleetConfig(
+                name="loaded",
+                hosts=[Host(name="h", url="http://h", engine="ollama",
+                            models=[ModelChoice(name="m", selected=True)])],
+                tests=["security-boundary"],
+            ),
+            root=tmp_path,
+        )
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Launch → Load existing (first entry) → enter on the only fleet.
+                await pilot.press("enter")
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+                assert pilot.app.config.name == "loaded"
+                assert pilot.app.config.tests == ["security-boundary"]
+
+        asyncio.run(_run())
+
+    def test_save_via_s_writes_yaml(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                # Launch → New fleet (second entry).
+                await pilot.press("down")
+                await pilot.press("enter")
+                await pilot.pause()
+                # Set a name programmatically (the FleetNameModal flow is
+                # exercised in test_config.TestSave.test_save_with_no_name_opens_modal).
+                pilot.app.config.name = "smoke"
+                await pilot.press("s")
+                await pilot.pause()
+                assert fleet_path("smoke").exists()
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_test_catalog.py
+++ b/tests/unit/tui/test_test_catalog.py
@@ -1,0 +1,33 @@
+"""Tests for hermia.tui.test_catalog — TestRecord + load_test_catalog()."""
+from hermia.tui.test_catalog import FRAMEWORKS, TestRecord, load_test_catalog
+
+
+class TestLoadTestCatalog:
+    def test_returns_one_record_per_test_id(self) -> None:
+        from hermia.schemas import TEST_IDS
+        catalog = load_test_catalog()
+        assert {r.id for r in catalog} == set(TEST_IDS)
+
+    def test_records_have_frameworks_keys(self) -> None:
+        catalog = load_test_catalog()
+        for r in catalog:
+            assert set(r.frameworks.keys()) == set(FRAMEWORKS)
+            for v in r.frameworks.values():
+                assert isinstance(v, bool)
+
+    def test_known_test_has_expected_framework_membership(self) -> None:
+        catalog = load_test_catalog()
+        # security-boundary is in agentic-tasks.json with non-empty csa_maestro.
+        rec = next(r for r in catalog if r.id == "security-boundary")
+        # At least one framework membership should be True for an annotated test.
+        assert any(rec.frameworks.values())
+
+
+class TestTestRecord:
+    def test_is_in_framework_helper(self) -> None:
+        rec = TestRecord(
+            id="x",
+            frameworks={"OWASP": True, "ATLAS": False, "MAESTRO": True, "NIST": False},
+        )
+        assert rec.is_in_framework("OWASP") is True
+        assert rec.is_in_framework("ATLAS") is False

--- a/tests/unit/tui/test_transport_adapter.py
+++ b/tests/unit/tui/test_transport_adapter.py
@@ -78,3 +78,16 @@ class TestSSRFGuard:
         tr = transport_for(host)
         with pytest.raises(urllib.error.URLError, match="Unsupported protocol scheme"):
             tr._fetch_sync("/api/tags")
+
+    def test_bare_host_gets_http_prefix(self) -> None:
+        # Schemeless URL (e.g. "localhost:1") gets normalized to http://
+        # so the SSRF guard doesn't reject the common typo. Port 1 is the
+        # tcpmux service port — reliably unused on any sane dev machine,
+        # so urlopen reliably fails with a connection error rather than
+        # potentially reaching a live Ollama on 11434.
+        host = Host(name="bare", url="127.0.0.1:1", engine="ollama")
+        tr = transport_for(host)
+        with pytest.raises(urllib.error.URLError) as exc_info:
+            tr._fetch_sync("/api/tags")
+        # Should fail with a connection error, NOT the scheme rejection.
+        assert "Unsupported protocol scheme" not in str(exc_info.value)

--- a/tests/unit/tui/test_transport_adapter.py
+++ b/tests/unit/tui/test_transport_adapter.py
@@ -1,0 +1,60 @@
+"""Tests for hermia.tui.transport_adapter — engine → transport factory."""
+from hermia.tui.state import Host
+from hermia.tui.transport_adapter import (
+    OllamaProbeTransport,
+    OpenAICompatProbeTransport,
+    transport_for,
+)
+
+
+class TestTransportFor:
+    def test_returns_object_with_list_models(self) -> None:
+        host = Host(name="h", url="http://h:11434", engine="ollama")
+        tr = transport_for(host)
+        assert hasattr(tr, "list_models")
+
+    def test_ollama_engine_returns_ollama_transport(self) -> None:
+        host = Host(name="h", url="http://h:11434", engine="ollama")
+        tr = transport_for(host)
+        assert isinstance(tr, OllamaProbeTransport)
+
+    def test_openai_compat_engine_returns_openai_transport(self) -> None:
+        host = Host(name="h", url="http://h:4000", engine="openai-compat")
+        tr = transport_for(host)
+        assert isinstance(tr, OpenAICompatProbeTransport)
+
+    def test_unknown_engine_falls_back_to_openai_compat(self) -> None:
+        # vLLM / SGLang / LiteLLM all speak the OpenAI shape — non-"ollama"
+        # falls through to the openai-compat path.
+        host = Host(name="h", url="http://h", engine="vllm")
+        tr = transport_for(host)
+        assert isinstance(tr, OpenAICompatProbeTransport)
+
+    def test_resolves_auth_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("MY_KEY", "secret-value")
+        host = Host(
+            name="h",
+            url="http://h:4000",
+            engine="openai-compat",
+            auth_header_env="MY_KEY",
+        )
+        tr = transport_for(host)
+        # The adapter stores the resolved bearer header on the transport
+        # instance for the probe to use when calling /v1/models.
+        assert tr.auth_header == "Bearer secret-value"
+
+    def test_missing_env_var_leaves_auth_none(self, monkeypatch) -> None:
+        monkeypatch.delenv("NOT_SET_ANYWHERE", raising=False)
+        host = Host(
+            name="h",
+            url="http://h:4000",
+            engine="openai-compat",
+            auth_header_env="NOT_SET_ANYWHERE",
+        )
+        tr = transport_for(host)
+        assert tr.auth_header is None
+
+    def test_no_auth_header_env_leaves_auth_none(self) -> None:
+        host = Host(name="h", url="http://h:11434", engine="ollama")
+        tr = transport_for(host)
+        assert tr.auth_header is None

--- a/tests/unit/tui/test_transport_adapter.py
+++ b/tests/unit/tui/test_transport_adapter.py
@@ -1,4 +1,8 @@
 """Tests for hermia.tui.transport_adapter — engine → transport factory."""
+import urllib.error
+
+import pytest
+
 from hermia.tui.state import Host
 from hermia.tui.transport_adapter import (
     OllamaProbeTransport,
@@ -58,3 +62,19 @@ class TestTransportFor:
         host = Host(name="h", url="http://h:11434", engine="ollama")
         tr = transport_for(host)
         assert tr.auth_header is None
+
+
+class TestSSRFGuard:
+    """SSRF guard — only http(s) schemes are allowed for probe URLs."""
+
+    def test_file_scheme_raises_url_error(self) -> None:
+        host = Host(name="bad", url="file:///etc/passwd", engine="ollama")
+        tr = transport_for(host)
+        with pytest.raises(urllib.error.URLError, match="Unsupported protocol scheme"):
+            tr._fetch_sync("/api/tags")
+
+    def test_ftp_scheme_raises_url_error(self) -> None:
+        host = Host(name="bad", url="ftp://example.com", engine="ollama")
+        tr = transport_for(host)
+        with pytest.raises(urllib.error.URLError, match="Unsupported protocol scheme"):
+            tr._fetch_sync("/api/tags")

--- a/tests/unit/tui/test_widgets_breadcrumb.py
+++ b/tests/unit/tui/test_widgets_breadcrumb.py
@@ -1,0 +1,68 @@
+"""Tests for Breadcrumb — segmented drill-path header."""
+import asyncio
+
+from textual.app import App, ComposeResult
+
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+class _Host(App):
+    def __init__(self, segments: list[str]) -> None:
+        super().__init__()
+        self._segments = segments
+        self.jumped_to: int | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Breadcrumb(self._segments)
+
+    def on_breadcrumb_jumped(self, event: Breadcrumb.Jumped) -> None:
+        self.jumped_to = event.index
+
+
+class TestBreadcrumb:
+    def test_renders_segments_with_separator(self) -> None:
+        async def _run() -> None:
+            async with _Host(["hermia", "fleet", "smoke"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                assert bc.text == "hermia ▸ fleet ▸ smoke"
+
+        asyncio.run(_run())
+
+    def test_empty_segments_renders_empty(self) -> None:
+        async def _run() -> None:
+            async with _Host([]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                assert bc.text == ""
+
+        asyncio.run(_run())
+
+    def test_update_changes_rendering(self) -> None:
+        async def _run() -> None:
+            async with _Host(["a", "b"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                bc.set_segments(["x", "y", "z"])
+                await pilot.pause()
+                assert bc.text == "x ▸ y ▸ z"
+
+        asyncio.run(_run())
+
+    def test_jump_emits_message_with_index(self) -> None:
+        async def _run() -> None:
+            async with _Host(["a", "b", "c"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                bc.jump_to(1)
+                await pilot.pause()
+                assert pilot.app.jumped_to == 1
+
+        asyncio.run(_run())
+
+    def test_jump_out_of_range_is_noop(self) -> None:
+        async def _run() -> None:
+            async with _Host(["a", "b"]).run_test() as pilot:
+                bc = pilot.app.query_one(Breadcrumb)
+                bc.jump_to(5)
+                bc.jump_to(-1)
+                await pilot.pause()
+                assert pilot.app.jumped_to is None
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_widgets_drillable_list.py
+++ b/tests/unit/tui/test_widgets_drillable_list.py
@@ -114,6 +114,24 @@ class TestDrillableList:
 
         asyncio.run(_run())
 
+    def test_set_selected_ids_replaces_selection(self) -> None:
+        """set_selected_ids replaces the selection set without emitting
+        SelectionChanged (caller is the source of truth).
+        """
+        async def _run() -> None:
+            async with _Host().run_test() as pilot:
+                dl = pilot.app.query_one(DrillableList)
+                dl.set_selected_ids(["a", "c"])
+                await pilot.pause()
+                assert dl.is_selected("a")
+                assert dl.is_selected("c")
+                assert not dl.is_selected("b")
+                # No SelectionChanged emitted — host.toggled stays empty
+                # (it only fills from Toggled events, which we did not fire).
+                assert pilot.app.toggled == []
+
+        asyncio.run(_run())
+
     def test_click_on_row_drills(self) -> None:
         """Mouse parity per spec §5 — clicking a row moves cursor and drills."""
         async def _run() -> None:


### PR DESCRIPTION
## Summary

Plan 2 of the Fleet TUI roadmap (per [docs/superpowers/specs/2026-06-18-fleet-tui-design.md](docs/superpowers/specs/2026-06-18-fleet-tui-design.md) + [docs/superpowers/plans/2026-06-18-fleet-tui-picker.md](docs/superpowers/plans/2026-06-18-fleet-tui-picker.md)). Builds the picker flow on top of the Plan 1 foundation: Launch → Fleet Config → Hosts → Host Models / Tests, with save/load YAML and async host probing.

Tracking: \`hermia-86g\`. Plan 1 merged via [#119](https://github.com/scottblydotcom/hermia/pull/119).

## What's in this PR

**New source (`src/hermia/tui/`):**
- \`app.py\` + \`__main__.py\` — \`HermiaApp\` + \`python -m hermia.tui\` entry
- \`test_catalog.py\` — \`TestRecord\` + framework tags loaded from \`agentic-tasks.json\`
- \`transport_adapter.py\` — stdlib \`urllib.request\` + \`asyncio.to_thread\` probe transports (no new deps)
- \`widgets/breadcrumb.py\` — segmented drill-path header
- \`screens/launch.py\` — Load existing / New fleet / Quick local run
- \`screens/config.py\` — Fleet Config home base (Hosts ▸ + Tests ▸ drillable, run-plan trial count, save)
- \`screens/hosts.py\` — Hosts drill + AddHostModal trigger + async probe wiring
- \`screens/host_models.py\` — single-host model picker
- \`screens/tests.py\` — fleet-scoped multi-select with framework filter axis
- \`screens/modals.py\` — \`FleetNameModal\` (save prompt) + \`AddHostModal\`

**Foundation extension:**
- \`widgets/drillable_list.py\` gains \`SelectionChanged\` message for bulk select_all / select_none (single-row toggles still emit \`Toggled\`)

**Tests:** 67 new tests in \`tests/unit/tui/\` and \`tests/unit/tui/screens/\` covering every flow, plus 3 end-to-end Pilot smokes in \`test_picker_e2e.py\`.

## Numbers

- 160/160 \`tests/unit/tui/\` tests green
- 1685/1685 full project (no regression)
- ruff + mypy clean
- 13 commits, one per Plan 2 task (some tightly-coupled tasks bundled)

## Design adaptations from the plan

1. **Tasks 4+5 landed as one commit** — HermiaApp lazily imports LaunchScreen on mount; trying to commit independently with xfail markers churns more than it gains.
2. **Tasks 6+7+8 landed together** — all three Launch entry flows push to FleetConfigScreen; staged placeholders that exit and then get replaced would have made tests less honest.
3. **\`SelectionChanged\` message added to DrillableList** — bulk select_all/none from the widget needed a way to sync the host screen's domain model. Single-row \`Toggled\` already existed; the new message complements it.
4. **\`_rerender\` uses seq-bumped child IDs** — Textual's \`remove()\` returns AwaitRemove (async), and synchronous re-mount can collide with pending removals. Same lesson from Plan 1's DrillableList stable-row work.
5. **Per-screen \`SessionBus\` for HostsScreen probes** — Plan 3 will introduce \`app.bus\` for the runner; per-screen bus for now means probe events don't bleed into future runner topics.

## Test plan

- [x] \`pytest tests/unit/tui/\` — all green
- [x] \`pytest\` — full suite green
- [x] \`ruff check src/hermia/tui/ tests/unit/tui/ tests/fixtures/\` — clean
- [x] \`mypy src/hermia/tui/\` — clean
- [ ] Manual: \`python -m hermia.tui\` — walk Quick Local Run → save → reload (will exercise live probe against localhost Ollama if running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a unified Fleet TUI with a Launch flow, fleet config screen, and fleet save/load support.
  * Included Hosts browsing with probe status tags, per-host model selection, and fleet-scoped Tests picking with search and framework filtering.
  * Added modals for naming fleets and adding hosts, plus an unsaved-changes indicator during config edits.
  * Introduced a probe transport adapter with engine-specific model listing and URL/auth safety checks, and a cached test catalog.

* **Tests**
  * Added unit and end-to-end coverage for screens, widgets, selection/dirtiness propagation, probing behavior, and transport/test-catalog logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->