### PR TITLE
docs(v0.2.0): bring README + usage to v0.2 reality, add 5-minute getting-started (hermia-6ce + hermia-1pj docs half)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,10 +166,10 @@
         "filename": "docs/usage.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 323,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-03T19:16:59Z"
+  "generated_at": "2026-06-30T02:41:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,10 +166,10 @@
         "filename": "docs/usage.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 326,
+        "line_number": 339,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-30T03:05:28Z"
+  "generated_at": "2026-06-30T06:58:49Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,10 +166,10 @@
         "filename": "docs/usage.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 344,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-30T06:58:49Z"
+  "generated_at": "2026-06-30T19:40:44Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,10 +166,10 @@
         "filename": "docs/usage.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 323,
+        "line_number": 326,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-30T02:41:38Z"
+  "generated_at": "2026-06-30T03:05:28Z"
 }

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ No cloud API keys required. No data leaves your machine.
 | Windows | Any | ❌ Not yet |
 
 *NVIDIA metrics tested on Linux eval client. Windows Ollama servers are supported as fleet
-targets via `--host`; running Hermia itself on Windows is not yet supported.
+targets (point a fleet YAML entry's `host:` at the Windows box); running Hermia itself on
+Windows is not yet supported.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ benchmarking measures actual model load time from a clean VRAM state, not cached
 Because "how fast is it really" is a different question than "how fast is it after it's
 already warm."
 
-**v0.1 scope:** single-turn, deterministic structural eval against Ollama-compatible local
-endpoints. Nuanced intent evaluation and multi-turn support land in v0.3.
+**v0.2 scope:** deterministic structural eval against Ollama-compatible local endpoints,
+with deterministic multi-turn corpus cases for context-carry and boundary-persistence
+testing. LLM-as-judge intent scoring lands in v0.3.
 
 **Fleet mode** (`--fleet FILE`) runs headless multi-host eval from a YAML config — same
 test suite, multiple Ollama endpoints evaluated **concurrently** (default: up to 4 hosts
 in parallel). Compare CUDA vs. Metal on the same model. See where your inference stack
 diverges. Entries that share the same host are evaluated sequentially so a single GPU
 node is never asked to hold two models simultaneously (VRAM-safe). Control parallelism
-with `--max-concurrency N`.
+with `--max-concurrency N`. Per-test timeout is configurable via `--test-timeout SECONDS`
+or per-host `test_timeout:` in the fleet YAML.
 
 ---
 
@@ -174,9 +176,10 @@ and Postgres export.
 
 ## Roadmap
 
-**v0.2 — Endpoint Bus** (target ~2026-06-15): Hermia evaluates anything that speaks
-OpenAI-compatible — LiteLLM, OpenAI, Anthropic, Google, Bedrock, plus local Ollama. Fleet
-config file for multi-host runs; backend stack tagging by GPU arch and runtime version.
+**v0.2 — Fleet + TUI** (shipping): Headless fleet mode for multi-host eval from a YAML
+config; full-featured TUI for launch/configure/run/inspect; backend stack tagging by GPU
+arch, runtime version, and execution path (GPU vs spill). Configurable per-test timeout
+for thinking-mode models.
 
 **v0.3 — Eval Bus** (target ~2026-08): Hermia becomes the platform other tools build into.
 Probe adapters for Garak, PyRIT, and HarmBench pull their results into Hermia's
@@ -189,10 +192,11 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 ## Project Status
 
-**v0.1.1** — stable and tested. The core eval suite, fleet mode, audit trail, and findings
-analysis pipeline are all shipping. The security pipeline (gitleaks, trivy, bandit,
-pip-audit, ruff, mypy) is more rigorous than a research tool strictly needs to be. That
-was intentional.
+**v0.2.0** — stable and tested. The core eval suite, fleet mode, TUI, audit trail, and
+findings analysis pipeline are all shipping. Cross-stack reproducibility evidence
+(Metal × CUDA × ROCm) is captured in the n=3 dataset. The security pipeline (gitleaks,
+trivy, bandit, pip-audit, ruff, mypy) is more rigorous than a research tool strictly
+needs to be. That was intentional.
 
 Available on [PyPI](https://pypi.org/project/hermia/): `pipx install hermia`
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 **v0.2.0** — stable and tested. The core eval suite, fleet mode, TUI, audit trail, and
 findings analysis pipeline are all shipping. Cross-stack reproducibility evidence
-(Metal × CUDA × ROCm) is captured in the n=3 dataset. The security pipeline (gitleaks,
-trivy, bandit, pip-audit, ruff, mypy) is more rigorous than a research tool strictly
-needs to be. That was intentional.
+(Metal x CUDA x ROCm) is being captured in an n=3 dataset and will publish alongside the
+v0.2.0 release notes. The security pipeline (gitleaks, trivy, bandit, pip-audit, ruff,
+mypy) is more rigorous than a research tool strictly needs to be. That was intentional.
 
 Available on [PyPI](https://pypi.org/project/hermia/): `pipx install hermia`
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ Hermia opens a TUI. Select a model from the list, choose which eval dimensions t
 and press **Run**. Results appear live alongside system metrics. Each run writes
 `results/eval_TIMESTAMP.jsonl` and `results/eval_TIMESTAMP.csv`.
 
-See the [Getting Started Guide](docs/usage.md) for a full walkthrough: result
-interpretation, `--repeat N` consistency scoring, fleet mode, regression detection,
-and Postgres export.
+New here? [docs/getting-started.md](docs/getting-started.md) is the 5-minute
+zero-to-first-eval path.
+
+See [docs/usage.md](docs/usage.md) for the full reference: result interpretation,
+`--repeat N` consistency scoring, fleet mode, regression detection, and Postgres export.
 
 ---
 
@@ -213,8 +215,9 @@ The tool steals answers from the Oracle and tells you which one to trust.
 
 ## Documentation
 
-- [Getting Started Guide](docs/usage.md) — install, run, interpret results, fleet mode, Postgres export
-- [Roadmap](docs/roadmap.md) — v0.2 endpoint bus, v0.3 eval bus, full backlog
+- [Getting Started](docs/getting-started.md) — 5-minute zero-to-first-eval guide
+- [Usage Reference](docs/usage.md) — full walkthrough: install, run, interpret results, fleet mode, regression detection, Postgres export
+- [Roadmap](docs/roadmap.md) — v0.2 fleet + TUI, v0.3 eval bus, full backlog
 - [GUARDS Framework](docs/GUARDS.md) — six-dimension standard for LLM system-prompt guardrail construction (Goal/Unit/Actions/Response/Detect/Stop)
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,136 @@
+# Getting Started with Hermia
+
+Zero to your first eval in under 5 minutes. No accounts, no cloud, no API keys.
+
+This guide is the fastest path. For the full reference (fleet mode, regression
+detection, Postgres export, result schema) see [usage.md](usage.md).
+
+---
+
+## 1. Install Ollama
+
+Hermia evaluates models served by [Ollama](https://ollama.ai). Install it first.
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+**macOS (alternative):** download the installer from [ollama.com/download](https://ollama.com/download).
+
+**Windows:** download the installer from [ollama.com/download](https://ollama.com/download). Hermia runs against Ollama on Windows as a fleet target, but running Hermia itself on Windows is not yet supported.
+
+---
+
+## 2. Start Ollama and pull a model
+
+```bash
+ollama serve &        # start the daemon in the background
+ollama pull llama3.2  # ~2 GB; takes a minute on a decent connection
+```
+
+`llama3.2` is the recommended starter model: small, fast, runs on a laptop CPU
+if you have no GPU. Pull whatever else you want to test the same way:
+`ollama pull qwen2.5:7b`, `ollama pull mistral:7b`, etc.
+
+Confirm it landed:
+
+```bash
+ollama list
+```
+
+You should see `llama3.2:latest` in the output.
+
+---
+
+## 3. Install Hermia
+
+Recommended (isolated install via [pipx](https://pipx.pypa.io)):
+
+```bash
+pipx install hermia
+```
+
+Or with pip:
+
+```bash
+pip install hermia
+```
+
+Confirm the install:
+
+```bash
+hermia --version
+```
+
+---
+
+## 4. Run your first eval
+
+Launch Hermia:
+
+```bash
+hermia
+```
+
+You land on the **LaunchScreen**. Three entries:
+
+- **Quick local run** — pre-fills a fleet pointed at your local Ollama with the full default test set
+- **Load existing fleet** — for saved YAML configs (you don't have any yet)
+- **New fleet** — for building a multi-host config from scratch
+
+Press **↓** to highlight **Quick local run**, then **Enter**.
+
+Hermia drops into the **FleetConfigScreen** with a localhost entry pre-filled.
+You'll see five rows — hosts, models, tests, name, options. Press **r** to run.
+
+The runner shows a live three-level drill view:
+
+- **L1** — aggregate pass/fail/running counts per host
+- **L2** — per-trial table for one host (press Enter on the host to drill in)
+- **L3** — full prompt and model output for one trial (press Enter on a trial)
+
+**Esc** walks back up. **q** quits.
+
+---
+
+## 5. Find your results
+
+Each run writes two files to `results/` in your current directory:
+
+```
+results/eval_TIMESTAMP.jsonl  # one row per trial, full metrics
+results/eval_TIMESTAMP.csv    # same rows, spreadsheet-friendly
+```
+
+Open the CSV in a spreadsheet to see at a glance: per-model pass rates, t/s
+throughput, failure reasons. The JSONL has the full raw_prompt, raw_response,
+and stack fingerprint per trial for audit purposes.
+
+---
+
+## What's next
+
+- **More models?** Run `ollama pull <name>` for each, then re-run Hermia — they'll show up automatically on the next launch.
+- **Multi-host?** See [Multi-host fleet mode](usage.md#multi-host-fleet-mode---fleet) in usage.md.
+- **Track behavior over time?** See [Regression detection](usage.md#regression-detection) in usage.md.
+- **Long-term storage?** See [Postgres export](usage.md#postgres-export) in usage.md.
+
+---
+
+## Troubleshooting
+
+**No models listed in the TUI** — Ollama isn't running, or you haven't pulled a
+model. Run `ollama serve` in another terminal, `ollama pull llama3.2`, and
+relaunch Hermia.
+
+**`hermia: command not found`** — `pipx` installs to `~/.local/bin` by default;
+make sure that's on your `PATH`. `pipx ensurepath` will fix it.
+
+**`Connection refused` against localhost:11434** — Ollama isn't running. Start
+it with `ollama serve`.
+
+**Tests timing out** — Larger / thinking-mode models (e.g. `qwen3:32b`,
+`deepseek-r1`) need more than the default 90-second per-test budget. Bump it
+with `--test-timeout 180` or set `test_timeout: 180` in the fleet YAML.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,9 +115,9 @@ and stack fingerprint per trial for audit purposes.
 ## What's next
 
 - **More models?** Run `ollama pull <name>` for each, then re-run Hermia — they'll show up automatically on the next launch.
-- **Multi-host?** See [Multi-host fleet mode](usage.md#multi-host-fleet-mode--fleet) in usage.md.
+- **Multi-host?** See [Multi-host fleet mode](usage.md#multi-host-fleet-mode---fleet) in usage.md.
 - **Track behavior over time?** See [Regression detection](usage.md#regression-detection) in usage.md.
-- **Long-term storage?** See [Postgres export](usage.md#postgres-export) in usage.md.
+- **Long-term storage?** See [Export to Postgres](usage.md#export-to-postgres) in usage.md.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,8 @@ curl -fsSL https://ollama.com/install.sh | sh
 ## 2. Start Ollama and pull a model
 
 ```bash
-ollama serve &        # start the daemon in the background
-ollama pull llama3.2  # ~2 GB; takes a minute on a decent connection
+ollama serve > /dev/null 2>&1 &   # start the daemon in the background, log to /dev/null
+ollama pull llama3.2              # ~2 GB; takes a minute on a decent connection
 ```
 
 `llama3.2` is the recommended starter model: small, fast, runs on a laptop CPU
@@ -99,7 +99,7 @@ The runner shows a live three-level drill view:
 
 Each run writes two files to `results/` in your current directory:
 
-```
+```text
 results/eval_TIMESTAMP.jsonl  # one row per trial, full metrics
 results/eval_TIMESTAMP.csv    # same rows, spreadsheet-friendly
 ```
@@ -113,7 +113,7 @@ and stack fingerprint per trial for audit purposes.
 ## What's next
 
 - **More models?** Run `ollama pull <name>` for each, then re-run Hermia — they'll show up automatically on the next launch.
-- **Multi-host?** See [Multi-host fleet mode](usage.md#multi-host-fleet-mode---fleet) in usage.md.
+- **Multi-host?** See [Multi-host fleet mode](usage.md#multi-host-fleet-mode--fleet) in usage.md.
 - **Track behavior over time?** See [Regression detection](usage.md#regression-detection) in usage.md.
 - **Long-term storage?** See [Postgres export](usage.md#postgres-export) in usage.md.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,16 +74,18 @@ Launch Hermia:
 hermia
 ```
 
-You land on the **LaunchScreen**. Three entries:
+You land on the **LaunchScreen**. Three entries (in this order):
 
 - **Quick local run** — pre-fills a fleet pointed at your local Ollama with the full default test set
-- **Load existing fleet** — for saved YAML configs (you don't have any yet)
 - **New fleet** — for building a multi-host config from scratch
+- **Load existing fleet** — for saved YAML configs (you don't have any yet)
 
-Press **↓** to highlight **Quick local run**, then **Enter**.
+Press **Enter** with the cursor on **Quick local run** (the default).
 
 Hermia drops into the **FleetConfigScreen** with a localhost entry pre-filled.
-You'll see five rows — hosts, models, tests, name, options. Press **r** to run.
+You'll see two rows — **Hosts** and **Tests**. Press **Enter** on Hosts to drill
+into the per-host model picker; **Esc** brings you back. Press **r** to start
+the run.
 
 The runner shows a live three-level drill view:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,14 @@
 # Hermia Roadmap
 
 **Status:** Living document. Updated as decisions change.
-**Last revised:** 2026-05-10
+**Last revised:** 2026-05-10 — predates v0.2.0 cut
 **Owner:** @scottblydotcom
+
+> ⚠️ **This roadmap predates the v0.2.0 release.** Some v0.1 milestone planning
+> below (CLI shape, screen names, dates) is now historical, not current state.
+> The v0.2 deliverables described in [README.md](../README.md#roadmap) and
+> [docs/getting-started.md](getting-started.md) supersede the milestone tables
+> here. A post-v0.2 rewrite is tracked separately.
 
 This document is the strategic plan. Beads are the tactical execution. Each leaf entry below is shaped to map 1-to-1 to a `bd add` invocation when work begins. Don't pre-create beads — they go stale before you touch them.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,10 @@
-# Getting Started with Hermia
+# Hermia Usage Reference
 
-This guide walks you through installing Hermia, running your first eval, interpreting the
-results, and optionally exporting to Postgres for long-term tracking.
+This is the full reference: install, eval flow, result schema, repeat runs, fleet mode,
+regression detection, and Postgres export.
+
+> **Want the 5-minute version?** See [getting-started.md](getting-started.md) for the
+> minimal zero-to-first-eval path.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,8 +214,20 @@ server's** hardware via Ollama's `/api/ps` endpoint, not the eval client's idle 
 The local preflight check is bypassed — resource checks run on the server side.
 
 This works with any host accessible over the network: a bare Ollama server, a LiteLLM
-gateway (use its Ollama-compatible endpoint), or a remote lab machine. Add an `auth:`
-block for endpoints behind a bearer token.
+gateway (use its Ollama-compatible endpoint), or a remote lab machine. For endpoints
+behind a bearer token, add an `auth.bearer.key_env` block naming the env var that
+holds the token:
+
+```yaml
+fleet:
+  - name: remote-box
+    host: http://192.168.10.50:11434
+    auth:
+      bearer:
+        key_env: HERMIA_API_KEY   # bearer token read from $HERMIA_API_KEY at runtime
+    models:
+      - llama3.2:latest
+```
 
 ---
 
@@ -247,8 +259,9 @@ Use the identical host string for all entries on one box to keep them serialized
 
 **Per-test timeout for thinking-mode models.** Default test timeout is 90 seconds.
 Thinking models (qwen3 thinking variants, deepseek-r1) regularly need longer. Raise it
-with `--test-timeout SECONDS` or per-host `test_timeout:` in the fleet YAML (per-host
-wins over CLI; CLI wins over the 90s default):
+with `--test-timeout SECONDS` or per-host `test_timeout:` in the fleet YAML. Precedence:
+**CLI `--test-timeout` wins over per-host `test_timeout:`, which wins over the 90s
+default.**
 
 ```bash
 hermia --fleet fleets/heavy.yaml --test-timeout 180

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,10 @@ hermia --help
 Expected output:
 
 ```
-usage: hermia [-h] [--host HOST] [--repeat N]
+usage: hermia [-h] [--version] [--repeat N] [--fleet FILE] [--verbose | --quiet]
+              [--max-concurrency MAX_CONCURRENCY] [--test-timeout SECONDS]
+              [--audit [FILE]] [--audit-format {jsonl,html,spill}]
+              [--submit | --submit-dry-run]
 ```
 
 ---
@@ -51,41 +54,48 @@ Make sure Ollama is running and has at least one model pulled, then launch the T
 hermia
 ```
 
-### SelectionScreen
+### LaunchScreen
 
-Hermia opens the **SelectionScreen**. You'll see two columns:
+Hermia opens the **LaunchScreen** with three entries:
 
-- **Models** — all models currently available via `ollama list`, pre-checked
-- **Eval dimensions** — `security`, `tool-use`, `reasoning`, `constraint`, `routing`,
-  `memory`, `domain`, pre-checked
+- **Quick local run** — pre-fills a fleet with `localhost:11434` (engine: ollama) and the
+  full default test set, then jumps to the FleetConfigScreen so you can confirm or edit.
+- **Load existing fleet** — scans `fleets/*.yaml` and lists saved configs; Enter loads one.
+- **New fleet** — starts an empty FleetConfig.
 
-Use the checkboxes to select which models and dimensions to run. Press **Run** to start.
+Use ↑/↓ to navigate, Enter to select, `q` to quit.
 
-If no models appear, Ollama is not running or has no models pulled. Start it with
-`ollama serve` and pull a model with `ollama pull llama3.2`.
+### FleetConfigScreen
 
-### RunnerScreen
+The **FleetConfigScreen** is the central editor. Five rows (hosts, models, tests, name,
+options) each open a subscreen for inspection or edit. The footer shows the available
+bindings:
 
-The **RunnerScreen** shows a live feed as each test runs:
+- `e` — edit the focused row
+- `r` — run the eval against the current fleet config
+- `s` — save the fleet to `fleets/<name>.yaml`
+- `Esc` — back
 
-```
-Preflight  VRAM 18.2/18.2 GB free  RAM 10.4/18.0 GB free  Disk 124.3 GB free
-Cold-loading llama3.2...
+If no models appear when you open the Models row, Ollama is not running or has no models
+pulled. Start it with `ollama serve` and pull a model with `ollama pull llama3.2`.
 
-  ✅ security-direct-injection             42.3 t/s  GPU 82%  VRAM 4.2GB  CPU 18%
-  ✅ security-indirect-injection           39.1 t/s  GPU 79%  VRAM 4.2GB  CPU 16%
-  ⚠  tool-use-invalid-invocation          38.8 t/s  GPU 81%  VRAM 4.2GB  CPU 17%
-  ❌ reasoning-partial-failure             35.2 t/s  GPU 76%  VRAM 4.1GB  CPU 15%
-       output did not match expected schema
-```
+### RunnerScreen (L1) → RunnerTrialsScreen (L2) → RunnerDetailScreen (L3)
 
-Icons mean:
-- `✅` — JSON valid **and** schema compliant (full pass)
-- `⚠` — JSON valid but schema non-compliant (partial pass)
-- `❌` — JSON invalid or error (full fail); preview of the failure reason shown below
+When the run starts, Hermia drops into a three-level drill view:
 
-Per-test metrics: `t/s` = tokens per second, `GPU%` = peak GPU utilization,
-`VRAM` = peak VRAM used (GB), `CPU%` = peak CPU utilization.
+- **L1 — RunnerScreen** — aggregate per-host counts (passed / failed / running), updates
+  live as trials complete.
+- **L2 — RunnerTrialsScreen** — per-trial table for one host: model, test ID, status,
+  elapsed time, t/s.
+- **L3 — RunnerDetailScreen** — detail for one trial: full prompt, model output, parsed
+  fields, failure reason if any.
+
+Press Enter on a host to drill from L1 → L2, and Enter on a trial to drill L2 → L3.
+Esc walks back up.
+
+Each trial row carries: status (pass / fail), elapsed seconds, tokens/sec, and a short
+failure reason on fail. Detailed metrics (GPU%, VRAM, CPU%) are written to the result
+files; the live UI focuses on pass/fail and throughput.
 
 ### Summary
 
@@ -157,10 +167,11 @@ Each result row contains:
 ## Repeat runs and consistency scoring
 
 Use `--repeat N` to run each (model, test) pair N times. This enables consistency scoring
-and cold-vs-warm delta measurement:
+and cold-vs-warm delta measurement. `--repeat` requires `--fleet` (it is a headless-only
+flag):
 
 ```bash
-hermia --repeat 5
+hermia --fleet fleets/quick-local.yaml --repeat 5
 ```
 
 Additional fields populated when `--repeat N > 1`:
@@ -179,18 +190,29 @@ reward-hacking — it passes sometimes and fails sometimes on the same input.
 
 ## Run against a remote Ollama host
 
-Use `--host` to target any Ollama-compatible endpoint instead of localhost:
+To target a remote Ollama-compatible endpoint, define it in a fleet YAML and run
+headless. A single-host fleet is the supported equivalent of the old `--host` flag:
 
-```bash
-hermia --host http://192.168.10.50:11434
+```yaml
+# fleets/remote.yaml
+fleet:
+  - name: remote-box
+    host: http://192.168.10.50:11434
+    models:
+      - llama3.2:latest
 ```
 
-In fleet mode (any non-localhost host), local hardware metrics (GPU%, VRAM, CPU%) reflect
-the **inference server's** hardware via Ollama's `/api/ps` endpoint, not the eval client's
-idle laptop. The preflight check is also bypassed — resource checks run on the server side.
+```bash
+hermia --fleet fleets/remote.yaml
+```
+
+For any non-localhost host, hardware metrics (GPU%, VRAM, CPU%) reflect the **inference
+server's** hardware via Ollama's `/api/ps` endpoint, not the eval client's idle laptop.
+The local preflight check is bypassed — resource checks run on the server side.
 
 This works with any host accessible over the network: a bare Ollama server, a LiteLLM
-gateway (in v0.1, use the Ollama-compatible endpoint), or a remote lab machine.
+gateway (use its Ollama-compatible endpoint), or a remote lab machine. Add an `auth:`
+block for endpoints behind a bearer token.
 
 ---
 
@@ -219,6 +241,24 @@ parallel up to `--max-concurrency`.
 point at the same physical machine via different addresses (e.g. `localhost` vs
 `127.0.0.1` vs its hostname), they will **not** be grouped and may run concurrently.
 Use the identical host string for all entries on one box to keep them serialized.
+
+**Per-test timeout for thinking-mode models.** Default test timeout is 90 seconds.
+Thinking models (qwen3 thinking variants, deepseek-r1) regularly need longer. Raise it
+with `--test-timeout SECONDS` or per-host `test_timeout:` in the fleet YAML (per-host
+wins over CLI; CLI wins over the 90s default):
+
+```bash
+hermia --fleet fleets/heavy.yaml --test-timeout 180
+```
+
+```yaml
+fleet:
+  - name: thinking-host
+    host: http://192.168.10.50:11434
+    test_timeout: 180
+    models:
+      - qwen3:32b
+```
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,17 +70,22 @@ Use ↑/↓ to navigate, Enter to select, `q` to quit.
 
 ### FleetConfigScreen
 
-The **FleetConfigScreen** is the central editor. Five rows (hosts, models, tests, name,
-options) each open a subscreen for inspection or edit. The footer shows the available
-bindings:
+The **FleetConfigScreen** is the central editor. Two rows — **Hosts** and **Tests** —
+each open a subscreen:
 
-- `e` — edit the focused row
-- `r` — run the eval against the current fleet config
+- **Hosts** → HostsScreen, where each host has its own model picker (HostModelsScreen)
+- **Tests** → TestsScreen, the 30-test corpus catalog
+
+Visible footer bindings:
+
+- `Enter` — open the focused row
 - `s` — save the fleet to `fleets/<name>.yaml`
+- `r` — run the eval against the current fleet config
 - `Esc` — back
 
-If no models appear when you open the Models row, Ollama is not running or has no models
-pulled. Start it with `ollama serve` and pull a model with `ollama pull llama3.2`.
+If no models appear on the per-host model picker, Ollama is not running on that host or
+has no models pulled. Start it with `ollama serve` and pull a model with
+`ollama pull llama3.2`. The hosts screen shows an actionable hint when this happens.
 
 ### RunnerScreen (L1) → RunnerTrialsScreen (L2) → RunnerDetailScreen (L3)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,12 +59,12 @@ hermia
 
 ### LaunchScreen
 
-Hermia opens the **LaunchScreen** with three entries:
+Hermia opens the **LaunchScreen** with three entries (in this order):
 
 - **Quick local run** — pre-fills a fleet with `localhost:11434` (engine: ollama) and the
   full default test set, then jumps to the FleetConfigScreen so you can confirm or edit.
-- **Load existing fleet** — scans `fleets/*.yaml` and lists saved configs; Enter loads one.
 - **New fleet** — starts an empty FleetConfig.
+- **Load existing fleet** — scans `fleets/*.yaml` and lists saved configs; Enter loads one.
 
 Use ↑/↓ to navigate, Enter to select, `q` to quit.
 


### PR DESCRIPTION
## Summary
Two of the v0.2.0 P1 docs items in one PR.

**Commit 6997427 — hermia-6ce: README + usage.md to v0.2 reality**
- README: v0.1 scope claim → v0.2 (corrects the multi-turn classification — the corpus *does* have deterministic multi-turn cases; what lands in v0.3 is LLM-as-judge intent scoring, not multi-turn); v0.2 roadmap entry now reflects what shipped (fleet mode, TUI, stack tagging, configurable per-test timeout) instead of the stale "target ~2026-06-15" date; Project Status v0.1.1 → v0.2.0
- usage.md: real \`--help\` output; rewrote "Run a local eval" to describe the actual LaunchScreen → FleetConfigScreen → drill-runner (L1/L2/L3) flow (the old SelectionScreen no longer exists); removed dead \`--host\` references (single-host fleet YAML now); corrected \`--repeat\` example (headless-only — requires \`--fleet\`); added \`--test-timeout\` documentation

**Commit 856295c — hermia-1pj (docs half): docs/getting-started.md**
- New 5-minute zero-to-first-eval guide: Ollama install → \`ollama pull llama3.2\` → \`pipx install hermia\` → Quick local run → results
- Cross-linked from README ("New here?" callout + Documentation list) and usage.md (top-of-file pointer)
- Single troubleshooting section covers the four most common first-run failures

The TUI empty-state half of hermia-1pj (probe-failed and no_models guidance in HostsScreen / HostModelsScreen / LaunchScreen) is code, not docs, and ships separately.

## Test plan
- [ ] Render README on github.com and confirm "New here?" callout + Documentation list look right
- [ ] Read docs/getting-started.md top to bottom; verify the install/pull/run sequence is correct
- [ ] Spot-check usage.md "Run a local eval" section matches what the TUI actually does on launch
- [ ] Confirm \`hermia --help\` output in usage.md matches current CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Getting Started” guide covering installation, the first TUI run, where results are saved, and common troubleshooting.
  * Refreshed the usage reference with expanded CLI help, clearer multi-level drill-down screens, updated fleet-mode repeat requirements, revised remote hosting guidance, and per-test “thinking-mode” timeout behavior (including precedence).
  * Updated the README for the current v0.2 scope, fleet concurrency defaults, roadmap updates, and revised version/status messaging.
* **Chores / Security**
  * Updated the recorded secrets-check baseline for the usage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->