### PR TITLE
feat(tui): Fleet TUI Plan 3 — runner screens (L1/L2/L3) + bus wiring

### DIFF
--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -25,3 +25,6 @@ class HermiaApp(App[None]):
         # Import here to avoid a circular import — screens.launch imports HermiaApp.
         from hermia.tui.screens.launch import LaunchScreen
         self.push_screen(LaunchScreen())
+
+    def on_unmount(self) -> None:
+        self.bus.close()

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -1,13 +1,15 @@
 """HermiaApp — Textual App for the unified Fleet TUI.
 
 Holds the shared FleetConfig as a mutable attribute. Picker screens read
-and write directly to `app.config`. Plan 3 adds `app.bus = SessionBus()`
-for runner ↔ screen communication.
+and write directly to `app.config`. `app.bus` is the shared SessionBus for
+runner ↔ screen communication (probe topics and run topics share one bus;
+they use distinct topic prefixes and screens only subscribe to their own).
 """
 from __future__ import annotations
 
 from textual.app import App
 
+from hermia.tui.bus import SessionBus
 from hermia.tui.state import FleetConfig
 
 
@@ -17,6 +19,7 @@ class HermiaApp(App[None]):
     def __init__(self) -> None:
         super().__init__()
         self.config: FleetConfig = FleetConfig(name="")
+        self.bus: SessionBus = SessionBus()
 
     def on_mount(self) -> None:
         # Import here to avoid a circular import — screens.launch imports HermiaApp.

--- a/src/hermia/tui/bus.py
+++ b/src/hermia/tui/bus.py
@@ -78,3 +78,12 @@ class SessionBus:
                     pass
                 if not self._subscribers[topic]:
                     del self._subscribers[topic]
+
+    def close(self) -> None:
+        """Clear all subscriber registrations (called on app exit).
+
+        Does not unblock coroutines waiting in await q.get() — Textual's
+        task cancellation handles that via the try/finally in _consume.
+        After close(), publish() calls are no-ops (no subscribers remain).
+        """
+        self._subscribers.clear()

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -169,10 +169,12 @@ class TuiRunner:
 
     def _write_result(self, result: dict[str, Any], fleet_host_name: str) -> None:
         from hermia.results import append_result
+        # Caller (_run_trial) guards with `if self._results_dir is not None`.
+        results_dir: Path = self._results_dir  # type: ignore[assignment]
         result = dict(result)
         result["fleet_host_name"] = fleet_host_name
-        jsonl_path = self._results_dir / "results.jsonl"
-        csv_path = self._results_dir / "results.csv"
+        jsonl_path = results_dir / "results.jsonl"
+        csv_path = results_dir / "results.csv"
         append_result(result, jsonl_path, csv_path)
 
     def _count_trials(self) -> int:
@@ -221,7 +223,7 @@ def _real_run_test(
         else OllamaTransport(host, headers)
     )
     sampler = MetricsSampler()
-    return run_test(  # type: ignore[return-value]
+    return run_test(
         model_name, test, sampler,
         host=host, transport=transport, locality="remote",
     )

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -31,3 +31,197 @@ def verdict_from_result(result: dict[str, Any]) -> str:
     if result.get("failure_reason", ""):
         return "error"
     return "defended"
+
+
+# Type alias for the injectable run function.
+RunTestFn = Callable[..., dict[str, Any]]
+
+
+class TuiRunner:
+    """Async fleet eval dispatcher.
+
+    Call start() to create a background task that iterates all
+    (host, model, test, repeat) combinations and publishes bus events.
+    Call abort() to stop after the current in-flight trial finishes.
+    """
+
+    def __init__(
+        self,
+        config: FleetConfig,
+        bus: SessionBus,
+        results_dir: Path | None,
+        *,
+        run_test_fn: RunTestFn | None = None,
+        _tests_override: list[dict[str, Any]] | None = None,  # for tests only
+    ) -> None:
+        self._config = config
+        self._bus = bus
+        self._results_dir = results_dir
+        self._run_fn: RunTestFn = run_test_fn or _real_run_test
+        self._tests_override = _tests_override
+        self._abort_requested = False
+        self._n_completed = 0
+        self._task: asyncio.Task[None] | None = None
+
+    # ── Public API ─────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Launch the runner in a background asyncio task."""
+        self._task = asyncio.create_task(self._run())
+
+    def abort(self) -> None:
+        """Signal the runner to stop after the current trial finishes."""
+        self._abort_requested = True
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    # ── Internal ───────────────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        n_trials = self._count_trials()
+        await self._bus.publish("run.started", {
+            "run_id": _make_run_id(),
+            "n_hosts": len(self._config.hosts),
+            "n_trials_total": n_trials,
+        })
+
+        # Hosts run concurrently; trials within a host run sequentially
+        # (VRAM-aware — one model loaded at a time on each GPU host).
+        host_tasks = [
+            asyncio.create_task(self._run_host(host))
+            for host in self._config.hosts
+        ]
+        await asyncio.gather(*host_tasks, return_exceptions=True)
+
+        if self._abort_requested:
+            await self._bus.publish("run.aborted", {"n_completed": self._n_completed})
+        else:
+            await self._bus.publish("run.completed", {
+                "n_trials_total": n_trials,
+                "n_completed": self._n_completed,
+            })
+
+    async def _run_host(self, host: Host) -> None:
+        tests = self._load_tests()
+        for model in host.models:
+            if not model.selected:
+                continue
+            if self._abort_requested:
+                return
+            for test in tests:
+                if self._abort_requested:
+                    return
+                for repeat_idx in range(1, self._config.repeat + 1):
+                    if self._abort_requested:
+                        return
+                    await self._run_trial(host, model, test, repeat_idx)
+
+    async def _run_trial(
+        self,
+        host: Host,
+        model: ModelChoice,
+        test: dict[str, Any],
+        repeat_idx: int,
+    ) -> None:
+        await self._bus.publish("run.trial_started", {
+            "host_name": host.name,
+            "model_name": model.name,
+            "test_id": test["id"],
+            "repeat_idx": repeat_idx,
+        })
+
+        try:
+            result: dict[str, Any] = await asyncio.to_thread(
+                self._run_fn,
+                model.name,
+                test,
+                host=host.url,
+                engine=host.engine,
+                auth_env=host.auth_header_env,
+            )
+        except Exception as exc:  # noqa: BLE001
+            result = {
+                "model": model.name,
+                "test_id": test["id"],
+                "failure_reason": f"ERROR: {exc}",
+                "elapsed_sec": 0.0,
+                "output_preview": str(exc)[:120],
+                "signals": {},
+            }
+
+        self._n_completed += 1
+
+        await self._bus.publish("run.trial_finished", {
+            "host_name": host.name,
+            "model_name": model.name,
+            "test_id": test["id"],
+            "repeat_idx": repeat_idx,
+            "verdict": verdict_from_result(result),
+            "elapsed_sec": float(result.get("elapsed_sec") or 0.0),
+            "failure_reason": result.get("failure_reason", ""),
+            "output_preview": result.get("output_preview", ""),
+        })
+
+        if self._results_dir is not None:
+            self._write_result(result, host.name)
+
+    def _write_result(self, result: dict[str, Any], fleet_host_name: str) -> None:
+        from hermia.results import append_result
+        result = dict(result)
+        result["fleet_host_name"] = fleet_host_name
+        jsonl_path = self._results_dir / "results.jsonl"
+        csv_path = self._results_dir / "results.csv"
+        append_result(result, jsonl_path, csv_path)
+
+    def _count_trials(self) -> int:
+        n = 0
+        for host in self._config.hosts:
+            n_selected = sum(1 for m in host.models if m.selected)
+            n += n_selected * len(self._config.tests) * self._config.repeat
+        return n
+
+    def _load_tests(self) -> list[dict[str, Any]]:
+        if self._tests_override is not None:
+            return self._tests_override
+        from hermia.runner import load_tests
+        return load_tests(self._config.tests)
+
+
+def _make_run_id() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _real_run_test(
+    model_name: str,
+    test: dict[str, Any],
+    *,
+    host: str,
+    engine: str,
+    auth_env: str | None,
+) -> dict[str, Any]:
+    """Production run_test bridge — called from asyncio.to_thread."""
+    import os
+
+    from hermia.metrics import MetricsSampler
+    from hermia.runner import run_test
+    from hermia.transport.ollama import OllamaTransport
+    from hermia.transport.openai_compat import OpenAICompatTransport
+
+    headers: dict[str, str] = {}
+    if auth_env:
+        token = os.environ.get(auth_env, "")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+    transport = (
+        OpenAICompatTransport(host, headers)
+        if engine == "openai-compat"
+        else OllamaTransport(host, headers)
+    )
+    sampler = MetricsSampler()
+    return run_test(  # type: ignore[return-value]
+        model_name, test, sampler,
+        host=host, transport=transport, locality="remote",
+    )

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -109,7 +109,8 @@ class TuiRunner:
         ]
         results = await asyncio.gather(*host_tasks, return_exceptions=True)
         for host, host_result in zip(self._config.hosts, results, strict=True):
-            if isinstance(host_result, BaseException) and not isinstance(host_result, asyncio.CancelledError):
+            is_exc = isinstance(host_result, BaseException)
+            if is_exc and not isinstance(host_result, asyncio.CancelledError):
                 await self._bus.publish("run.trial_finished", {
                     "host_name": host.name,
                     "model_name": "",

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -165,7 +165,7 @@ class TuiRunner:
         })
 
         if self._results_dir is not None:
-            self._write_result(result, host.name)
+            await asyncio.to_thread(self._write_result, result, host.name)
 
     def _write_result(self, result: dict[str, Any], fleet_host_name: str) -> None:
         from hermia.results import append_result

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -80,7 +80,21 @@ class TuiRunner:
     # ── Internal ───────────────────────────────────────────────────────────
 
     async def _run(self) -> None:
-        n_trials = self._count_trials()
+        try:
+            tests = self._load_tests()
+        except Exception as exc:  # noqa: BLE001
+            await self._bus.publish("run.started", {
+                "run_id": _make_run_id(),
+                "n_hosts": len(self._config.hosts),
+                "n_trials_total": 0,
+            })
+            await self._bus.publish("run.aborted", {
+                "n_completed": 0,
+                "error": str(exc),
+            })
+            return
+
+        n_trials = self._count_trials(tests)
         await self._bus.publish("run.started", {
             "run_id": _make_run_id(),
             "n_hosts": len(self._config.hosts),
@@ -90,10 +104,22 @@ class TuiRunner:
         # Hosts run concurrently; trials within a host run sequentially
         # (VRAM-aware — one model loaded at a time on each GPU host).
         host_tasks = [
-            asyncio.create_task(self._run_host(host))
+            asyncio.create_task(self._run_host(host, tests))
             for host in self._config.hosts
         ]
-        await asyncio.gather(*host_tasks, return_exceptions=True)
+        results = await asyncio.gather(*host_tasks, return_exceptions=True)
+        for host, host_result in zip(self._config.hosts, results, strict=True):
+            if isinstance(host_result, BaseException) and not isinstance(host_result, asyncio.CancelledError):
+                await self._bus.publish("run.trial_finished", {
+                    "host_name": host.name,
+                    "model_name": "",
+                    "test_id": "",
+                    "repeat_idx": 0,
+                    "verdict": "error",
+                    "elapsed_sec": 0.0,
+                    "failure_reason": f"HOST_ERROR: {host_result}",
+                    "output_preview": str(host_result)[:120],
+                })
 
         if self._abort_requested:
             await self._bus.publish("run.aborted", {"n_completed": self._n_completed})
@@ -103,8 +129,7 @@ class TuiRunner:
                 "n_completed": self._n_completed,
             })
 
-    async def _run_host(self, host: Host) -> None:
-        tests = self._load_tests()
+    async def _run_host(self, host: Host, tests: list[dict[str, Any]]) -> None:
         for model in host.models:
             if not model.selected:
                 continue
@@ -171,17 +196,19 @@ class TuiRunner:
         from hermia.results import append_result
         # Caller (_run_trial) guards with `if self._results_dir is not None`.
         results_dir: Path = self._results_dir  # type: ignore[assignment]
+        results_dir.mkdir(parents=True, exist_ok=True)
         result = dict(result)
         result["fleet_host_name"] = fleet_host_name
         jsonl_path = results_dir / "results.jsonl"
         csv_path = results_dir / "results.csv"
         append_result(result, jsonl_path, csv_path)
 
-    def _count_trials(self) -> int:
+    def _count_trials(self, tests: list[dict[str, Any]]) -> int:
+        n_tests = len(tests)
         n = 0
         for host in self._config.hosts:
             n_selected = sum(1 for m in host.models if m.selected)
-            n += n_selected * len(self._config.tests) * self._config.repeat
+            n += n_selected * n_tests * self._config.repeat
         return n
 
     def _load_tests(self) -> list[dict[str, Any]]:

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -1,0 +1,33 @@
+"""TuiRunner — async eval dispatcher that publishes run.* events on SessionBus.
+
+Bridges the sync hermia.runner.run_test machinery into the Textual async
+event loop via asyncio.to_thread. One trial per to_thread call; hosts run
+concurrently (separate tasks), trials within a host run sequentially
+(VRAM-aware).
+
+run_test_fn is injectable for tests — pass a sync callable with the same
+signature as _real_run_test to avoid network I/O in unit tests.
+Pass results_dir=None to skip disk writes (useful in tests).
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from hermia.tui.bus import SessionBus
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+def verdict_from_result(result: dict[str, Any]) -> str:
+    """Convert a run_test result dict to a TUI verdict string.
+
+    v0.2 simplification: failure_reason="" → "defended"; any non-empty
+    failure_reason → "error". Signal-based "refused"/"breached" distinction
+    is a follow-up (filed as a bd bead after Plan 3 merges).
+    """
+    if result.get("failure_reason", ""):
+        return "error"
+    return "defended"

--- a/src/hermia/tui/screens/__init__.py
+++ b/src/hermia/tui/screens/__init__.py
@@ -1,6 +1,6 @@
 """Picker + runner screens for the Fleet TUI."""
 from hermia.tui.screens.runner import RunnerScreen
 from hermia.tui.screens.runner_detail import RunnerDetailScreen
-from hermia.tui.screens.runner_trials import RunnerTrialsScreen, _TrialRow
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen
 
-__all__ = ["RunnerScreen", "RunnerTrialsScreen", "RunnerDetailScreen", "_TrialRow"]
+__all__ = ["RunnerScreen", "RunnerTrialsScreen", "RunnerDetailScreen"]

--- a/src/hermia/tui/screens/__init__.py
+++ b/src/hermia/tui/screens/__init__.py
@@ -1,1 +1,6 @@
 """Picker + runner screens for the Fleet TUI."""
+from hermia.tui.screens.runner import RunnerScreen
+from hermia.tui.screens.runner_detail import RunnerDetailScreen
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen, _TrialRow
+
+__all__ = ["RunnerScreen", "RunnerTrialsScreen", "RunnerDetailScreen", "_TrialRow"]

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -152,6 +152,7 @@ class FleetConfigScreen(Screen[None]):
 
     def action_run(self) -> None:
         from pathlib import Path
+
         from hermia.tui.runner_backend import TuiRunner
         from hermia.tui.screens.runner import RunnerScreen
         results_dir: Path | None = None

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -157,8 +157,12 @@ class FleetConfigScreen(Screen[None]):
         from hermia.tui.screens.runner import RunnerScreen
         results_dir: Path | None = None
         if self.app_config.name:
-            results_dir = Path("results") / self.app_config.name
-            results_dir.mkdir(parents=True, exist_ok=True)
+            # Strip any directory components from the fleet name before using
+            # it as a path segment (guards against '../' traversal in YAML).
+            safe_name = Path(self.app_config.name).name or "unnamed"
+            results_dir = Path("results") / safe_name
+            # mkdir is deferred to _write_result so no empty dir is created
+            # if the run is aborted before writing any results.
         runner = TuiRunner(
             config=self.app_config,
             bus=self.app.bus,  # type: ignore[attr-defined]

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -151,5 +151,16 @@ class FleetConfigScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_run(self) -> None:
-        # Plan 3 wires this to the runner.
-        pass
+        from pathlib import Path
+        from hermia.tui.runner_backend import TuiRunner
+        from hermia.tui.screens.runner import RunnerScreen
+        results_dir: Path | None = None
+        if self.app_config.name:
+            results_dir = Path("results") / self.app_config.name
+            results_dir.mkdir(parents=True, exist_ok=True)
+        runner = TuiRunner(
+            config=self.app_config,
+            bus=self.app.bus,  # type: ignore[attr-defined]
+            results_dir=results_dir,
+        )
+        self.app.push_screen(RunnerScreen(runner=runner))

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -56,12 +56,6 @@ class HostsScreen(Screen[None]):
         self._listener_tasks: list[asyncio.Task[None]] = []
 
     @property
-    def _bus(self):  # type: ignore[no-untyped-def]
-        """Shared app-level bus. probe.* events use the same bus as run.* events;
-        screens subscribe only to the topics they care about, so there is no bleeding."""
-        return self.app.bus  # type: ignore[attr-defined]
-
-    @property
     def app_config(self) -> FleetConfig:
         return self.app.config  # type: ignore[attr-defined,no-any-return]
 
@@ -179,7 +173,7 @@ class HostsScreen(Screen[None]):
             await probe_host(
                 host,
                 transport=transport,  # type: ignore[arg-type]
-                bus=self._bus,
+                bus=self.app.bus,  # type: ignore[attr-defined]
                 timeout=self._probe_timeout,
             )
 
@@ -205,7 +199,7 @@ class HostsScreen(Screen[None]):
         self.workers.cancel_all()
 
     async def _listen(self, topic: str, final_state: str) -> None:
-        async for ev in self._bus.subscribe(topic):
+        async for ev in self.app.bus.subscribe(topic):  # type: ignore[attr-defined]
             self.probe_state[ev["host_name"]] = final_state
             if self.is_mounted:
                 self._rerender()

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -1,9 +1,12 @@
 """Hosts drill — list, add, remove, probe state.
 
 Lists existing hosts in app.config. `+` opens AddHostModal; enter drills
-into the host's models (Task 12); escape pops back. Background probes via
-SessionBus update probe_state per host (`probing` / `ok` / `failed`) which
-renders as inline `[state]` tags on each row.
+into the host's models; escape pops back. Background probes via app.bus
+update probe_state per host (`probing` / `ok` / `failed`) which renders
+as inline `[state]` tags on each row.
+
+Probe events use the `probe.*` topic prefix; runner events use `run.*`.
+Both share app.bus — screens subscribe only to their own prefix.
 """
 from __future__ import annotations
 
@@ -18,7 +21,6 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Static
 
-from hermia.tui.bus import SessionBus
 from hermia.tui.probe import DEFAULT_PROBE_TIMEOUT_SECONDS, probe_host
 from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.state import FleetConfig, Host
@@ -49,12 +51,15 @@ class HostsScreen(Screen[None]):
         self._make_transport = transport_factory
         self._probe_timeout = probe_timeout
         self._render_seq: int = 0
-        # Per-screen bus so probe events don't bleed into Plan 3's app.bus
-        # when the runner lands.
-        self._bus: SessionBus = SessionBus()
         # Listener tasks — created once on first probe and reused, so
         # re-firing _start_probes (after add-host) doesn't subscribe twice.
         self._listener_tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def _bus(self):  # type: ignore[no-untyped-def]
+        """Shared app-level bus. probe.* events use the same bus as run.* events;
+        screens subscribe only to the topics they care about, so there is no bleeding."""
+        return self.app.bus  # type: ignore[attr-defined]
 
     @property
     def app_config(self) -> FleetConfig:
@@ -148,7 +153,8 @@ class HostsScreen(Screen[None]):
 
         Started in on_mount and after any host is added. Idempotent on two
         axes: per-host (probes skipped for hosts with recorded probe_state)
-        and per-screen (listener tasks created once and reused).
+        and per-screen (listener tasks created once and reused, so
+        re-firing _start_probes after add-host doesn't double-subscribe).
         """
         # Subscribe first so events fired during probe_host land in queues.
         # Listeners are screen-lifetime singletons — multiple _start_probes
@@ -170,8 +176,6 @@ class HostsScreen(Screen[None]):
 
         async def _probe(host: Host) -> None:
             transport = factory(host)
-            # The transport satisfies probe._ListModelsTransport structurally
-            # (Protocol checks); mypy can't always see through Callable wrap.
             await probe_host(
                 host,
                 transport=transport,  # type: ignore[arg-type]
@@ -179,19 +183,13 @@ class HostsScreen(Screen[None]):
                 timeout=self._probe_timeout,
             )
 
-        # Probe all unprobed hosts concurrently — sequential gather would
-        # serialize a slow host's timeout across the entire fleet.
-        # return_exceptions=True ensures one host blowing up (with a class
-        # probe_host doesn't catch) doesn't abort the other in-flight probes.
+        # Probe all unprobed hosts concurrently.
         to_probe = [h for h in list(self.app_config.hosts) if h.name not in self.probe_state]
         if to_probe:
             results = await asyncio.gather(
                 *[_probe(h) for h in to_probe],
                 return_exceptions=True,
             )
-            # Any host whose probe raised an unexpected exception (one that
-            # probe_host didn't catch and translate into a bus event) would
-            # otherwise stay stuck in "probing" forever. Mark them failed.
             any_failed = False
             for host, result in zip(to_probe, results, strict=True):
                 if isinstance(result, BaseException):
@@ -204,18 +202,10 @@ class HostsScreen(Screen[None]):
         # Cancel listener tasks so they don't outlive the screen.
         for t in self._listener_tasks:
             t.cancel()
-        # Also cancel any @work probe workers still in flight — Textual's
-        # default cleanup is not guaranteed to drop them synchronously, and
-        # an orphan probe writing to host.models after the screen tears down
-        # would race the next mount. workers.cancel_all() is sync + safe.
         self.workers.cancel_all()
 
     async def _listen(self, topic: str, final_state: str) -> None:
         async for ev in self._bus.subscribe(topic):
             self.probe_state[ev["host_name"]] = final_state
-            # Re-render so the row's [state] tag updates. Skip if unmounting
-            # — on_unmount cancels these tasks but a late event may sneak in.
-            # Avoid a bare `except Exception` which would silently mask real
-            # bugs in _rerender / _row_text.
             if self.is_mounted:
                 self._rerender()

--- a/src/hermia/tui/screens/runner.py
+++ b/src/hermia/tui/screens/runner.py
@@ -1,0 +1,170 @@
+"""RunnerScreen (L1) — aggregate runner view.
+
+One row per host shows per-host verdict counts (defended / error) and
+current status (waiting / running / done). Subscribes to run.* topics on
+app.bus. enter drills to L2 (RunnerTrialsScreen). escape blocked while
+running; available after run.completed or run.aborted.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.state import FleetConfig, Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+if TYPE_CHECKING:
+    from hermia.tui.runner_backend import TuiRunner
+
+
+class RunnerScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Trials", show=True),
+    ]
+
+    def __init__(self, runner: "TuiRunner | None" = None) -> None:
+        super().__init__()
+        self.cursor_idx: int = 0
+        self.run_done: bool = False
+        # {host_name: {"defended": int, "error": int, "status": str}}
+        self._host_counts: dict[str, dict[str, Any]] = {}
+        self._listener_tasks: list[asyncio.Task[None]] = []
+        self._render_seq: int = 0
+        self._runner = runner
+
+    @property
+    def app_config(self) -> FleetConfig:
+        return self.app.config  # type: ignore[attr-defined,no-any-return]
+
+    @property
+    def breadcrumb_text(self) -> str:
+        return self.query_one(Breadcrumb).text
+
+    def host_counts(self, host_name: str) -> dict[str, Any]:
+        return self._host_counts.get(
+            host_name, {"defended": 0, "error": 0, "status": "waiting"}
+        )
+
+    def row_text(self, idx: int) -> str:
+        """Return the cached text for host row at idx. Used in tests."""
+        hosts = self.app_config.hosts
+        if idx >= len(hosts):
+            return ""
+        return self._row_text(hosts[idx], idx)
+
+    def compose(self) -> ComposeResult:
+        name = self.app_config.name or "(unnamed)"
+        with Vertical(id="runner-root"):
+            yield Breadcrumb(["hermia", "fleet", name, "runner"])
+            yield Static("", id="runner-progress")
+
+    def on_mount(self) -> None:
+        for host in self.app_config.hosts:
+            self._host_counts[host.name] = {"defended": 0, "error": 0, "status": "waiting"}
+        self._rerender()
+        self._listener_tasks = [
+            asyncio.create_task(self._listen_trial_finished()),
+            asyncio.create_task(self._listen_completed()),
+            asyncio.create_task(self._listen_aborted()),
+        ]
+        if self._runner is not None:
+            asyncio.create_task(self._runner.start())
+
+    def on_unmount(self) -> None:
+        for t in self._listener_tasks:
+            t.cancel()
+
+    # ── Rendering ─────────────────────────────────────────────────────────
+
+    def _row_text(self, host: Host, idx: int) -> str:
+        cursor = "▸" if idx == self.cursor_idx else " "
+        c = self._host_counts.get(host.name, {"defended": 0, "error": 0, "status": "waiting"})
+        return (
+            f"{cursor} {host.name:<20}"
+            f"  ok:{c['defended']}  err:{c['error']}"
+            f"  [{c['status']}]"
+        )
+
+    def _rerender(self) -> None:
+        root = self.query_one("#runner-root", Vertical)
+        host_rows = [
+            c for c in root.children
+            if isinstance(c, Static) and not isinstance(c, Breadcrumb)
+            and getattr(c, "id", "") != "runner-progress"
+        ]
+        hosts = self.app_config.hosts
+        if hosts and len(host_rows) == len(hosts):
+            for i, host in enumerate(hosts):
+                host_rows[i].update(self._row_text(host, i))
+            return
+        for child in host_rows:
+            child.remove()
+        self._render_seq += 1
+        seq = self._render_seq
+        for i, host in enumerate(hosts):
+            root.mount(Static(self._row_text(host, i), id=f"runner-row-{seq}-{i}"))
+
+    # ── Bus listeners ──────────────────────────────────────────────────────
+
+    async def _listen_trial_finished(self) -> None:
+        async for ev in self.app.bus.subscribe("run.trial_finished"):  # type: ignore[attr-defined]
+            host_name = ev.get("host_name", "")
+            if host_name not in self._host_counts:
+                self._host_counts[host_name] = {"defended": 0, "error": 0, "status": "running"}
+            counts = self._host_counts[host_name]
+            counts["status"] = "running"
+            if ev.get("verdict") == "defended":
+                counts["defended"] += 1
+            else:
+                counts["error"] += 1
+            if self.is_mounted:
+                self._rerender()
+
+    async def _listen_completed(self) -> None:
+        async for _ev in self.app.bus.subscribe("run.completed"):  # type: ignore[attr-defined]
+            self._mark_done()
+            return
+
+    async def _listen_aborted(self) -> None:
+        async for _ev in self.app.bus.subscribe("run.aborted"):  # type: ignore[attr-defined]
+            self._mark_done()
+            return
+
+    def _mark_done(self) -> None:
+        self.run_done = True
+        for counts in self._host_counts.values():
+            if counts["status"] == "running":
+                counts["status"] = "done"
+        if self.is_mounted:
+            self._rerender()
+
+    # ── Navigation ─────────────────────────────────────────────────────────
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_idx > 0:
+            self.cursor_idx -= 1
+            self._rerender()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_idx < len(self.app_config.hosts) - 1:
+            self.cursor_idx += 1
+            self._rerender()
+
+    def action_back(self) -> None:
+        if self.run_done:
+            self.app.pop_screen()
+
+    def action_drill(self) -> None:
+        from hermia.tui.screens.runner_trials import RunnerTrialsScreen
+        hosts = self.app_config.hosts
+        if 0 <= self.cursor_idx < len(hosts):
+            self.app.push_screen(RunnerTrialsScreen(host=hosts[self.cursor_idx]))

--- a/src/hermia/tui/screens/runner.py
+++ b/src/hermia/tui/screens/runner.py
@@ -38,6 +38,7 @@ class RunnerScreen(Screen[None]):
         # {host_name: {"defended": int, "error": int, "status": str}}
         self._host_counts: dict[str, dict[str, Any]] = {}
         self._listener_tasks: list[asyncio.Task[None]] = []
+        self._runner_task: asyncio.Task[None] | None = None
         self._render_seq: int = 0
         self._runner = runner
 
@@ -77,11 +78,13 @@ class RunnerScreen(Screen[None]):
             asyncio.create_task(self._listen_aborted()),
         ]
         if self._runner is not None:
-            asyncio.create_task(self._runner.start())
+            self._runner_task = asyncio.create_task(self._runner.start())
 
     def on_unmount(self) -> None:
         for t in self._listener_tasks:
             t.cancel()
+        if self._runner_task is not None:
+            self._runner_task.cancel()
 
     # ── Rendering ─────────────────────────────────────────────────────────
 
@@ -96,17 +99,23 @@ class RunnerScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#runner-root", Vertical)
+        prefix = f"runner-row-{self._render_seq}-"
         host_rows = [
             c for c in root.children
             if isinstance(c, Static) and not isinstance(c, Breadcrumb)
-            and getattr(c, "id", "") != "runner-progress"
+            and str(getattr(c, "id", "")).startswith(prefix)
         ]
         hosts = self.app_config.hosts
         if hosts and len(host_rows) == len(hosts):
             for i, host in enumerate(hosts):
                 host_rows[i].update(self._row_text(host, i))
             return
-        for child in host_rows:
+        stale = [
+            c for c in root.children
+            if isinstance(c, Static) and not isinstance(c, Breadcrumb)
+            and getattr(c, "id", "") != "runner-progress"
+        ]
+        for child in stale:
             child.remove()
         self._render_seq += 1
         seq = self._render_seq
@@ -142,7 +151,7 @@ class RunnerScreen(Screen[None]):
     def _mark_done(self) -> None:
         self.run_done = True
         for counts in self._host_counts.values():
-            if counts["status"] == "running":
+            if counts["status"] != "done":
                 counts["status"] = "done"
         if self.is_mounted:
             self._rerender()

--- a/src/hermia/tui/screens/runner.py
+++ b/src/hermia/tui/screens/runner.py
@@ -31,7 +31,7 @@ class RunnerScreen(Screen[None]):
         Binding("enter", "drill", "Trials", show=True),
     ]
 
-    def __init__(self, runner: "TuiRunner | None" = None) -> None:
+    def __init__(self, runner: TuiRunner | None = None) -> None:
         super().__init__()
         self.cursor_idx: int = 0
         self.run_done: bool = False

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -1,0 +1,89 @@
+"""RunnerDetailScreen (L3) — detail view for one trial.
+
+Receives a _TrialRow at init. If the trial is still pending or running,
+subscribes to run.trial_finished to update when the result arrives. escape
+always pops.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.screens.runner_trials import _TrialRow
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+_AWAITING_STATES = frozenset({"pending", "running"})
+
+
+class RunnerDetailScreen(Screen[None]):
+    BINDINGS = [Binding("escape", "back", "Back", show=True)]
+
+    def __init__(self, *, trial: _TrialRow) -> None:
+        super().__init__()
+        self._trial = trial
+        self._listener_task: asyncio.Task[None] | None = None
+
+    @property
+    def breadcrumb_text(self) -> str:
+        return self.query_one(Breadcrumb).text
+
+    @property
+    def summary_text(self) -> str:
+        return str(self.query_one("#detail-summary", Static).render())
+
+    @property
+    def is_awaiting_result(self) -> bool:
+        return self._trial.state in _AWAITING_STATES
+
+    def compose(self) -> ComposeResult:
+        t = self._trial
+        with Vertical():
+            yield Breadcrumb(["hermia", "runner", t.model_name, t.test_id])
+            yield Static("", id="detail-summary")
+            yield Static("", id="detail-output")
+
+    def on_mount(self) -> None:
+        self._refresh()
+        if self.is_awaiting_result:
+            self._listener_task = asyncio.create_task(self._listen_finished())
+
+    def on_unmount(self) -> None:
+        if self._listener_task is not None:
+            self._listener_task.cancel()
+
+    def _refresh(self) -> None:
+        t = self._trial
+        if self.is_awaiting_result:
+            summary = f"Trial in progress…  ({t.model_name} / {t.test_id})"
+        else:
+            elapsed = f"{t.elapsed_sec:.2f}s" if t.elapsed_sec is not None else "—"
+            # Escape square brackets so Rich doesn't treat them as markup tags.
+            reason = f"  \[{t.failure_reason}]" if t.failure_reason else ""
+            summary = f"verdict: {t.state}  elapsed: {elapsed}{reason}"
+
+        self.query_one("#detail-summary", Static).update(summary)
+        self.query_one("#detail-output", Static).update(t.output_preview or "")
+
+    async def _listen_finished(self) -> None:
+        t = self._trial
+        async for ev in self.app.bus.subscribe("run.trial_finished"):  # type: ignore[attr-defined]
+            if (
+                ev.get("model_name") == t.model_name
+                and ev.get("test_id") == t.test_id
+                and ev.get("repeat_idx") == t.repeat_idx
+            ):
+                t.state = ev.get("verdict", "error")
+                t.elapsed_sec = ev.get("elapsed_sec")
+                t.failure_reason = ev.get("failure_reason", "")
+                t.output_preview = ev.get("output_preview", "")
+                if self.is_mounted:
+                    self._refresh()
+                return
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -27,6 +27,7 @@ class RunnerDetailScreen(Screen[None]):
         super().__init__()
         self._trial = trial
         self._listener_task: asyncio.Task[None] | None = None
+        self._summary: str = ""
 
     @property
     def breadcrumb_text(self) -> str:
@@ -34,7 +35,7 @@ class RunnerDetailScreen(Screen[None]):
 
     @property
     def summary_text(self) -> str:
-        return str(self.query_one("#detail-summary", Static).render())
+        return self._summary
 
     @property
     def is_awaiting_result(self) -> bool:
@@ -66,6 +67,7 @@ class RunnerDetailScreen(Screen[None]):
             reason = f"  \[{t.failure_reason}]" if t.failure_reason else ""
             summary = f"verdict: {t.state}  elapsed: {elapsed}{reason}"
 
+        self._summary = summary
         self.query_one("#detail-summary", Static).update(summary)
         self.query_one("#detail-output", Static).update(t.output_preview or "")
 

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -78,6 +78,7 @@ class RunnerDetailScreen(Screen[None]):
                 ev.get("model_name") == t.model_name
                 and ev.get("test_id") == t.test_id
                 and ev.get("repeat_idx") == t.repeat_idx
+                and (not t.host_name or ev.get("host_name") == t.host_name)
             ):
                 t.state = ev.get("verdict", "error")
                 t.elapsed_sec = ev.get("elapsed_sec")

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -101,12 +101,18 @@ class RunnerTrialsScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#trials-root", Vertical)
-        existing = [c for c in root.children if not isinstance(c, Breadcrumb)]
-        if existing and len(existing) == len(self._trials):
+        prefix = f"trial-row-{self._render_seq}-"
+        current = [
+            c for c in root.children
+            if not isinstance(c, Breadcrumb)
+            and str(getattr(c, "id", "")).startswith(prefix)
+        ]
+        if current and len(current) == len(self._trials):
             for i, trial in enumerate(self._trials):
-                existing[i].update(self._row_text(trial, i))
+                current[i].update(self._row_text(trial, i))
             return
-        for child in existing:
+        stale = [c for c in root.children if not isinstance(c, Breadcrumb)]
+        for child in stale:
             child.remove()
         self._render_seq += 1
         seq = self._render_seq

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from typing import cast
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -94,10 +95,14 @@ class RunnerTrialsScreen(Screen[None]):
 
     def _row_text(self, trial: _TrialRow, idx: int) -> str:
         cursor = "▸" if idx == self.cursor_idx else " "
-        state_icon = {"pending": " ", "running": "↺", "defended": "✓", "error": "✗"}.get(trial.state, "?")
+        _icons = {"pending": " ", "running": "↺", "defended": "✓", "error": "✗"}
+        state_icon = _icons.get(trial.state, "?")
         elapsed = f"  {trial.elapsed_sec:.1f}s" if trial.elapsed_sec is not None else ""
         reason = f"  [{trial.failure_reason}]" if trial.failure_reason else ""
-        return f"{cursor} {state_icon}  {trial.model_name:<20}  {trial.test_id:<24}{elapsed}{reason}"
+        return (
+            f"{cursor} {state_icon}  {trial.model_name:<20}"
+            f"  {trial.test_id:<24}{elapsed}{reason}"
+        )
 
     def _rerender(self) -> None:
         root = self.query_one("#trials-root", Vertical)
@@ -109,7 +114,7 @@ class RunnerTrialsScreen(Screen[None]):
         ]
         if current and len(current) == len(self._trials):
             for i, trial in enumerate(self._trials):
-                current[i].update(self._row_text(trial, i))
+                cast("Static", current[i]).update(self._row_text(trial, i))
             return
         stale = [c for c in root.children if not isinstance(c, Breadcrumb)]
         for child in stale:

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -25,6 +25,7 @@ class _TrialRow:
     model_name: str
     test_id: str
     repeat_idx: int
+    host_name: str = ""
     state: str = "pending"   # pending | running | defended | error
     elapsed_sec: float | None = None
     failure_reason: str = ""
@@ -80,6 +81,7 @@ class RunnerTrialsScreen(Screen[None]):
                         model_name=model.name,
                         test_id=test_id,
                         repeat_idx=rep,
+                        host_name=self._host.name,
                     ))
         self._rerender()
         self._listener_tasks = [

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -1,0 +1,161 @@
+"""RunnerTrialsScreen (L2) — trial table for one host.
+
+One row per (selected model × test × repeat) combination. Subscribes to
+run.trial_started and run.trial_finished on app.bus; filters to this
+host only. enter drills to L3 for the focused trial. escape always pops.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import Static
+
+from hermia.tui.state import FleetConfig, Host
+from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+
+@dataclass
+class _TrialRow:
+    model_name: str
+    test_id: str
+    repeat_idx: int
+    state: str = "pending"   # pending | running | defended | error
+    elapsed_sec: float | None = None
+    failure_reason: str = ""
+    output_preview: str = ""
+
+
+class RunnerTrialsScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("up", "cursor_prev", "Up", show=False),
+        Binding("down", "cursor_next", "Down", show=False),
+        Binding("enter", "drill", "Detail", show=True),
+    ]
+
+    def __init__(self, *, host: Host) -> None:
+        super().__init__()
+        self._host = host
+        self.cursor_idx: int = 0
+        self._trials: list[_TrialRow] = []
+        self._render_seq: int = 0
+        self._listener_tasks: list[asyncio.Task[None]] = []
+
+    @property
+    def app_config(self) -> FleetConfig:
+        return self.app.config  # type: ignore[attr-defined,no-any-return]
+
+    @property
+    def breadcrumb_text(self) -> str:
+        return self.query_one(Breadcrumb).text
+
+    @property
+    def n_trial_rows(self) -> int:
+        return len(self._trials)
+
+    def trial_state(self, model_name: str, test_id: str, repeat_idx: int) -> str:
+        for t in self._trials:
+            if t.model_name == model_name and t.test_id == test_id and t.repeat_idx == repeat_idx:
+                return t.state
+        return "not-found"
+
+    def compose(self) -> ComposeResult:
+        name = self.app_config.name or "(unnamed)"
+        with Vertical(id="trials-root"):
+            yield Breadcrumb(["hermia", "fleet", name, "runner", self._host.name])
+
+    def on_mount(self) -> None:
+        for model in self._host.models:
+            if not model.selected:
+                continue
+            for test_id in self.app_config.tests:
+                for rep in range(1, self.app_config.repeat + 1):
+                    self._trials.append(_TrialRow(
+                        model_name=model.name,
+                        test_id=test_id,
+                        repeat_idx=rep,
+                    ))
+        self._rerender()
+        self._listener_tasks = [
+            asyncio.create_task(self._listen_started()),
+            asyncio.create_task(self._listen_finished()),
+        ]
+
+    def on_unmount(self) -> None:
+        for t in self._listener_tasks:
+            t.cancel()
+
+    # ── Rendering ─────────────────────────────────────────────────────────
+
+    def _row_text(self, trial: _TrialRow, idx: int) -> str:
+        cursor = "▸" if idx == self.cursor_idx else " "
+        state_icon = {"pending": " ", "running": "↺", "defended": "✓", "error": "✗"}.get(trial.state, "?")
+        elapsed = f"  {trial.elapsed_sec:.1f}s" if trial.elapsed_sec is not None else ""
+        reason = f"  [{trial.failure_reason}]" if trial.failure_reason else ""
+        return f"{cursor} {state_icon}  {trial.model_name:<20}  {trial.test_id:<24}{elapsed}{reason}"
+
+    def _rerender(self) -> None:
+        root = self.query_one("#trials-root", Vertical)
+        existing = [c for c in root.children if not isinstance(c, Breadcrumb)]
+        if existing and len(existing) == len(self._trials):
+            for i, trial in enumerate(self._trials):
+                existing[i].update(self._row_text(trial, i))
+            return
+        for child in existing:
+            child.remove()
+        self._render_seq += 1
+        seq = self._render_seq
+        for i, trial in enumerate(self._trials):
+            root.mount(Static(self._row_text(trial, i), id=f"trial-row-{seq}-{i}"))
+
+    # ── Bus listeners ──────────────────────────────────────────────────────
+
+    async def _listen_started(self) -> None:
+        async for ev in self.app.bus.subscribe("run.trial_started"):  # type: ignore[attr-defined]
+            if ev.get("host_name") != self._host.name:
+                continue
+            for t in self._trials:
+                if (t.model_name == ev.get("model_name") and t.test_id == ev.get("test_id")
+                        and t.repeat_idx == ev.get("repeat_idx")):
+                    t.state = "running"
+            if self.is_mounted:
+                self._rerender()
+
+    async def _listen_finished(self) -> None:
+        async for ev in self.app.bus.subscribe("run.trial_finished"):  # type: ignore[attr-defined]
+            if ev.get("host_name") != self._host.name:
+                continue
+            for t in self._trials:
+                if (t.model_name == ev.get("model_name") and t.test_id == ev.get("test_id")
+                        and t.repeat_idx == ev.get("repeat_idx")):
+                    t.state = ev.get("verdict", "error")
+                    t.elapsed_sec = ev.get("elapsed_sec")
+                    t.failure_reason = ev.get("failure_reason", "")
+                    t.output_preview = ev.get("output_preview", "")
+            if self.is_mounted:
+                self._rerender()
+
+    # ── Navigation ─────────────────────────────────────────────────────────
+
+    def action_cursor_prev(self) -> None:
+        if self.cursor_idx > 0:
+            self.cursor_idx -= 1
+            self._rerender()
+
+    def action_cursor_next(self) -> None:
+        if self.cursor_idx < len(self._trials) - 1:
+            self.cursor_idx += 1
+            self._rerender()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_drill(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+        if 0 <= self.cursor_idx < len(self._trials):
+            self.app.push_screen(RunnerDetailScreen(trial=self._trials[self.cursor_idx]))

--- a/tests/unit/tui/screens/test_config.py
+++ b/tests/unit/tui/screens/test_config.py
@@ -127,6 +127,35 @@ class TestSave:
         asyncio.run(_run())
 
 
+class TestFleetConfigScreenActionRun:
+    def test_action_run_pushes_runner_screen(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.screens.runner import RunnerScreen
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = FleetConfig(
+                    name="run-smoke",
+                    hosts=[
+                        Host(
+                            name="local",
+                            url="http://localhost:11434",
+                            engine="ollama",
+                            models=[ModelChoice(name="qwen3:32b", selected=True)],
+                        )
+                    ],
+                    tests=["t1"],
+                    repeat=1,
+                )
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("r")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerScreen)
+
+        asyncio.run(_run())
+
+
 class TestDirtyPropagation:
     def test_test_toggle_marks_config_dirty(self) -> None:
         from hermia.tui.screens.tests import TestsScreen

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -160,3 +160,39 @@ class TestHostsProbe:
                 assert screen.probe_state["locked"] == "failed"
 
         asyncio.run(_run())
+
+
+class TestHostsScreenBusMigration:
+    def test_probe_events_flow_through_app_bus(self) -> None:
+        """After migration, probe.completed events appear on app.bus, not a private bus."""
+        import asyncio
+
+        from tests.fixtures.fake_transport import FakeTransport
+        from hermia.tui.app import HermiaApp
+        from hermia.tui.screens.hosts import HostsScreen
+        from hermia.tui.state import Host
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="eric-5090", url="http://e:11434", engine="ollama")
+                ]
+                received: list[dict] = []
+
+                async def listen() -> None:
+                    async for ev in pilot.app.bus.subscribe("probe.completed"):
+                        received.append(ev)
+                        return
+
+                task = asyncio.create_task(listen())
+                await asyncio.sleep(0)
+
+                fake = FakeTransport(models=["qwen3:32b"])
+                pilot.app.push_screen(
+                    HostsScreen(transport_factory=lambda _host: fake, probe_timeout=2.0)
+                )
+                await pilot.pause()
+                await asyncio.wait_for(task, timeout=3.0)
+                assert received[0]["host_name"] == "eric-5090"
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -167,10 +167,10 @@ class TestHostsScreenBusMigration:
         """After migration, probe.completed events appear on app.bus, not a private bus."""
         import asyncio
 
-        from tests.fixtures.fake_transport import FakeTransport
         from hermia.tui.app import HermiaApp
         from hermia.tui.screens.hosts import HostsScreen
         from hermia.tui.state import Host
+        from tests.fixtures.fake_transport import FakeTransport
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:

--- a/tests/unit/tui/screens/test_runner.py
+++ b/tests/unit/tui/screens/test_runner.py
@@ -1,0 +1,210 @@
+"""Tests for RunnerScreen (L1 aggregate view)."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.runner import RunnerScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+def _two_host_config() -> FleetConfig:
+    return FleetConfig(
+        name="smoke",
+        hosts=[
+            Host(name="eric-5090", url="http://e:11434", engine="ollama",
+                 models=[ModelChoice(name="qwen3:32b", selected=True)]),
+            Host(name="marcus", url="http://m:4000", engine="openai-compat",
+                 models=[ModelChoice(name="qwen2.5:7b", selected=True)]),
+        ],
+        tests=["t1"],
+        repeat=1,
+    )
+
+
+class TestRunnerScreenLayout:
+    def test_breadcrumb_contains_runner(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "runner" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_host_rows_rendered_for_each_host(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "eric-5090" in screen.row_text(0)
+                assert "marcus" in screen.row_text(1)
+
+        asyncio.run(_run())
+
+    def test_initial_counts_are_zero(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                counts = screen.host_counts("eric-5090")
+                assert counts["defended"] == 0
+                assert counts["error"] == 0
+
+        asyncio.run(_run())
+
+
+class TestRunnerScreenBusSubscription:
+    def test_trial_finished_increments_defended_count(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.trial_finished", {
+                    "host_name": "eric-5090",
+                    "model_name": "qwen3:32b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                    "verdict": "defended",
+                    "elapsed_sec": 0.4,
+                    "failure_reason": "",
+                    "output_preview": "ok",
+                })
+                await pilot.pause()
+
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.host_counts("eric-5090")["defended"] == 1
+
+        asyncio.run(_run())
+
+    def test_trial_finished_error_increments_error_count(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.trial_finished", {
+                    "host_name": "marcus",
+                    "model_name": "qwen2.5:7b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                    "verdict": "error",
+                    "elapsed_sec": 90.0,
+                    "failure_reason": "TIMEOUT",
+                    "output_preview": "",
+                })
+                await pilot.pause()
+
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.host_counts("marcus")["error"] == 1
+
+        asyncio.run(_run())
+
+    def test_run_completed_marks_run_done(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.completed", {
+                    "n_trials_total": 2,
+                    "n_completed": 2,
+                })
+                await pilot.pause()
+
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.run_done is True
+
+        asyncio.run(_run())
+
+    def test_run_aborted_marks_run_done(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.aborted", {"n_completed": 1})
+                await pilot.pause()
+
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.run_done is True
+
+        asyncio.run(_run())
+
+
+class TestRunnerScreenNavigation:
+    def test_cursor_moves_down_and_up(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.cursor_idx == 0
+                await pilot.press("down")
+                await pilot.pause()
+                assert screen.cursor_idx == 1
+                await pilot.press("up")
+                await pilot.pause()
+                assert screen.cursor_idx == 0
+
+        asyncio.run(_run())
+
+    def test_enter_drills_to_runner_trials_screen(self) -> None:
+        from hermia.tui.screens.runner_trials import RunnerTrialsScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerTrialsScreen)
+
+        asyncio.run(_run())
+
+    def test_escape_blocked_while_running(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.run_done is False
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerScreen)
+
+        asyncio.run(_run())
+
+    def test_escape_pops_when_run_done(self) -> None:
+        from hermia.tui.screens.config import FleetConfigScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = _two_host_config()
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.completed", {
+                    "n_trials_total": 2, "n_completed": 2
+                })
+                await pilot.pause()
+
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, FleetConfigScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_runner_detail.py
+++ b/tests/unit/tui/screens/test_runner_detail.py
@@ -1,0 +1,133 @@
+"""Tests for RunnerDetailScreen (L3 detail view)."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen, _TrialRow
+
+
+def _make_finished_trial(**kwargs) -> _TrialRow:
+    defaults = dict(
+        model_name="qwen3:32b",
+        test_id="t1",
+        repeat_idx=1,
+        state="defended",
+        elapsed_sec=0.4,
+        failure_reason="",
+        output_preview="All clear",
+    )
+    defaults.update(kwargs)
+    return _TrialRow(**defaults)
+
+
+class TestRunnerDetailScreenLayout:
+    def test_breadcrumb_includes_model_and_test(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                trial = _make_finished_trial()
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+                screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "qwen3:32b" in screen.breadcrumb_text
+                assert "t1" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_verdict_shown_in_summary(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                trial = _make_finished_trial(state="defended", elapsed_sec=0.42)
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+                screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "defended" in screen.summary_text
+
+        asyncio.run(_run())
+
+    def test_error_verdict_shown_with_reason(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                trial = _make_finished_trial(
+                    state="error", failure_reason="TIMEOUT", output_preview=""
+                )
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+                screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "error" in screen.summary_text
+                assert "TIMEOUT" in screen.summary_text
+
+        asyncio.run(_run())
+
+    def test_pending_trial_shows_in_progress(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                trial = _make_finished_trial(state="pending", elapsed_sec=None)
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+                screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.is_awaiting_result is True
+
+        asyncio.run(_run())
+
+
+class TestRunnerDetailScreenBus:
+    def test_live_update_on_trial_finished(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                trial = _make_finished_trial(state="running", elapsed_sec=None)
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+
+                screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.is_awaiting_result is True
+
+                await pilot.app.bus.publish("run.trial_finished", {
+                    "host_name": "eric-5090",
+                    "model_name": "qwen3:32b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                    "verdict": "error",
+                    "elapsed_sec": 90.0,
+                    "failure_reason": "TIMEOUT",
+                    "output_preview": "",
+                })
+                await pilot.pause()
+
+                assert screen.is_awaiting_result is False
+                assert "error" in screen.summary_text
+
+        asyncio.run(_run())
+
+
+class TestRunnerDetailScreenNavigation:
+    def test_escape_pops_to_trials_screen(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+        from hermia.tui.state import Host, ModelChoice
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="h", url="u", engine="ollama",
+                         models=[ModelChoice(name="m", selected=True)])
+                ]
+                pilot.app.config.tests = ["t1"]
+                host = pilot.app.config.hosts[0]
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                trial = _make_finished_trial()
+                pilot.app.push_screen(RunnerDetailScreen(trial=trial))
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerTrialsScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_runner_trials.py
+++ b/tests/unit/tui/screens/test_runner_trials.py
@@ -1,0 +1,167 @@
+"""Tests for RunnerTrialsScreen (L2 trial table)."""
+import asyncio
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.screens.runner import RunnerScreen
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+def _host_with_models() -> Host:
+    return Host(
+        name="eric-5090",
+        url="http://e:11434",
+        engine="ollama",
+        models=[
+            ModelChoice(name="qwen3:32b", selected=True),
+            ModelChoice(name="qwen2.5:7b", selected=False),  # not selected — no row
+        ],
+    )
+
+
+def _config_with_host(host: Host) -> FleetConfig:
+    return FleetConfig(name="smoke", hosts=[host], tests=["t1", "t2"], repeat=1)
+
+
+class TestRunnerTrialsScreenLayout:
+    def test_breadcrumb_includes_host_name(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert "eric-5090" in screen.breadcrumb_text
+
+        asyncio.run(_run())
+
+    def test_rows_only_for_selected_models(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                # 1 selected model × 2 tests × 1 repeat = 2 rows
+                assert screen.n_trial_rows == 2
+
+        asyncio.run(_run())
+
+    def test_initial_state_is_pending(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.trial_state(model_name="qwen3:32b", test_id="t1", repeat_idx=1) == "pending"
+
+        asyncio.run(_run())
+
+
+class TestRunnerTrialsScreenBus:
+    def test_trial_started_flips_to_running(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.trial_started", {
+                    "host_name": "eric-5090",
+                    "model_name": "qwen3:32b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                })
+                await pilot.pause()
+
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.trial_state("qwen3:32b", "t1", 1) == "running"
+
+        asyncio.run(_run())
+
+    def test_trial_finished_sets_verdict(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.trial_finished", {
+                    "host_name": "eric-5090",
+                    "model_name": "qwen3:32b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                    "verdict": "defended",
+                    "elapsed_sec": 0.4,
+                    "failure_reason": "",
+                    "output_preview": "ok",
+                })
+                await pilot.pause()
+
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+
+        asyncio.run(_run())
+
+    def test_events_for_other_host_ignored(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+
+                await pilot.app.bus.publish("run.trial_finished", {
+                    "host_name": "other-host",
+                    "model_name": "qwen3:32b",
+                    "test_id": "t1",
+                    "repeat_idx": 1,
+                    "verdict": "defended",
+                    "elapsed_sec": 0.1,
+                    "failure_reason": "",
+                    "output_preview": "",
+                })
+                await pilot.pause()
+
+                screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.trial_state("qwen3:32b", "t1", 1) == "pending"
+
+        asyncio.run(_run())
+
+
+class TestRunnerTrialsScreenNavigation:
+    def test_escape_pops_to_runner_screen(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerScreen())
+                await pilot.pause()
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerScreen)
+
+        asyncio.run(_run())
+
+    def test_enter_drills_to_runner_detail(self) -> None:
+        from hermia.tui.screens.runner_detail import RunnerDetailScreen
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                host = _host_with_models()
+                pilot.app.config = _config_with_host(host)
+                pilot.app.push_screen(RunnerTrialsScreen(host=host))
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerDetailScreen)
+
+        asyncio.run(_run())

--- a/tests/unit/tui/screens/test_runner_trials.py
+++ b/tests/unit/tui/screens/test_runner_trials.py
@@ -57,7 +57,10 @@ class TestRunnerTrialsScreenLayout:
                 pilot.app.push_screen(RunnerTrialsScreen(host=host))
                 await pilot.pause()
                 screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
-                assert screen.trial_state(model_name="qwen3:32b", test_id="t1", repeat_idx=1) == "pending"
+                assert (
+                    screen.trial_state(model_name="qwen3:32b", test_id="t1", repeat_idx=1)
+                    == "pending"
+                )
 
         asyncio.run(_run())
 

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -29,3 +29,32 @@ class TestHermiaApp:
                 assert app.config.name == "smoke"
 
         asyncio.run(_run())
+
+
+class TestHermiaAppBus:
+    def test_app_has_bus_attribute(self) -> None:
+        from hermia.tui.bus import SessionBus
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                assert isinstance(pilot.app.bus, SessionBus)
+
+        asyncio.run(_run())
+
+    def test_bus_can_publish_and_receive(self) -> None:
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                events: list[dict] = []
+
+                async def reader() -> None:
+                    async for ev in pilot.app.bus.subscribe("run.started"):
+                        events.append(ev)
+                        return
+
+                task = asyncio.create_task(reader())
+                await asyncio.sleep(0)
+                await pilot.app.bus.publish("run.started", {"run_id": "r1"})
+                await asyncio.wait_for(task, timeout=1.0)
+                assert events == [{"run_id": "r1"}]
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_bus.py
+++ b/tests/unit/tui/test_bus.py
@@ -148,3 +148,50 @@ class TestBoundedQueue:
             assert events == [{"chunk": "c3"}, {"chunk": "c4"}]
 
         asyncio.run(_run())
+
+
+class TestSessionBusClose:
+    def test_close_clears_subscriber_registry(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            events: list[dict] = []
+
+            async def reader() -> None:
+                try:
+                    async for ev in bus.subscribe("probe.started"):
+                        events.append(ev)
+                except asyncio.CancelledError:
+                    return
+
+            task = asyncio.create_task(reader())
+            await asyncio.sleep(0)
+            assert "probe.started" in bus._subscribers
+
+            bus.close()
+            # After close, the registry is empty.
+            assert bus._subscribers == {}
+            # Cancel the reader (it's blocked on q.get — close doesn't unblock it).
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+
+    def test_publish_after_close_is_noop(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            bus.close()
+            # Should not raise.
+            await bus.publish("run.started", {"run_id": "r1"})
+
+        asyncio.run(_run())
+
+    def test_close_is_idempotent(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            bus.close()
+            bus.close()  # should not raise
+
+        asyncio.run(_run())

--- a/tests/unit/tui/test_picker_e2e.py
+++ b/tests/unit/tui/test_picker_e2e.py
@@ -11,6 +11,76 @@ from hermia.tui.screens.config import FleetConfigScreen
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
 
+class TestRunnerE2E:
+    def test_r_key_from_config_pushes_runner_screen(self, tmp_path, monkeypatch) -> None:
+        from hermia.tui.runner_backend import TuiRunner  # noqa: F401
+        from hermia.tui.screens.runner import RunnerScreen
+        monkeypatch.chdir(tmp_path)
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config = FleetConfig(
+                    name="e2e-smoke",
+                    hosts=[
+                        Host(name="local", url="http://localhost:11434", engine="ollama",
+                             models=[ModelChoice(name="qwen3:32b", selected=True)])
+                    ],
+                    tests=["t1"],
+                    repeat=1,
+                )
+                pilot.app.push_screen(FleetConfigScreen())
+                await pilot.pause()
+                await pilot.press("r")
+                await pilot.pause()
+                assert isinstance(pilot.app.screen, RunnerScreen)
+
+        asyncio.run(_run())
+
+    def test_runner_screen_receives_events_from_tui_runner(self) -> None:
+        from hermia.tui.runner_backend import TuiRunner
+        from hermia.tui.screens.runner import RunnerScreen
+
+        def _fake_run_test(model_name, test, *, host, engine, auth_env):
+            return {
+                "model": model_name,
+                "test_id": test["id"],
+                "failure_reason": "",
+                "elapsed_sec": 0.1,
+                "output_preview": "ok",
+                "signals": {},
+            }
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                cfg = FleetConfig(
+                    name="e2e-smoke",
+                    hosts=[
+                        Host(name="local", url="http://localhost:11434", engine="ollama",
+                             models=[ModelChoice(name="qwen3:32b", selected=True)])
+                    ],
+                    tests=["t1"],
+                    repeat=1,
+                )
+                pilot.app.config = cfg
+                runner = TuiRunner(
+                    config=cfg,
+                    bus=pilot.app.bus,
+                    results_dir=None,
+                    run_test_fn=_fake_run_test,
+                    _tests_override=[{"id": "t1"}],
+                )
+                pilot.app.push_screen(RunnerScreen(runner=runner))
+                await pilot.pause()
+                # Wait long enough for the runner to complete (fake fn is fast).
+                for _ in range(20):
+                    await pilot.pause()
+                screen: RunnerScreen = pilot.app.screen  # type: ignore[assignment]
+                assert screen.run_done is True
+                assert screen.host_counts("local")["defended"] == 1
+
+        asyncio.run(_run())
+
+
 class TestPickerE2E:
     def test_quick_local_flow_ends_in_config_screen_with_pre_populated_config(self) -> None:
         async def _run() -> None:

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -1,0 +1,32 @@
+"""Tests for hermia.tui.runner_backend — TuiRunner + helpers."""
+import asyncio
+
+import pytest
+
+from hermia.tui.runner_backend import verdict_from_result
+
+
+class TestVerdictFromResult:
+    def test_empty_failure_reason_is_defended(self) -> None:
+        result = {"failure_reason": "", "signals": {}}
+        assert verdict_from_result(result) == "defended"
+
+    def test_timeout_failure_is_error(self) -> None:
+        result = {"failure_reason": "TIMEOUT: no response in 90s", "signals": {}}
+        assert verdict_from_result(result) == "error"
+
+    def test_schema_fail_is_error(self) -> None:
+        result = {"failure_reason": "SCHEMA_FAIL", "signals": {}}
+        assert verdict_from_result(result) == "error"
+
+    def test_empty_response_is_error(self) -> None:
+        result = {"failure_reason": "EMPTY_RESPONSE", "signals": {}}
+        assert verdict_from_result(result) == "error"
+
+    def test_api_error_is_error(self) -> None:
+        result = {"failure_reason": "API_ERROR: connection refused", "signals": {}}
+        assert verdict_from_result(result) == "error"
+
+    def test_missing_failure_reason_key_treated_as_defended(self) -> None:
+        result = {"signals": {}}
+        assert verdict_from_result(result) == "defended"

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -1,8 +1,6 @@
 """Tests for hermia.tui.runner_backend — TuiRunner + helpers."""
 import asyncio
 
-import pytest
-
 from hermia.tui.bus import SessionBus
 from hermia.tui.runner_backend import TuiRunner, verdict_from_result
 from hermia.tui.state import FleetConfig, Host, ModelChoice

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -3,7 +3,9 @@ import asyncio
 
 import pytest
 
-from hermia.tui.runner_backend import verdict_from_result
+from hermia.tui.bus import SessionBus
+from hermia.tui.runner_backend import TuiRunner, verdict_from_result
+from hermia.tui.state import FleetConfig, Host, ModelChoice
 
 
 class TestVerdictFromResult:
@@ -30,3 +32,270 @@ class TestVerdictFromResult:
     def test_missing_failure_reason_key_treated_as_defended(self) -> None:
         result = {"signals": {}}
         assert verdict_from_result(result) == "defended"
+
+
+def _make_config(
+    n_hosts: int = 1,
+    n_models: int = 1,
+    test_ids: list[str] | None = None,
+    repeat: int = 1,
+) -> FleetConfig:
+    hosts = [
+        Host(
+            name=f"host-{i}",
+            url=f"http://host{i}:11434",
+            engine="ollama",
+            models=[ModelChoice(name=f"m{j}", selected=True) for j in range(n_models)],
+        )
+        for i in range(n_hosts)
+    ]
+    return FleetConfig(
+        name="test",
+        hosts=hosts,
+        tests=test_ids or ["t1"],
+        repeat=repeat,
+    )
+
+
+def _fake_run_test_fn(
+    model_name: str,
+    test: dict,
+    *,
+    host: str,
+    engine: str,
+    auth_env: str | None,
+) -> dict:
+    """Sync fake; returns immediately with a clean result."""
+    return {
+        "model": model_name,
+        "test_id": test["id"],
+        "failure_reason": "",
+        "elapsed_sec": 0.01,
+        "tokens_per_sec": 50.0,
+        "output_preview": "ok",
+        "signals": {},
+        "schema_compliant": True,
+    }
+
+
+class TestTuiRunnerBusEvents:
+    def test_run_started_published_first(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            received: list[dict] = []
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.started"):
+                    received.append(ev)
+                    return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)
+
+            config = _make_config(n_hosts=2, n_models=1, test_ids=["t1"], repeat=1)
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=_fake_run_test_fn,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(task, timeout=3.0)
+            assert received[0]["n_hosts"] == 2
+            assert received[0]["n_trials_total"] == 2  # 2 hosts × 1 model × 1 test × 1 repeat
+
+        asyncio.run(_run())
+
+    def test_trial_started_and_finished_each_trial(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            started: list[dict] = []
+            finished: list[dict] = []
+
+            async def listen_started() -> None:
+                async for ev in bus.subscribe("run.trial_started"):
+                    started.append(ev)
+                    if len(started) == 2:
+                        return
+
+            async def listen_finished() -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    finished.append(ev)
+                    if len(finished) == 2:
+                        return
+
+            t1 = asyncio.create_task(listen_started())
+            t2 = asyncio.create_task(listen_finished())
+            await asyncio.sleep(0)
+
+            config = _make_config(n_hosts=1, n_models=2, test_ids=["t1"], repeat=1)
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=_fake_run_test_fn,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(asyncio.gather(t1, t2), timeout=5.0)
+
+            assert len(started) == 2
+            assert len(finished) == 2
+            assert all(e["host_name"] == "host-0" for e in started)
+            assert all(e["verdict"] == "defended" for e in finished)
+
+        asyncio.run(_run())
+
+    def test_run_completed_published_after_all_trials(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            completed: list[dict] = []
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.completed"):
+                    completed.append(ev)
+                    return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)
+
+            config = _make_config(n_hosts=1, n_models=1, test_ids=["t1", "t2"], repeat=1)
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=_fake_run_test_fn,
+                _tests_override=[{"id": "t1"}, {"id": "t2"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(task, timeout=5.0)
+
+            assert completed[0]["n_completed"] == 2
+            assert completed[0]["n_trials_total"] == 2
+
+        asyncio.run(_run())
+
+    def test_abort_stops_runner_and_publishes_aborted(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            aborted: list[dict] = []
+            started: list[dict] = []
+
+            def slow_fake(model_name, test, *, host, engine, auth_env):
+                import time
+                time.sleep(0.05)
+                return {
+                    "model": model_name, "test_id": test["id"],
+                    "failure_reason": "", "elapsed_sec": 0.05,
+                    "output_preview": "ok", "signals": {},
+                }
+
+            async def listen_abort() -> None:
+                async for ev in bus.subscribe("run.aborted"):
+                    aborted.append(ev)
+                    return
+
+            async def listen_started() -> None:
+                async for ev in bus.subscribe("run.trial_started"):
+                    started.append(ev)
+                    if len(started) == 1:
+                        return
+
+            t1 = asyncio.create_task(listen_abort())
+            t2 = asyncio.create_task(listen_started())
+            await asyncio.sleep(0)
+
+            config = _make_config(n_hosts=1, n_models=10, test_ids=["t1"], repeat=1)
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=slow_fake,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(t2, timeout=3.0)
+            runner.abort()
+            await asyncio.wait_for(t1, timeout=3.0)
+
+            assert len(aborted) == 1
+            assert aborted[0]["n_completed"] < 10
+
+        asyncio.run(_run())
+
+    def test_unselected_models_are_skipped(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            finished: list[dict] = []
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    finished.append(ev)
+                    if len(finished) == 1:
+                        return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)
+
+            host = Host(
+                name="h",
+                url="http://h:11434",
+                engine="ollama",
+                models=[
+                    ModelChoice(name="selected", selected=True),
+                    ModelChoice(name="skipped", selected=False),
+                ],
+            )
+            config = FleetConfig(name="t", hosts=[host], tests=["t1"], repeat=1)
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=_fake_run_test_fn,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(task, timeout=3.0)
+
+            await asyncio.sleep(0.1)
+            assert len(finished) == 1
+            assert finished[0]["model_name"] == "selected"
+
+        asyncio.run(_run())
+
+    def test_error_result_publishes_error_verdict(self) -> None:
+        async def _run() -> None:
+            bus = SessionBus()
+            finished: list[dict] = []
+
+            def error_fake(model_name, test, *, host, engine, auth_env):
+                return {
+                    "model": model_name, "test_id": test["id"],
+                    "failure_reason": "TIMEOUT: no response in 90s",
+                    "elapsed_sec": 90.0, "output_preview": "", "signals": {},
+                }
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    finished.append(ev)
+                    return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)
+
+            config = _make_config()
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=error_fake,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            await asyncio.wait_for(task, timeout=3.0)
+
+            assert finished[0]["verdict"] == "error"
+            assert finished[0]["failure_reason"] == "TIMEOUT: no response in 90s"
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary

- **TuiRunner** (`runner_backend.py`): async eval dispatcher that bridges sync `run_test` machinery to Textual via `asyncio.to_thread`; publishes `run.*` events on `app.bus`; hosts run concurrently, trials within a host run sequentially (VRAM-aware)
- **RunnerScreen (L1)**: aggregate per-host verdict counts (defended/error); escape blocked while running
- **RunnerTrialsScreen (L2)**: per-trial state table for one host; subscribes to `run.trial_started` / `run.trial_finished`
- **RunnerDetailScreen (L3)**: detail view for one trial; live-updates if trial is still in-flight
- **`HermiaApp.bus`**: shared `SessionBus` added to app; `HostsScreen._bus` shim migrated → `app.bus`; `SessionBus.close()` added for app-exit teardown
- **`FleetConfigScreen.action_run`**: wired — `r` key now creates a `TuiRunner` and pushes `RunnerScreen`

## Code review fixes applied pre-PR

1. `RunnerDetailScreen._listen_finished`: added `host_name` to match predicate (wrong host result could overwrite detail view in multi-host fleet)
2. `TuiRunner._run()`: inspect `asyncio.gather` results; publish `HOST_ERROR` trial event for host tasks that die before any trial starts
3. `TuiRunner._count_trials()`: use loaded test count (was using raw config list — overcounted when unknown test IDs given)
4. `config.py action_run`: strip directory components from fleet name before using as path segment (`../` traversal guard)
5. `_write_result`: defer `mkdir` to first write — no empty directory created on aborted run
6. `hosts.py`: remove `_bus` property shim; call sites now use `self.app.bus` directly
7. `screens/__init__.py`: remove private `_TrialRow` from public `__all__`

## Test plan

- [ ] 1739 tests pass, 91% coverage, ruff + mypy clean
- [ ] `python -m hermia.tui` → Quick Local Run → FleetConfigScreen → `r` → RunnerScreen shows hosts
- [ ] Bus events update L1 host counts in real time
- [ ] `enter` drills L1→L2→L3; `escape` unwinds; escape blocked on L1 while running
- [ ] Gemini review — post `/gemini review` as PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added test runner interface for executing configured test suites directly within the TUI
* Introduced runner progress screen displaying per-host aggregate test results with counts
* Added detailed trial view with breadcrumb navigation, status display, and failure diagnostics
* Implemented real-time event-driven UI updates reflecting test execution lifecycle

**Tests**
* Comprehensive test coverage for runner functionality, event handling, and navigation flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->