### PR TITLE
feat(packaging): Homebrew tap install path + release-time formula bump

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,118 @@
+name: Bump Homebrew Formula
+
+# Runs after a successful PyPI publish (see publish.yml, same v*.*.* tag
+# trigger) and opens a PR against scottblydotcom/homebrew-tap updating the
+# hermia formula's url/sha256 to the just-published release.
+#
+# Requires a repo secret HOMEBREW_TAP_TOKEN: a fine-grained PAT scoped to
+# Contents: read/write on scottblydotcom/homebrew-tap only. The default
+# GITHUB_TOKEN cannot push to a different repository.
+#
+# Only bumps the main package resource (url + sha256). Transitive
+# dependency resources (textual, rich, etc.) are not re-pinned here — if
+# pyproject.toml's dependency versions changed, regenerate those manually
+# with `homebrew-pypi-poet` and update Formula/hermia.rb by hand.
+on:
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+
+jobs:
+  bump-formula:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Determine version from tag
+        id: version
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unexpected tag format: $TAG" >&2
+            exit 1
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch sdist url + sha256 from PyPI
+        id: pypi
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            JSON="$(curl -sf "https://pypi.org/pypi/hermia/${VERSION}/json" || true)"
+            if [[ -n "$JSON" ]]; then
+              RESULT="$(echo "$JSON" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for entry in data["urls"]:
+    if entry["packagetype"] == "sdist":
+        print(entry["url"])
+        print(entry["digests"]["sha256"])
+        break
+else:
+    sys.exit(1)
+')"
+              if [[ -n "$RESULT" ]]; then
+                echo "url=$(echo "$RESULT" | sed -n 1p)" >> "$GITHUB_OUTPUT"
+                echo "sha256=$(echo "$RESULT" | sed -n 2p)" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+            echo "sdist not available yet for ${VERSION}, retrying (attempt ${attempt})..."
+            sleep 20
+          done
+          echo "Gave up waiting for hermia ${VERSION} sdist on PyPI" >&2
+          exit 1
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: scottblydotcom/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: true
+
+      - name: Update formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SDIST_URL: ${{ steps.pypi.outputs.url }}
+          SDIST_SHA256: ${{ steps.pypi.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          python3 - "$VERSION" "$SDIST_URL" "$SDIST_SHA256" <<'EOF'
+          import re
+          import sys
+
+          version, url, sha256 = sys.argv[1:4]
+          path = "Formula/hermia.rb"
+          text = open(path).read()
+
+          head, sep, rest = text.partition("\n  resource ")
+          head = re.sub(r'url ".*"\n', f'url "{url}"\n', head, count=1)
+          head = re.sub(r'sha256 ".*"\n', f'sha256 "{sha256}"\n', head, count=1)
+
+          open(path, "w").write(head + sep + rest)
+          EOF
+          git diff --stat
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "hermia-release-bot"
+          git config user.email "actions@users.noreply.github.com"
+          BRANCH="bump-hermia-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add Formula/hermia.rb
+          git commit -m "hermia ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "hermia ${VERSION}" \
+            --body "Automated bump to hermia ${VERSION}, triggered by scottblydotcom/hermia's release workflow." \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -46,16 +46,16 @@ jobs:
             JSON="$(curl -sf "https://pypi.org/pypi/hermia/${VERSION}/json" || true)"
             if [[ -n "$JSON" ]]; then
               RESULT="$(echo "$JSON" | python3 -c '
-import json, sys
-data = json.load(sys.stdin)
-for entry in data["urls"]:
-    if entry["packagetype"] == "sdist":
-        print(entry["url"])
-        print(entry["digests"]["sha256"])
-        break
-else:
-    sys.exit(1)
-')"
+          import json, sys
+          data = json.load(sys.stdin)
+          for entry in data["urls"]:
+              if entry["packagetype"] == "sdist":
+                  print(entry["url"])
+                  print(entry["digests"]["sha256"])
+                  break
+          else:
+              sys.exit(1)
+          ' || true)"
               if [[ -n "$RESULT" ]]; then
                 echo "url=$(echo "$RESULT" | sed -n 1p)" >> "$GITHUB_OUTPUT"
                 echo "sha256=$(echo "$RESULT" | sed -n 2p)" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ bd create "<title>"   # File a new issue
 
 ```bash
 pip install -e ".[dev]"
-pytest
+pytest -q
 ruff check src/
 mypy src/
 ```
@@ -45,7 +45,7 @@ At the start of every session, before writing any code, complete these steps in 
    - *Internal (bd installed):* Run `bd prime` and report the active bead ID and description.
    - *External contributor (no bd):* Confirm the GitHub Issue number and title in scope.
 3. **Confirm branch.** Run `git branch --show-current`. The branch name must match the task. If it does not, create a correctly named feature branch before touching anything.
-4. **Establish test baseline.** Run `pytest` and show the full output. Do not write a single line of code until the baseline is confirmed.
+4. **Establish test baseline.** Run `pytest -q` and show the output. Do not write a single line of code until the baseline is confirmed.
 5. **Confirm module scope.** State which files are permitted for this task per the Module Boundary Table in `AGENTS.md`. Flag any anticipated out-of-scope touches before starting.
 
 Do not write any code until all five steps are complete.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pipx install hermia
 Or via Homebrew (macOS):
 
 ```bash
-brew install scottbly/tap/hermia
+brew install scottblydotcom/tap/hermia
 ```
 
 Or with pip:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ Recommended (via pipx):
 pipx install hermia
 ```
 
+Or via Homebrew (macOS):
+
+```bash
+brew install scottbly/tap/hermia
+```
+
 Or with pip:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ pipx install hermia
 Or via Homebrew (macOS):
 
 ```bash
-brew install scottbly/tap/hermia
+brew install scottblydotcom/tap/hermia
 ```
 
 Or with pip:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,12 @@ Recommended (isolated install via [pipx](https://pipx.pypa.io)):
 pipx install hermia
 ```
 
+Or via Homebrew (macOS):
+
+```bash
+brew install scottbly/tap/hermia
+```
+
 Or with pip:
 
 ```bash


### PR DESCRIPTION
## Summary
- New `scottblydotcom/homebrew-tap` repo hosts a `hermia` Formula (already pushed + verified: `brew audit --strict --online` clean, `brew style` clean, `brew test` green on native arm64)
- New workflow `homebrew-bump.yml` opens a PR against the tap repo whenever `publish.yml` ships a new PyPI release (uses `HOMEBREW_TAP_TOKEN` secret)
- README + getting-started docs get the brew install path
- Chore commit: CLAUDE.md switches baseline `pytest` → `pytest -q` for lower session-start noise (unrelated to homebrew scope, per 2026-07-01 context-efficiency audit)

## Test plan
- [ ] CI green on this PR
- [ ] Verify `homebrew-bump.yml` only fires on `v*.*.*` tag pushes (post-merge)
- [ ] hermia-02d matrix (separate PR) will exercise the brew install path end-to-end

Bead: hermia-54s (closes on merge)
Related: hermia-02d (P1, next; will build docs-as-tested CI matrix using this brew path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow that automatically bumps the Homebrew formula and opens a PR after successful PyPI publishes for tagged releases.
  * Added Homebrew as an additional macOS installation option.

* **Documentation**
  * Updated installation guides (README and getting-started) with the new Homebrew `brew install ...` command.
  * Updated test-running instructions to use `pytest -q` for quieter output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->