### PR TITLE
feat(packaging): Docker image + ghcr.io publish workflow (hermia-rpx)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Keep the build context small. Anything not required at pip-install time
+# should be excluded — the wheel is built from pyproject + src/.
+.git
+.github
+.gitignore
+.venv
+venv
+env
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+coverage.xml
+coverage.html
+coverage.out
+
+# Local dev cruft
+.DS_Store
+.env
+.env.local
+.claude
+.beads
+results/
+fleets/
+session-notes/
+cmd/
+
+# Docs / plans — not needed to install the package
+docs/
+tests/
+
+# Editor
+.vscode
+.idea
+*.swp
+*.swo

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -34,26 +34,23 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Log in to ghcr.io
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
+      # Build locally first (load, don't push) so the image is fully
+      # verified before anything reaches the registry. push+load together
+      # in one build-push-action step is unreliable across buildx/driver
+      # versions, so publishing is a separate step after verification.
+      - name: Build (local only, verify before publishing)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: Dockerfile
-          push: true
+          push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke-test published image
+      - name: Smoke-test image
         env:
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
@@ -62,3 +59,53 @@ jobs:
           echo "Smoke-testing $IMAGE"
           docker run --rm "$IMAGE" --help | grep -q "hermia"
           docker run --rm "$IMAGE" --version | grep -qE "hermia [0-9]+\.[0-9]+\.[0-9]+"
+
+      - name: Verify non-root user
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
+          UID_OUT="$(docker run --rm --entrypoint id "$IMAGE" -u)"
+          test "$UID_OUT" = "1000"
+
+      - name: Smoke-test fleet-mode entrypoint
+        # Points at an unreachable host on purpose — run_fleet records
+        # per-host failures without raising, so this exercises the real
+        # config-parse + run + write-results path end to end.
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
+          mkdir -p /tmp/smoke-fleet /tmp/smoke-results
+          # Container writes as uid 1000, which won't generally match the
+          # runner's user — open the scratch dir up for this ephemeral CI
+          # smoke test only (not a pattern for real user-facing usage).
+          chmod 777 /tmp/smoke-results
+          cat > /tmp/smoke-fleet/smoke.yaml <<'EOF'
+          fleet:
+            - name: unreachable
+              host: http://127.0.0.1:1
+              transport: ollama
+          EOF
+          docker run --rm \
+            -v /tmp/smoke-fleet:/workspace/fleets:ro \
+            -v /tmp/smoke-results:/workspace/results \
+            "$IMAGE" --fleet fleets/smoke.yaml --quiet | grep -q "Saved:"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push verified image
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$IMAGE_TAGS" | while IFS= read -r tag; do
+            [ -n "$tag" ] && docker push "$tag"
+          done

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,64 @@
+name: Docker Release
+
+# Publish to ghcr.io on release tag pushes only (v*.*.*). Deliberately has
+# no `paths:` filter — path filters on tag-push events are not reliably
+# evaluated by GitHub the same way as branch pushes, and release publishing
+# is rare enough that always building on a tag push is the safer choice.
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/hermia
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test published image
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
+          echo "Smoke-testing $IMAGE"
+          docker run --rm "$IMAGE" --help | grep -q "hermia"
+          docker run --rm "$IMAGE" --version | grep -qE "hermia [0-9]+\.[0-9]+\.[0-9]+"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -33,7 +33,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
 
       - name: Log in to ghcr.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
@@ -48,6 +47,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,84 @@
+name: Docker Image
+
+# Build the image on every PR touching Docker/packaging bits (smoke-test only),
+# and publish to ghcr.io on release tag pushes (v*.*.*).
+on:
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - main
+      - dev
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - src/**
+      - .github/workflows/docker.yml
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - src/**
+      - .github/workflows/docker.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e15b46e7c7c9d6afc98da4ff0a45c4bd9436d8bd  # v3.4.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/hermia
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      # Login only when we intend to push (tag or protected-branch push).
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push on non-PR events)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c1c  # v6.18.0
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: ${{ github.event_name == 'pull_request' }}
+
+      - name: Smoke-test image
+        # `docker run hermia --help` must exit 0 and print the CLI usage.
+        # Uses the first tag emitted by metadata-action.
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          echo "Smoke-testing $IMAGE"
+          docker run --rm "$IMAGE" --help | grep -q "hermia"
+          docker run --rm "$IMAGE" --version | grep -qE "hermia [0-9]+\.[0-9]+\.[0-9]+"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,9 @@
 name: Docker Image
 
-# Build the image on every PR touching Docker/packaging bits (smoke-test only),
-# and publish to ghcr.io on release tag pushes (v*.*.*).
+# Build and smoke-test the image on PRs and branch pushes touching
+# Docker/packaging bits. Never publishes — see docker-release.yml for that.
 on:
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - main
       - dev
@@ -28,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout
@@ -47,31 +44,18 @@ jobs:
           tags: |
             type=ref,event=pr
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      # Only publish on release tag pushes (v*.*.*) — branch/PR events build
-      # and smoke-test but never push to the registry.
-      - name: Log in to ghcr.io
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build (and push on release tags only)
+      - name: Build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: Dockerfile
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          load: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Smoke-test image
         # `docker run hermia --help` must exit 0 and print the CLI usage.
@@ -84,3 +68,33 @@ jobs:
           echo "Smoke-testing $IMAGE"
           docker run --rm "$IMAGE" --help | grep -q "hermia"
           docker run --rm "$IMAGE" --version | grep -qE "hermia [0-9]+\.[0-9]+\.[0-9]+"
+
+      - name: Verify non-root user
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
+          UID_OUT="$(docker run --rm --entrypoint id "$IMAGE" -u)"
+          test "$UID_OUT" = "1000"
+
+      - name: Smoke-test fleet-mode entrypoint
+        # Points at an unreachable host on purpose — run_fleet records
+        # per-host failures without raising, so this exercises the real
+        # config-parse + run + write-results path end to end.
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
+          mkdir -p /tmp/smoke-fleet /tmp/smoke-results
+          cat > /tmp/smoke-fleet/smoke.yaml <<'EOF'
+          fleet:
+            - name: unreachable
+              host: http://127.0.0.1:1
+              transport: ollama
+          EOF
+          docker run --rm \
+            -v /tmp/smoke-fleet:/workspace/fleets:ro \
+            -v /tmp/smoke-results:/workspace/results \
+            "$IMAGE" --fleet fleets/smoke.yaml --quiet | grep -q "Saved:"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,6 +88,10 @@ jobs:
           set -euo pipefail
           IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
           mkdir -p /tmp/smoke-fleet /tmp/smoke-results
+          # Container writes as uid 1000, which won't generally match the
+          # runner's user — open the scratch dir up for this ephemeral CI
+          # smoke test only (not a pattern for real user-facing usage).
+          chmod 777 /tmp/smoke-results
           cat > /tmp/smoke-fleet/smoke.yaml <<'EOF'
           fleet:
             - name: unreachable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -52,33 +51,36 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      # Login only when we intend to push (tag or protected-branch push).
+      # Only publish on release tag pushes (v*.*.*) — branch/PR events build
+      # and smoke-test but never push to the registry.
       - name: Log in to ghcr.io
-        if: github.event_name != 'pull_request'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build (and push on non-PR events)
+      - name: Build (and push on release tags only)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          load: ${{ github.event_name == 'pull_request' }}
+          load: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Smoke-test image
         # `docker run hermia --help` must exit 0 and print the CLI usage.
         # Uses the first tag emitted by metadata-action.
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
-          IMAGE="$(printf '%s' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          IMAGE="$(printf '%s' "$IMAGE_TAGS" | head -n1)"
           echo "Smoke-testing $IMAGE"
           docker run --rm "$IMAGE" --help | grep -q "hermia"
           docker run --rm "$IMAGE" --version | grep -qE "hermia [0-9]+\.[0-9]+\.[0-9]+"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,14 +35,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e15b46e7c7c9d6afc98da4ff0a45c4bd9436d8bd  # v3.4.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Compute image tags
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermia
           tags: |
@@ -55,14 +55,14 @@ jobs:
       # Login only when we intend to push (tag or protected-branch push).
       - name: Log in to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (and push on non-PR events)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c1c  # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Non-root user — hermia doesn't need any elevated privileges at runtime.
 RUN groupadd --system --gid 1000 hermia \
  && useradd  --system --uid 1000 --gid hermia --home /workspace --shell /usr/sbin/nologin hermia \
- && mkdir -p /workspace/fleets /workspace/results \
+ && mkdir -p /workspace/results \
  && chown -R hermia:hermia /workspace
 
 COPY --from=builder /opt/venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Hermia — Docker image
+#
+# Multi-stage build. Stage 1 installs hermia into an isolated venv so the
+# runtime image ships only the artifacts pip actually needs. Stage 2 is a
+# slim runtime with the venv copied in.
+#
+# Usage (headless fleet mode is the intended container path — the TUI needs
+# a real terminal and is not the primary Docker use case):
+#
+#   docker run --rm \
+#     --network host \
+#     -v $PWD/fleets:/workspace/fleets:ro \
+#     -v $PWD/results:/workspace/results \
+#     ghcr.io/scottblydotcom/hermia:latest \
+#     --fleet fleets/quick-local.yaml
+#
+# On Docker Desktop (macOS/Windows) use --add-host host.docker.internal:host-gateway
+# and point the fleet YAML `host:` at http://host.docker.internal:11434.
+
+FROM python:3.11-slim AS builder
+
+# Build the wheel inside an isolated venv.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /build
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --upgrade pip \
+ && pip install .
+
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+# Non-root user — hermia doesn't need any elevated privileges at runtime.
+RUN groupadd --system --gid 1000 hermia \
+ && useradd  --system --uid 1000 --gid hermia --home /workspace --shell /usr/sbin/nologin hermia \
+ && mkdir -p /workspace/fleets /workspace/results \
+ && chown -R hermia:hermia /workspace
+
+COPY --from=builder /opt/venv /opt/venv
+
+USER hermia
+WORKDIR /workspace
+
+# results/ should be bind-mounted by the caller so output persists.
+VOLUME ["/workspace/results"]
+
+# Version + basic smoke work with no args. Actual eval requires --fleet.
+ENTRYPOINT ["hermia"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ cd hermia
 pip install -e .
 ```
 
+Or via Docker (headless fleet mode):
+
+```bash
+docker run --rm --network host \
+  -v $PWD/fleets:/workspace/fleets:ro \
+  -v $PWD/results:/workspace/results \
+  ghcr.io/scottblydotcom/hermia:latest \
+  --fleet fleets/quick-local.yaml
+```
+
+See [Docker usage](docs/getting-started.md#appendix-docker) for macOS / Windows
+networking (`host.docker.internal`) and volume-mount details.
+
 ---
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \
   ghcr.io/scottblydotcom/hermia:latest \
-  --fleet fleets/quick-local.yaml
+  --fleet fleets/local.yaml
 ```
 
 See [Docker usage](docs/getting-started.md#appendix-docker) for macOS / Windows

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ pip install -e .
 Or via Docker (headless fleet mode):
 
 ```bash
-mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
+mkdir -p results && chmod 777 results  # container writes as uid 1000, not your host user
 docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ pip install -e .
 Or via Docker (headless fleet mode):
 
 ```bash
+mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
 docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,7 +130,7 @@ a real terminal and isn't the primary Docker use case.
 ### Linux (bare Docker, host networking)
 
 ```bash
-mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
+mkdir -p results && chmod 777 results  # container writes as uid 1000, not your host user
 docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \
@@ -158,7 +158,7 @@ Docker Desktop doesn't support `--network host` cleanly. Add the host gateway
 and point the fleet YAML at `host.docker.internal`:
 
 ```bash
-mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
+mkdir -p results && chmod 777 results  # container writes as uid 1000, not your host user
 docker run --rm \
   --add-host host.docker.internal:host-gateway \
   -v $PWD/fleets:/workspace/fleets:ro \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,17 @@ docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \
   ghcr.io/scottblydotcom/hermia:latest \
-  --fleet fleets/quick-local.yaml
+  --fleet fleets/local.yaml
+```
+
+```yaml
+# fleets/local.yaml
+fleet:
+  - name: local
+    host: http://localhost:11434
+    transport: ollama
+    models:
+      - llama3.2:latest
 ```
 
 `--network host` lets the container reach `localhost:11434` on the host.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,7 @@ a real terminal and isn't the primary Docker use case.
 ### Linux (bare Docker, host networking)
 
 ```bash
+mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
 docker run --rm --network host \
   -v $PWD/fleets:/workspace/fleets:ro \
   -v $PWD/results:/workspace/results \
@@ -147,6 +148,7 @@ Docker Desktop doesn't support `--network host` cleanly. Add the host gateway
 and point the fleet YAML at `host.docker.internal`:
 
 ```bash
+mkdir -p results  # pre-create so it's owned by you, not root (container runs as uid 1000)
 docker run --rm \
   --add-host host.docker.internal:host-gateway \
   -v $PWD/fleets:/workspace/fleets:ro \
@@ -160,7 +162,7 @@ docker run --rm \
 fleet:
   - name: docker-desktop
     host: http://host.docker.internal:11434
-    engine: ollama
+    transport: ollama
     models:
       - llama3.2:latest
 ```
@@ -172,7 +174,9 @@ needed — put the remote URL directly in the fleet YAML.
 
 ### Version pinning
 
-For reproducible builds, pin the tag: `ghcr.io/scottblydotcom/hermia:0.2.0`.
+For reproducible builds, pin the tag to a released version, e.g.
+`ghcr.io/scottblydotcom/hermia:0.1.3` — check
+[releases](https://github.com/scottblydotcom/hermia/releases) for the latest.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,6 +121,61 @@ and stack fingerprint per trial for audit purposes.
 
 ---
 
+## Appendix: Docker
+
+Hermia ships a Docker image at `ghcr.io/scottblydotcom/hermia:latest`. The
+container is oriented at **headless fleet mode** — the interactive TUI needs
+a real terminal and isn't the primary Docker use case.
+
+### Linux (bare Docker, host networking)
+
+```bash
+docker run --rm --network host \
+  -v $PWD/fleets:/workspace/fleets:ro \
+  -v $PWD/results:/workspace/results \
+  ghcr.io/scottblydotcom/hermia:latest \
+  --fleet fleets/quick-local.yaml
+```
+
+`--network host` lets the container reach `localhost:11434` on the host.
+Bind-mount `fleets/` read-only and `results/` read-write so eval output lands
+on the host filesystem.
+
+### macOS / Windows (Docker Desktop)
+
+Docker Desktop doesn't support `--network host` cleanly. Add the host gateway
+and point the fleet YAML at `host.docker.internal`:
+
+```bash
+docker run --rm \
+  --add-host host.docker.internal:host-gateway \
+  -v $PWD/fleets:/workspace/fleets:ro \
+  -v $PWD/results:/workspace/results \
+  ghcr.io/scottblydotcom/hermia:latest \
+  --fleet fleets/desktop.yaml
+```
+
+```yaml
+# fleets/desktop.yaml
+fleet:
+  - name: docker-desktop
+    host: http://host.docker.internal:11434
+    engine: ollama
+    models:
+      - llama3.2:latest
+```
+
+### Remote Ollama
+
+If Ollama isn't on the same box as the container, no special networking is
+needed — put the remote URL directly in the fleet YAML.
+
+### Version pinning
+
+For reproducible builds, pin the tag: `ghcr.io/scottblydotcom/hermia:0.2.0`.
+
+---
+
 ## Troubleshooting
 
 **No models listed in the TUI** — Ollama isn't running, or you haven't pulled a


### PR DESCRIPTION
## Summary
Third of the v0.2.0 P1 packaging chain (hermia-6ce + hermia-1pj docs already landed; this is hermia-rpx). Adds a Docker image that publishes to \`ghcr.io/scottblydotcom/hermia\` on tag pushes matching \`v*.*.*\`, plus a smoke-test that runs on every PR touching Docker/packaging bits.

## What's in the box
- **Dockerfile** — multi-stage (builder + slim runtime). Non-root user, \`ENTRYPOINT ["hermia"]\` with \`CMD ["--help"]\`, WORKDIR /workspace + VOLUME for results. Target use case is headless fleet mode; called out in the header comment.
- **.dockerignore** — trims context to pyproject + src/ + README.
- **.github/workflows/docker.yml** — build on PR + push, tag/label via \`docker/metadata-action\`, publish to ghcr.io only on non-PR runs, smoke-test \`--help\` and \`--version\` output.
- **README + docs/getting-started.md** — install-path fourth option and a Docker appendix covering Linux (\`--network host\`), Docker Desktop (\`host.docker.internal\`), remote Ollama, and version pinning.

## Test plan
- [x] Local pytest still 1732/1732 (docs/workflow-only changes)
- [x] YAML syntax check on the workflow parses cleanly
- [ ] CI Docker build succeeds on this PR (smoke-test does \`docker run <image> --help\` and \`--version\`)
- [ ] After merge, tag \`v0.2.0\` triggers a real ghcr.io publish (validated as part of \`hermia-4e8\` cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-stage Docker image for running Hermia in headless fleet mode with a non-root user (UID/GID 1000) and workspace setup, including default help behavior.
* **Documentation**
  * Expanded installation and getting-started materials with Docker run commands, macOS/Windows networking guidance (`host.docker.internal`), remote Ollama tips, and version pinning examples.
* **Tests**
  * Added container-based Docker CI smoke checks (help/version validation and fleet run verification).
* **Chores**
  * Improved Docker build context via an updated `.dockerignore`.
  * Added a Docker release workflow to publish and smoke-test versioned images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->