### PR TITLE
fix: TUI fleet YAML compat + probe subscription race (hermia-7ao, hermia-izi)

### DIFF
--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -61,7 +61,8 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
         raw = data.get("fleet") if isinstance(data, dict) else None
         entries = raw if isinstance(raw, list) else None
     if not isinstance(entries, list) or not entries:
-        key_name = "hosts" if isinstance(data, dict) and "hosts" in data and "fleet" not in data else "fleet"
+        is_tui_fmt = isinstance(data, dict) and "hosts" in data and "fleet" not in data
+        key_name = "hosts" if is_tui_fmt else "fleet"
         raise ValueError(f"Fleet config must contain at least one entry under '{key_name}'")
     for i, entry in enumerate(entries):
         if not isinstance(entry, dict):

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -11,8 +11,39 @@ from typing import Any
 import yaml
 
 
+def _tui_fleet_to_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert TUI save_fleet format to headless fleet entries.
+
+    TUI writes: hosts[]{name, url, engine, auth_header_env?, hardware?, models[]}
+    Headless expects: fleet[]{name, host, transport?, auth.bearer.key_env?, models?}
+    """
+    entries = []
+    for h in (data.get("hosts") or []):
+        if not isinstance(h, dict):
+            raise ValueError(
+                f"TUI fleet 'hosts' entry must be a mapping, got {type(h).__name__}"
+            )
+        entry: dict[str, Any] = {
+            "name": h.get("name"),
+            "host": h.get("url"),
+            "transport": h.get("engine", "ollama"),
+        }
+        if h.get("auth_header_env"):
+            entry["auth"] = {"bearer": {"key_env": h["auth_header_env"]}}
+        if h.get("models"):
+            entry["models"] = h["models"]
+        if h.get("stack"):
+            entry["stack"] = h["stack"]
+        entries.append(entry)
+    return entries
+
+
 def load_fleet_config(path: Path) -> list[dict[str, Any]]:
-    """Parse fleet YAML. Returns list of host entries. Raises ValueError on invalid config."""
+    """Parse fleet YAML. Returns list of host entries. Raises ValueError on invalid config.
+
+    Accepts both the headless format (fleet: key) and the TUI save_fleet format
+    (hosts: key) so fleets created in the TUI can be run headless without conversion.
+    """
     try:
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f)
@@ -20,7 +51,12 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
         raise ValueError(f"Cannot read fleet config {path}: {exc}") from exc
     except yaml.YAMLError as exc:
         raise ValueError(f"Invalid YAML in fleet config {path}: {exc}") from exc
-    entries = data.get("fleet") if isinstance(data, dict) else None
+    entries: list[dict[str, Any]] | None
+    if isinstance(data, dict) and "hosts" in data and "fleet" not in data:
+        entries = _tui_fleet_to_entries(data)
+    else:
+        raw = data.get("fleet") if isinstance(data, dict) else None
+        entries = raw if isinstance(raw, list) else None
     if not isinstance(entries, list) or not entries:
         raise ValueError("Fleet config must contain at least one entry under 'fleet'")
     for i, entry in enumerate(entries):

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -17,8 +17,11 @@ def _tui_fleet_to_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
     TUI writes: hosts[]{name, url, engine, auth_header_env?, hardware?, models[]}
     Headless expects: fleet[]{name, host, transport?, auth.bearer.key_env?, models?}
     """
+    hosts = data.get("hosts")
+    if hosts is not None and not isinstance(hosts, list):
+        raise ValueError(f"TUI fleet 'hosts' must be a list, got {type(hosts).__name__}")
     entries = []
-    for h in (data.get("hosts") or []):
+    for h in (hosts or []):
         if not isinstance(h, dict):
             raise ValueError(
                 f"TUI fleet 'hosts' entry must be a mapping, got {type(h).__name__}"
@@ -58,7 +61,8 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
         raw = data.get("fleet") if isinstance(data, dict) else None
         entries = raw if isinstance(raw, list) else None
     if not isinstance(entries, list) or not entries:
-        raise ValueError("Fleet config must contain at least one entry under 'fleet'")
+        key_name = "hosts" if isinstance(data, dict) and "hosts" in data and "fleet" not in data else "fleet"
+        raise ValueError(f"Fleet config must contain at least one entry under '{key_name}'")
     for i, entry in enumerate(entries):
         if not isinstance(entry, dict):
             raise ValueError(f"Fleet entry [{i}] must be a mapping, got {type(entry).__name__}")

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -11,7 +11,7 @@ Both share app.bus — screens subscribe only to their own prefix.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 from textual import work
@@ -161,16 +161,22 @@ class HostsScreen(Screen[None]):
         and per-screen (listener tasks created once and reused, so
         re-firing _start_probes after add-host doesn't double-subscribe).
         """
-        # Subscribe first so events fired during probe_host land in queues.
-        # Listeners are screen-lifetime singletons — multiple _start_probes
-        # calls reuse the same subscribers (no duplicate event handling).
+        # Subscribe synchronously before spawning tasks so queues are registered
+        # with no race window. create_task() schedules but doesn't step the
+        # coroutine; anything published between create_task and the first sleep(0)
+        # would be lost if subscribe() were called inside the task.
         if not self._listener_tasks:
             self._listener_tasks = [
-                asyncio.create_task(self._listen("probe.started", "probing")),
-                asyncio.create_task(self._listen("probe.completed", "ok")),
-                asyncio.create_task(self._listen("probe.failed", "failed")),
+                asyncio.create_task(
+                    self._listen(self.app.bus.subscribe("probe.started"), "probing")  # type: ignore[attr-defined]
+                ),
+                asyncio.create_task(
+                    self._listen(self.app.bus.subscribe("probe.completed"), "ok")  # type: ignore[attr-defined]
+                ),
+                asyncio.create_task(
+                    self._listen(self.app.bus.subscribe("probe.failed"), "failed")  # type: ignore[attr-defined]
+                ),
             ]
-            await asyncio.sleep(0)  # give subscribers a tick to register
 
         # Resolve transport factory lazily so unit tests don't import urllib
         # paths unless a real probe runs.
@@ -209,8 +215,8 @@ class HostsScreen(Screen[None]):
             t.cancel()
         self.workers.cancel_all()
 
-    async def _listen(self, topic: str, final_state: str) -> None:
-        async for ev in self.app.bus.subscribe(topic):  # type: ignore[attr-defined]
+    async def _listen(self, gen: AsyncIterator[dict[str, Any]], final_state: str) -> None:
+        async for ev in gen:
             self.probe_state[ev["host_name"]] = final_state
             if self.is_mounted:
                 self._rerender()

--- a/src/hermia/tui/screens/hosts.py
+++ b/src/hermia/tui/screens/hosts.py
@@ -165,7 +165,10 @@ class HostsScreen(Screen[None]):
         # with no race window. create_task() schedules but doesn't step the
         # coroutine; anything published between create_task and the first sleep(0)
         # would be lost if subscribe() were called inside the task.
-        if not self._listener_tasks:
+        if not self._listener_tasks or any(t.done() for t in self._listener_tasks):
+            for t in self._listener_tasks:
+                if not t.done():
+                    t.cancel()
             self._listener_tasks = [
                 asyncio.create_task(
                     self._listen(self.app.bus.subscribe("probe.started"), "probing")  # type: ignore[attr-defined]

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -699,6 +699,100 @@ def test_run_fleet_zero_models_counts_as_skipped(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# hermia-7ao: load_fleet_config must accept TUI-saved fleet YAML
+# ---------------------------------------------------------------------------
+
+
+def test_load_fleet_config_accepts_tui_format(tmp_path: Path) -> None:
+    """load_fleet_config must accept TUI-saved YAML (hosts:/url:/engine: schema).
+
+    TUI's save_fleet writes a different schema than the headless runner expects:
+      - key 'hosts' (not 'fleet')
+      - field 'url' (not 'host')
+      - field 'engine' (not 'transport')
+      - auth as flat 'auth_header_env' (not nested auth.bearer.key_env)
+
+    Users who create fleets in the TUI and try to run them headless get:
+      ValueError: Fleet config must contain at least one entry under 'fleet'
+    """
+    from hermia.tui.fleet_io import save_fleet
+    from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+    config = FleetConfig(
+        name="kwaainet-baseline",
+        hosts=[
+            Host(
+                name="eric-5090",
+                url="https://eric:11434",
+                engine="ollama",
+                models=[ModelChoice(name="qwen3:32b", selected=True)],
+            )
+        ],
+        tests=["prompt-injection-1"],
+        repeat=2,
+    )
+    yaml_path = save_fleet(config, root=tmp_path)
+
+    entries = load_fleet_config(yaml_path)
+
+    assert len(entries) == 1
+    assert entries[0]["name"] == "eric-5090"
+    assert entries[0]["host"] == "https://eric:11434"
+    assert entries[0].get("transport", "ollama") == "ollama"
+
+
+def test_load_fleet_config_tui_format_with_auth(tmp_path: Path) -> None:
+    """TUI-saved auth_header_env maps to the headless auth.bearer.key_env structure."""
+    from hermia.tui.fleet_io import save_fleet
+    from hermia.tui.state import FleetConfig, Host
+
+    config = FleetConfig(
+        name="secured",
+        hosts=[
+            Host(
+                name="gateway",
+                url="https://gw:4000",
+                engine="openai-compat",
+                auth_header_env="LITELLM_KEY",
+            )
+        ],
+    )
+    yaml_path = save_fleet(config, root=tmp_path)
+
+    entries = load_fleet_config(yaml_path)
+
+    assert entries[0]["auth"]["bearer"]["key_env"] == "LITELLM_KEY"
+    assert entries[0].get("transport", "ollama") == "openai-compat"
+
+
+def test_load_fleet_config_tui_format_preserves_model_list(tmp_path: Path) -> None:
+    """TUI-saved selected models are preserved as a list when loaded headless."""
+    from hermia.tui.fleet_io import save_fleet
+    from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+    config = FleetConfig(
+        name="models-test",
+        hosts=[
+            Host(
+                name="node",
+                url="http://node:11434",
+                engine="ollama",
+                models=[
+                    ModelChoice(name="qwen3:32b", selected=True),
+                    ModelChoice(name="llama3:8b", selected=True),
+                    ModelChoice(name="unused", selected=False),
+                ],
+            )
+        ],
+    )
+    yaml_path = save_fleet(config, root=tmp_path)
+
+    entries = load_fleet_config(yaml_path)
+
+    assert entries[0]["models"] == ["qwen3:32b", "llama3:8b"]
+
+
 def test_load_fleet_config_transport_default(tmp_path: Path) -> None:
     """No transport field → loads without error; default resolves to 'ollama'."""
     cfg = tmp_path / "fleet.yaml"

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -200,6 +200,131 @@ class TestHostsScreenBusMigration:
         asyncio.run(_run())
 
 
+class TestSubscriptionRace:
+    """hermia-izi: probe subscriptions must be registered before probes fire.
+
+    SessionBus.subscribe() is synchronous — it appends the queue to _subscribers
+    immediately. But _listen() calls subscribe() *inside* a task created with
+    create_task(). Tasks don't step until the event loop yields (sleep(0)), so
+    there's a race window between create_task() and the first sleep(0): if a probe
+    publishes an event in that window the event is lost.
+
+    Fix: call bus.subscribe() synchronously before create_task() and pass the
+    pre-created generator to the listener task, eliminating the race window.
+    """
+
+    def test_subscribe_inside_task_not_registered_until_task_steps(self) -> None:
+        """Demonstrates the race: subscribe() called inside a create_task coroutine
+        is NOT registered until the event loop steps that task (after sleep(0)).
+        This is the window in which a probe.* publish would be lost."""
+        import asyncio
+
+        from hermia.tui.bus import SessionBus
+
+        async def _run() -> None:
+            bus = SessionBus()
+
+            async def listener() -> None:
+                async for _ in bus.subscribe("probe.completed"):
+                    break
+
+            task = asyncio.create_task(listener())
+            # Race window: task scheduled but not yet stepped — no subscriber yet.
+            assert "probe.completed" not in bus._subscribers, (
+                "subscription must not exist before the task steps"
+            )
+
+            await asyncio.sleep(0)  # step the task
+            assert "probe.completed" in bus._subscribers, (
+                "subscription must exist after the task steps"
+            )
+
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+
+    def test_subscribe_before_create_task_registers_immediately(self) -> None:
+        """The fix: call subscribe() synchronously BEFORE create_task so the
+        subscription is registered with no race window."""
+        import asyncio
+
+        from hermia.tui.bus import SessionBus
+
+        async def _run() -> None:
+            bus = SessionBus()
+
+            # Subscribe synchronously — registration is immediate.
+            gen = bus.subscribe("probe.completed")
+            assert "probe.completed" in bus._subscribers, (
+                "subscription must be registered synchronously before create_task"
+            )
+
+            async def listener() -> None:
+                async for _ in gen:
+                    break
+
+            task = asyncio.create_task(listener())
+            # Still registered — no race window.
+            assert "probe.completed" in bus._subscribers
+
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+
+    def test_all_three_probe_topics_subscribed_before_probes_fire(self) -> None:
+        """Integration: when the first probe event hits the bus, all 3 probe
+        topics must already have subscribers — no event should be lost."""
+        import asyncio
+
+        from tests.fixtures.fake_transport import FakeTransport
+
+        from hermia.tui.app import HermiaApp
+        from hermia.tui.screens.hosts import HostsScreen
+        from hermia.tui.state import Host
+
+        async def _run() -> None:
+            async with HermiaApp().run_test() as pilot:
+                pilot.app.config.hosts = [
+                    Host(name="h1", url="http://h1", engine="ollama"),
+                ]
+                subscribed_at_first_publish: set[str] = set()
+
+                original_publish = pilot.app.bus.publish
+
+                async def spy_publish(topic: str, event: dict) -> None:
+                    if topic.startswith("probe.") and not subscribed_at_first_publish:
+                        subscribed_at_first_publish.update(pilot.app.bus._subscribers.keys())
+                    await original_publish(topic, event)
+
+                pilot.app.bus.publish = spy_publish  # type: ignore[method-assign]
+
+                screen = HostsScreen(
+                    transport_factory=lambda h: FakeTransport(models=[]),
+                    probe_timeout=2.0,
+                )
+                pilot.app.push_screen(screen)
+
+                for _ in range(30):
+                    if subscribed_at_first_publish:
+                        break
+                    await pilot.pause()
+
+                assert subscribed_at_first_publish, "no probe events published"
+                assert "probe.started" in subscribed_at_first_publish
+                assert "probe.completed" in subscribed_at_first_publish
+                assert "probe.failed" in subscribed_at_first_publish
+
+        asyncio.run(_run())
+
+
 class TestHostsFooter:
     def test_footer_present(self) -> None:
         async def _run() -> None:

--- a/tests/unit/tui/screens/test_hosts.py
+++ b/tests/unit/tui/screens/test_hosts.py
@@ -284,11 +284,10 @@ class TestSubscriptionRace:
         topics must already have subscribers — no event should be lost."""
         import asyncio
 
-        from tests.fixtures.fake_transport import FakeTransport
-
         from hermia.tui.app import HermiaApp
         from hermia.tui.screens.hosts import HostsScreen
         from hermia.tui.state import Host
+        from tests.fixtures.fake_transport import FakeTransport
 
         async def _run() -> None:
             async with HermiaApp().run_test() as pilot:


### PR DESCRIPTION
## Summary

- **hermia-7ao** — `load_fleet_config` now accepts TUI-saved YAML via `_tui_fleet_to_entries` bridge. Maps `hosts→fleet`, `url→host`, `engine→transport`, `auth_header_env→auth.bearer.key_env`. Detected by `"hosts" in data and "fleet" not in data` guard. Fixes the crash when users create a fleet in the TUI and try to run headless.
- **hermia-izi** — `_start_probes` calls `bus.subscribe()` synchronously before `create_task`, passing the pre-created async generator to `_listen`. Eliminates the race window between task creation and first event-loop yield where probe events could be silently lost.

## Test plan

- [ ] `pytest tests/unit/test_fleet.py` — 3 new TUI-format round-trip tests (auth, model list, basic)
- [ ] `pytest tests/unit/tui/screens/test_hosts.py` — 3 new `TestSubscriptionRace` tests demonstrating the before/after race behavior plus an integration spy test
- [ ] All 72 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fleet configuration now supports TUI “save_fleet” YAML shaped as `hosts[]`, including mapping `url`/`engine` and translating optional auth and model selections.

* **Bug Fixes**
  * Fixed a race in the hosts screen probe event handling to prevent missed `probe.*` events by ensuring subscribers are registered before probe tasks start.

* **Tests**
  * Added unit and TUI host screen tests covering TUI fleet YAML compatibility and subscription timing for probe events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->