### PR TITLE
fix(tui): UX improvements, trial hang timeout, Rich markup escape

### DIFF
--- a/src/hermia/tui/probe.py
+++ b/src/hermia/tui/probe.py
@@ -59,7 +59,10 @@ async def probe_host(
         # Happy-path inside the try block so a transport returning None or a
         # non-iterable surfaces as `unexpected` (catches our own bugs) rather
         # than crashing the coroutine outside the handler.
-        host.models = [ModelChoice(name=n, selected=False) for n in model_names]
+        # Preserve selected state for models that already exist — re-probing
+        # (e.g. when HostsScreen is pushed again) must not wipe user selections.
+        existing_selected = {m.name for m in host.models if m.selected}
+        host.models = [ModelChoice(name=n, selected=n in existing_selected) for n in model_names]
         await bus.publish(
             "probe.completed",
             {

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -163,6 +163,10 @@ class TuiRunner:
         })
 
         try:
+            # wait_for cancels the coroutine wrapper on timeout but cannot kill
+            # the OS thread. The thread runs until _run_fn returns or its own
+            # socket timeout fires (~90 s via the transport layer), so zombie
+            # threads are bounded to at most 1-2 per host lane at any moment.
             result: dict[str, Any] = await asyncio.wait_for(
                 asyncio.to_thread(
                     self._run_fn,

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -20,6 +20,8 @@ from typing import Any
 from hermia.tui.bus import SessionBus
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
+TRIAL_WALL_TIMEOUT: float = 120.0
+
 
 def verdict_from_result(result: dict[str, Any]) -> str:
     """Convert a run_test result dict to a TUI verdict string.
@@ -53,12 +55,14 @@ class TuiRunner:
         *,
         run_test_fn: RunTestFn | None = None,
         _tests_override: list[dict[str, Any]] | None = None,  # for tests only
+        trial_timeout: float = TRIAL_WALL_TIMEOUT,
     ) -> None:
         self._config = config
         self._bus = bus
         self._results_dir = results_dir
         self._run_fn: RunTestFn = run_test_fn or _real_run_test
         self._tests_override = _tests_override
+        self._trial_timeout = trial_timeout
         self._abort_requested = False
         self._n_completed = 0
         self._task: asyncio.Task[None] | None = None
@@ -159,14 +163,26 @@ class TuiRunner:
         })
 
         try:
-            result: dict[str, Any] = await asyncio.to_thread(
-                self._run_fn,
-                model.name,
-                test,
-                host=host.url,
-                engine=host.engine,
-                auth_env=host.auth_header_env,
+            result: dict[str, Any] = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self._run_fn,
+                    model.name,
+                    test,
+                    host=host.url,
+                    engine=host.engine,
+                    auth_env=host.auth_header_env,
+                ),
+                timeout=self._trial_timeout,
             )
+        except TimeoutError:
+            result = {
+                "model": model.name,
+                "test_id": test["id"],
+                "failure_reason": f"TIMEOUT: no response in {self._trial_timeout:.0f}s",
+                "elapsed_sec": self._trial_timeout,
+                "output_preview": "",
+                "signals": {},
+            }
         except Exception as exc:  # noqa: BLE001
             result = {
                 "model": model.name,

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -21,10 +21,10 @@ class FleetConfigScreen(Screen[None]):
         Binding("escape", "back", "Back", show=True),
         Binding("up", "cursor_prev", "Up", show=False),
         Binding("down", "cursor_next", "Down", show=False),
-        Binding("enter", "drill", "Drill", show=True),
+        Binding("enter", "drill", "Open", show=True),
         Binding("s", "save", "Save", show=True),
         Binding("l", "load", "Load", show=False),
-        Binding("r", "run", "Run", show=False),
+        Binding("r", "run", "Run", show=True),
     ]
 
     ROWS = [("hosts", "Hosts"), ("tests", "Tests")]
@@ -58,6 +58,14 @@ class FleetConfigScreen(Screen[None]):
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Breadcrumb(self._breadcrumb_segments())
+            yield Static(
+                "Step 1: Open Hosts to pick which models to test.\n"
+                "Step 2: Open Tests to choose which security tests to run.\n"
+                "Step 3: Press r to start the run.\n"
+                "\n"
+                "Use ↑↓ to move between rows, Enter to open.",
+                id="config-instructions",
+            )
             yield Static("", id="config-summary-hosts")
             yield Static("", id="config-summary-tests")
             yield Static("", id="config-run-plan")

--- a/src/hermia/tui/screens/host_models.py
+++ b/src/hermia/tui/screens/host_models.py
@@ -10,7 +10,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
-from textual.widgets import Footer
+from textual.widgets import Footer, Static
 
 from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.state import Host
@@ -27,7 +27,7 @@ class HostModelsScreen(Screen[None]):
         Binding("space", "toggle_model", "Toggle", show=True),
         Binding("a", "select_all", "All", show=True),
         Binding("n", "select_none", "None", show=True),
-        Binding("slash", "search_open", "Search", show=False),
+        Binding("slash", "search_open", "Search", show=True),
     ]
 
     def __init__(self, *, host: Host) -> None:
@@ -43,6 +43,13 @@ class HostModelsScreen(Screen[None]):
         name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
         with Vertical():
             yield Breadcrumb(["hermia", "fleet", name, "hosts", self._host.name])
+            yield Static(
+                "Select which models on this host to include in the run.\n"
+                "\n"
+                "  Space  Toggle selected     a  Select all     n  Select none\n"
+                "  /  Search by name          Esc  Back to hosts",
+                id="host-models-instructions",
+            )
             rows = [ListRow(id_=m.name, label=m.name) for m in self._host.models]
             yield DrillableList(rows)
             yield SearchBar()

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -67,6 +67,13 @@ class HostsScreen(Screen[None]):
         name = self.app_config.name or "(unnamed)"
         with Vertical(id="hosts-root"):
             yield Breadcrumb(["hermia", "fleet", name, "hosts"])
+            yield Static(
+                "Each host is an Ollama endpoint. hermia will probe it and list available models.\n"
+                "\n"
+                "  +  Add a new host          Enter  Choose models for this host\n"
+                "  Esc  Back to fleet config",
+                id="hosts-instructions",
+            )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -81,7 +88,10 @@ class HostsScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#hosts-root", Vertical)
-        existing_rows = [c for c in root.children if not isinstance(c, Breadcrumb)]
+        existing_rows = [
+            c for c in root.children
+            if not isinstance(c, Breadcrumb) and c.id != "hosts-instructions"
+        ]
         # Stable-row optimization (Plan 1 lesson): when host count is unchanged
         # and we're not transitioning to/from empty state, update Statics in
         # place. Cursor moves and probe-state updates take this path.

--- a/src/hermia/tui/screens/launch.py
+++ b/src/hermia/tui/screens/launch.py
@@ -37,10 +37,16 @@ class LaunchScreen(Screen[None]):
     ]
 
     HOME_ENTRIES: list[LaunchEntry] = [
-        LaunchEntry(id="load", label="Load existing fleet"),
-        LaunchEntry(id="new", label="New fleet"),
         LaunchEntry(id="quick", label="Quick local run"),
+        LaunchEntry(id="new", label="New fleet"),
+        LaunchEntry(id="load", label="Load existing fleet"),
     ]
+
+    HOME_DESCRIPTIONS: dict[str, str] = {
+        "quick": "Probe localhost:11434 (Ollama) and run all 30 security tests. Start here.",
+        "new":   "Choose which hosts, models, and tests to include. Save as a named fleet.",
+        "load":  "Resume a previously saved fleet configuration.",
+    }
 
     def __init__(self) -> None:
         super().__init__()
@@ -53,7 +59,8 @@ class LaunchScreen(Screen[None]):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="launch-root"):
-            yield Static("Welcome to hermia fleet", id="launch-title")
+            yield Static("hermia — LLM security evaluation", id="launch-title")
+            yield Static("", id="launch-subtitle")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -65,12 +72,19 @@ class LaunchScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#launch-root", Vertical)
-        # Update title in place rather than re-mounting.
-        title = root.query_one("#launch-title", Static)
-        title.update("Welcome to hermia fleet" if self.mode == "home" else "Load fleet")
-        # Remove old dynamic children (everything except the title).
+        # Update title + subtitle in place.
+        root.query_one("#launch-title", Static).update(
+            "hermia — LLM security evaluation" if self.mode == "home" else "Load fleet"
+        )
+        subtitle = root.query_one("#launch-subtitle", Static)
+        subtitle.update(
+            "Use ↑↓ to move, Enter to select, q to quit."
+            if self.mode == "home"
+            else "Select a saved fleet with Enter, or Esc to go back."
+        )
+        # Remove old dynamic children (everything except title + subtitle).
         for child in list(root.children):
-            if child.id == "launch-title":
+            if child.id in ("launch-title", "launch-subtitle"):
                 continue
             child.remove()
         # Mount fresh dynamic children with seq-bumped IDs so any AwaitRemove
@@ -80,8 +94,12 @@ class LaunchScreen(Screen[None]):
         if not self.entries:
             root.mount(Static("No saved fleets in fleets/", id="launch-empty-notice"))
             return
+        root.mount(Static("", id=f"launch-gap-{seq}"))
         for i, entry in enumerate(self.entries):
             root.mount(Static(self._row_text(entry, i), id=f"launch-row-{seq}-{i}"))
+            if self.mode == "home" and entry.id in self.HOME_DESCRIPTIONS:
+                desc = self.HOME_DESCRIPTIONS[entry.id]
+                root.mount(Static(f"       {desc}", id=f"launch-desc-{seq}-{i}"))
 
     def _scan_fleets(self) -> list[LaunchEntry]:
         fleets_dir = Path("fleets")

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -70,6 +70,11 @@ class RunnerTrialsScreen(Screen[None]):
         name = self.app_config.name or "(unnamed)"
         with Vertical(id="trials-root"):
             yield Breadcrumb(["hermia", "fleet", name, "runner", self._host.name])
+            yield Static(
+                "  ✓ defended   ✗ breached   ↺ running   · pending   ! error\n"
+                "  Enter  View trial detail     Esc  Back to runner",
+                id="trials-legend",
+            )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -119,7 +124,10 @@ class RunnerTrialsScreen(Screen[None]):
             for i, trial in enumerate(self._trials):
                 cast("Static", current[i]).update(self._row_text(trial, i))
             return
-        stale = [c for c in root.children if not isinstance(c, Breadcrumb)]
+        stale = [
+            c for c in root.children
+            if not isinstance(c, Breadcrumb) and c.id != "trials-legend"
+        ]
         for child in stale:
             child.remove()
         self._render_seq += 1

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -72,7 +72,7 @@ class RunnerTrialsScreen(Screen[None]):
         with Vertical(id="trials-root"):
             yield Breadcrumb(["hermia", "fleet", name, "runner", self._host.name])
             yield Static(
-                "  ✓ defended   ✗ breached   ↺ running   · pending   ! error\n"
+                "  ✓ defended   ✗ error   ↺ running     pending\n"
                 "  Enter  View trial detail     Esc  Back to runner",
                 id="trials-legend",
             )

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -10,6 +10,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import cast
 
+from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
@@ -106,7 +107,7 @@ class RunnerTrialsScreen(Screen[None]):
         _icons = {"pending": " ", "running": "↺", "defended": "✓", "error": "✗"}
         state_icon = _icons.get(trial.state, "?")
         elapsed = f"  {trial.elapsed_sec:.1f}s" if trial.elapsed_sec is not None else ""
-        reason = f"  [{trial.failure_reason}]" if trial.failure_reason else ""
+        reason = f"  {escape(f'[{trial.failure_reason}]')}" if trial.failure_reason else ""
         return (
             f"{cursor} {state_icon}  {trial.model_name:<20}"
             f"  {trial.test_id:<24}{elapsed}{reason}"

--- a/src/hermia/tui/screens/tests.py
+++ b/src/hermia/tui/screens/tests.py
@@ -10,7 +10,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
-from textual.widgets import Footer
+from textual.widgets import Footer, Static
 
 from hermia.tui.screens._dirty import _mark_dirty_in_stack
 from hermia.tui.test_catalog import FRAMEWORKS, load_test_catalog
@@ -32,8 +32,8 @@ class TestsScreen(Screen[None]):
         Binding("space", "toggle_test", "Toggle", show=True),
         Binding("a", "select_all", "All", show=True),
         Binding("n", "select_none", "None", show=True),
-        Binding("slash", "search_open", "Search", show=False),
-        Binding("tab", "next_axis", "Filter axis", show=False),
+        Binding("slash", "search_open", "Search", show=True),
+        Binding("tab", "next_axis", "Filter", show=True),
         Binding("right", "next_value", "Next value", show=False),
         Binding("left", "prev_value", "Prev value", show=False),
     ]
@@ -53,6 +53,15 @@ class TestsScreen(Screen[None]):
         name = self.app.config.name or "(unnamed)"  # type: ignore[attr-defined]
         with Vertical():
             yield Breadcrumb(["hermia", "fleet", name, "tests"])
+            yield Static(
+                "Choose which security tests to run against your models.\n"
+                "All 30 tests are selected by default — deselect any you want to skip.\n"
+                "\n"
+                "  Space  Toggle     a  Select all     n  Select none\n"
+                "  /  Search by test ID     Tab  Cycle framework filter\n"
+                "  ←→  Change filter value     Esc  Back to fleet config",
+                id="tests-instructions",
+            )
             yield FilterAxis({"framework": FRAMEWORKS})
             rows = [ListRow(id_=r.id, label=r.id) for r in self._catalog]
             yield DrillableList(rows)

--- a/tests/unit/tui/screens/test_launch.py
+++ b/tests/unit/tui/screens/test_launch.py
@@ -14,7 +14,7 @@ class TestLaunchEntries:
                 assert isinstance(pilot.app.screen, LaunchScreen)
                 screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
                 labels = [e.label for e in screen.entries]
-                assert labels == ["Load existing fleet", "New fleet", "Quick local run"]
+                assert labels == ["Quick local run", "New fleet", "Load existing fleet"]
 
         asyncio.run(_run())
 
@@ -78,7 +78,9 @@ class TestLoadExisting:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("enter")  # selects Load
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Load (index 2)
+                await pilot.press("enter")
                 await pilot.pause()
                 screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
                 labels = [e.label for e in screen.entries]
@@ -101,7 +103,9 @@ class TestLoadExisting:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("enter")  # Load
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Load (index 2)
+                await pilot.press("enter")
                 await pilot.pause()
                 await pilot.press("enter")  # select alpha
                 await pilot.pause()
@@ -125,7 +129,9 @@ class TestLoadExisting:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("enter")  # Load
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Load (index 2)
+                await pilot.press("enter")
                 await pilot.pause()
                 await pilot.press("enter")  # try to load 'broken'
                 await pilot.pause()
@@ -140,7 +146,9 @@ class TestLoadExisting:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("enter")  # Load
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Load (index 2)
+                await pilot.press("enter")
                 await pilot.pause()
                 await pilot.pause()  # let _rerender mount() complete
                 screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
@@ -155,14 +163,16 @@ class TestLoadExisting:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("enter")  # Load
+                await pilot.press("down")
+                await pilot.press("down")  # cursor → Load (index 2)
+                await pilot.press("enter")
                 await pilot.pause()
                 await pilot.press("escape")
                 await pilot.pause()
                 screen: LaunchScreen = pilot.app.screen  # type: ignore[assignment]
                 assert screen.mode == "home"
                 assert [e.label for e in screen.entries] == [
-                    "Load existing fleet", "New fleet", "Quick local run",
+                    "Quick local run", "New fleet", "Load existing fleet",
                 ]
 
         asyncio.run(_run())
@@ -176,7 +186,7 @@ class TestNewFleet:
             async with HermiaApp().run_test() as pilot:
                 # Mutate config first so we can prove New resets it.
                 pilot.app.config.name = "stale"
-                await pilot.press("down")  # cursor → New
+                await pilot.press("down")  # cursor → New (index 1)
                 await pilot.press("enter")
                 await pilot.pause()
                 assert pilot.app.config.name == ""
@@ -193,9 +203,7 @@ class TestQuickLocalRun:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                await pilot.press("down")
-                await pilot.press("down")  # cursor → Quick
-                await pilot.press("enter")
+                await pilot.press("enter")  # Quick local run is index 0
                 await pilot.pause()
                 cfg = pilot.app.config
                 assert cfg.name == "quick-local"

--- a/tests/unit/tui/screens/test_runner_trials.py
+++ b/tests/unit/tui/screens/test_runner_trials.py
@@ -1,7 +1,6 @@
 """Tests for RunnerTrialsScreen (L2 trial table)."""
 import asyncio
 from io import StringIO
-from unittest.mock import MagicMock
 
 from rich.console import Console
 from textual.widgets import Footer
@@ -185,7 +184,8 @@ class TestRowText:
 
     def _render(self, text: str) -> str:
         buf = StringIO()
-        Console(file=buf, markup=True, no_color=True, highlight=False, width=200).print(text, end="")
+        console = Console(file=buf, markup=True, no_color=True, highlight=False, width=200)
+        console.print(text, end="")
         return buf.getvalue()
 
     def test_failure_reason_rich_style_name_survives_rendering(self) -> None:

--- a/tests/unit/tui/screens/test_runner_trials.py
+++ b/tests/unit/tui/screens/test_runner_trials.py
@@ -1,11 +1,14 @@
 """Tests for RunnerTrialsScreen (L2 trial table)."""
 import asyncio
+from io import StringIO
+from unittest.mock import MagicMock
 
+from rich.console import Console
 from textual.widgets import Footer
 
 from hermia.tui.app import HermiaApp
 from hermia.tui.screens.runner import RunnerScreen
-from hermia.tui.screens.runner_trials import RunnerTrialsScreen
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen, _TrialRow
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
 
@@ -170,6 +173,46 @@ class TestRunnerTrialsScreenNavigation:
                 assert isinstance(pilot.app.screen, RunnerDetailScreen)
 
         asyncio.run(_run())
+
+
+class TestRowText:
+    def _make_screen(self) -> RunnerTrialsScreen:
+        host = Host(name="h", url="http://h:11434", engine="ollama", models=[])
+        screen = RunnerTrialsScreen.__new__(RunnerTrialsScreen)
+        screen._host = host
+        screen.cursor_idx = 0
+        return screen
+
+    def _render(self, text: str) -> str:
+        buf = StringIO()
+        Console(file=buf, markup=True, no_color=True, highlight=False, width=200).print(text, end="")
+        return buf.getvalue()
+
+    def test_failure_reason_rich_style_name_survives_rendering(self) -> None:
+        # _row_text wraps failure_reason in [...]. A reason equal to a Rich style
+        # name (e.g. "bold", "b", "red") produces "[bold]" in the row string, which
+        # Rich consumes as a markup tag — the reason disappears from the output.
+        # rich.markup.escape in _row_text prevents this.
+        screen = self._make_screen()
+        trial = _TrialRow(
+            model_name="m", test_id="t1", repeat_idx=1,
+            state="error", failure_reason="bold",
+        )
+        row = screen._row_text(trial, 0)
+        rendered = self._render(row)
+        assert "bold" in rendered
+
+    def test_failure_reason_with_inner_brackets_survives_rich_rendering(self) -> None:
+        # failure_reason containing brackets (e.g. from Go panic messages:
+        # "index out of range [5]") must appear intact in the rendered row.
+        screen = self._make_screen()
+        trial = _TrialRow(
+            model_name="llama3.2", test_id="t1", repeat_idx=1,
+            state="error", failure_reason="TIMEOUT: no response in [120s]",
+        )
+        row = screen._row_text(trial, 0)
+        rendered = self._render(row)
+        assert "TIMEOUT: no response in [120s]" in rendered
 
 
 class TestRunnerTrialsFooter:

--- a/tests/unit/tui/test_picker_e2e.py
+++ b/tests/unit/tui/test_picker_e2e.py
@@ -85,8 +85,8 @@ class TestPickerE2E:
     def test_quick_local_flow_ends_in_config_screen_with_pre_populated_config(self) -> None:
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                # Launch → Quick local run (third entry).
-                await pilot.press("down", "down", "enter")
+                # Launch → Quick local run (first entry).
+                await pilot.press("enter")
                 await pilot.pause()
                 assert isinstance(pilot.app.screen, FleetConfigScreen)
                 cfg = pilot.app.config
@@ -110,8 +110,8 @@ class TestPickerE2E:
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:
-                # Launch → Load existing (first entry) → enter on the only fleet.
-                await pilot.press("enter")
+                # Launch → Load existing (third entry) → enter on the only fleet.
+                await pilot.press("down", "down", "enter")
                 await pilot.pause()
                 await pilot.press("enter")
                 await pilot.pause()

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -262,6 +262,50 @@ class TestTuiRunnerBusEvents:
 
         asyncio.run(_run())
 
+    def test_stalled_trial_times_out_and_publishes_error_verdict(self) -> None:
+        """A run_fn that stalls beyond trial_timeout must resolve as error, not hang."""
+        import threading
+
+        async def _run() -> None:
+            bus = SessionBus()
+            finished: list[dict] = []
+            unblock = threading.Event()
+
+            def stall_fn(model_name, test, *, host, engine, auth_env):
+                # Blocks until unblock is set — simulates Ollama stall.
+                unblock.wait(timeout=10)
+                return {
+                    "model": model_name, "test_id": test["id"],
+                    "failure_reason": "", "elapsed_sec": 0.0, "output_preview": "", "signals": {},
+                }
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.trial_finished"):
+                    finished.append(ev)
+                    return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)
+
+            config = _make_config()
+            runner = TuiRunner(
+                config=config,
+                bus=bus,
+                results_dir=None,
+                run_test_fn=stall_fn,
+                _tests_override=[{"id": "t1"}],
+                trial_timeout=0.05,
+            )
+            await runner.start()
+            # Should resolve within a short window — trial_timeout=0.05s + slack.
+            await asyncio.wait_for(task, timeout=3.0)
+            unblock.set()  # release the stalled thread
+
+            assert finished[0]["verdict"] == "error"
+            assert "TIMEOUT" in finished[0]["failure_reason"]
+
+        asyncio.run(_run())
+
     def test_error_result_publishes_error_verdict(self) -> None:
         async def _run() -> None:
             bus = SessionBus()


### PR DESCRIPTION
## Summary

- **UX pass** (`cde9494`): LaunchScreen reorder + per-entry descriptions, FleetConfigScreen 3-step instruction block + binding visibility, HostsScreen/HostModelsScreen/TestsScreen instruction blocks + binding visibility, RunnerTrialsScreen icon legend. Probe selection fix in `probe.py` (hermia-cdt): preserve `existing_selected` before overwriting `host.models` on re-probe.
- **Trial hang timeout** (hermia-w0i): `runner_backend._run_trial` now wraps `asyncio.to_thread` in `asyncio.wait_for(timeout=120s)`. A stalled Ollama mid-response no longer freezes a trial row on ▶ indefinitely.
- **Rich markup escape** (hermia-d9f): `RunnerTrialsScreen._row_text` uses `rich.markup.escape` on the full `[failure_reason]` bracket expression. A reason equal to a Rich style name (e.g. `bold`) was silently consumed as markup.

## Test plan

- [ ] 1715 tests passing (`pytest`)
- [ ] `ruff check src/` clean
- [ ] `mypy src/ --ignore-missing-imports` clean
- [ ] Trial hang: confirm `TRIAL_WALL_TIMEOUT=120s` constant injectable for tests; `test_runner_backend.py` covers the timeout path
- [ ] Markup escape: `TestRowText` covers `failure_reason="bold"` (Rich style name) and bracket-in-reason cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 120-second trial timeout to prevent test runs from hanging indefinitely during stalls

* **Bug Fixes**
  * Fixed model selections being lost when hosts are re-probed

* **Improved User Experience**
  * Added on-screen instructions and step-by-step navigation guidance across all screens
  * Made keyboard shortcuts and help text visible for better discoverability
  * Enhanced interface with visual legends and help panels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->