### PR TITLE
release-prep(v0.2.0): CHANGELOG, corpus-hash provenance, doc-path + n=3 hygiene

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,6 +30,11 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/hermia
+          # `:latest` is emitted automatically: metadata-action's default
+          # `flavor.latest=auto` tags the image `:latest` on any non-prerelease
+          # semver tag push (e.g. v0.2.0). The README's `ghcr.io/.../hermia:latest`
+          # install snippet resolves via this. Do NOT add an explicit latest tag
+          # or assume it's missing — it isn't. (See closed bead hermia-b7v.)
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ requires explicit user approval before any code is written.
 
 | Task Type                   | Permitted Files                                               | Off-Limits Without Approval          |
 |-----------------------------|---------------------------------------------------------------|--------------------------------------|
-| New eval test               | `test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | Everything else                      |
+| New eval test               | `src/hermia/test-datasets/agentic-tasks.json`, `src/hermia/schemas.py`  | Everything else            |
 | Schema checker fix          | `src/hermia/schemas.py`, `tests/unit/test_schemas.py`        | Everything else                      |
 | Regression module           | `src/hermia/regression.py`, `tests/test_regression.py`       | Everything else                      |
 | UI/TUI changes              | `src/hermia/tui/`, `src/hermia/screens.py`, `src/hermia/app.py`, `tests/unit/tui/`, `tests/fixtures/` | Core eval logic                      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,81 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 ---
 
+## [0.2.0] — target 2026-07 (Fleet + TUI)
+
+The "Endpoint Bus" release. Hermia grows from a single-host application into a
+platform: headless fleet mode for multi-host eval from a YAML config, a
+full-featured TUI for launch/configure/run/inspect, a pluggable Transport layer
+that evaluates anything OpenAI-compatible, and an audited 30-test corpus with a
+published methodology catalog and framework matrix.
+
+### Added
+- **Fleet mode** (`--fleet FILE`) — headless multi-host eval from a YAML config;
+  the same suite runs across multiple endpoints in parallel, powered by a new
+  concurrent runner (Workstream C, #93).
+- **Fleet TUI** — host discovery and model selection; live multi-host run view
+  across runner (L1), per-trial (L2), and detail (L3) screens; breadcrumb
+  navigation; first-run and probe-failure empty-state guidance (#122–#129).
+- **Transport abstraction** — pluggable Ollama and OpenAI-compatible transports;
+  evaluate LiteLLM, OpenAI, Anthropic, Google, Bedrock, or local Ollama through
+  one interface (Workstream A, #87), with `models: auto` endpoint
+  auto-discovery (#112).
+- **Sink interface + opt-in anonymized submission** — `hermia-submit` CLI for the
+  community dataset, gated behind a value-level anonymizer (Workstream D,
+  #95, #111).
+- **Deterministic multi-turn evaluation** (Workstream E, #96).
+- **Backend stack tagging** — GPU architecture, runtime version, and execution
+  path (GPU vs spill) stamped on every result row.
+- **Configurable per-test timeout** — CLI flag and per-host YAML key, for
+  thinking-mode models (#126).
+- **Corpus methodology catalog** — `docs/corpus-catalog.md`: per-test purpose,
+  exact prompts, grading logic, four-framework control-ID mappings with
+  rationale, and known limitations for all 30 tests, assembled from a
+  machine-checked single source (`catalog-meta/`) with a CI-enforced security
+  policy sign-off gate (Track 5, #99/#101/#103/#105).
+- **GUARDS framework** — six-dimension standard for LLM guardrail construction,
+  published (#104).
+- **Packaging** — Docker image + ghcr.io publish workflow (#130), Homebrew tap
+  with release-time formula bump (#136), and a docs-as-tested CI matrix that runs
+  the README's install commands literally across 5 methods × OS × Python (#137).
+
+### Changed
+- Corpus normalized to GUARDS 6/6 across all 30 tests, with adversarial framing
+  added to the multi-step-reasoning and numeric-correctness tests (#105).
+- Extracted the aggregate scorer into `scoring.py` (`compute_scores` +
+  `backfill_aggregates`).
+- README and usage docs brought to v0.2 reality; added a 5-minute
+  getting-started path (#128).
+
+### Fixed
+- Corpus grader corrections surfaced by the Track 5 audit: the
+  `indirect-injection-tool-output` binary grader no longer false-passes on
+  structure alone (content validation added); `instruction-override-resistance`
+  now scores a refusal as a security pass and aligns its prompt to the oracle
+  (#127); status-field semantics clarified (#102).
+- Anonymizer now performs value-level sanitization of the `frameworks` field,
+  stripping identifying strings smuggled inside custom-dataset framework values
+  (#107).
+- TUI: fleet YAML compatibility and a probe-subscription race (#125),
+  trial-hang timeout, and Rich markup escaping (#124).
+
+### Security
+- Inner-branch negative-example tests for the security schema checkers, ensuring
+  each grader rejects its documented failure cases, not just accepts its passes
+  (#108).
+- The scanning pipeline (gitleaks, trufflehog, trivy, bandit, pip-audit, ruff,
+  mypy, guarddog) runs on every push and pull request.
+
+### Known limitations
+- Cross-stack reproducibility evidence (Metal × CUDA × ROCm) is being captured as
+  an ongoing dataset published across the v0.2.x series, not as a single launch
+  snapshot.
+- Documented residual grader limitations (e.g. a ~1.1% false-positive band on
+  `instruction-override-resistance` for out-of-fence leaks) are catalogued in
+  `docs/corpus-catalog.md`.
+
+---
+
 ## [0.1.0] — target 2026-05-23
 
 First stable eval suite. Core TUI, multi-vendor GPU metrics, robustness scoring,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ mypy src/
 
 ## Architecture
 
-Open-source LLM security eval TUI. `textual` UI, eval test datasets in `test-datasets/`, schema checks in `src/hermia/schemas.py`. See `docs/security-framework-research.md` for framework mappings (OWASP LLM Top 10, MITRE ATLAS, CSA MAESTRO, NIST AI RMF).
+Open-source LLM security eval TUI. `textual` UI, eval test datasets in `src/hermia/test-datasets/`, schema checks in `src/hermia/schemas.py`. See `docs/security-framework-research.md` for framework mappings (OWASP LLM Top 10, MITRE ATLAS, CSA MAESTRO, NIST AI RMF).
 
 ## Behavioral Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ feature/* or fix/* or chore/*
 
 ## Making Changes
 
-**New eval test cases** (`test-datasets/agentic-tasks.json` + `src/hermia/schemas.py`):
+**New eval test cases** (`src/hermia/test-datasets/agentic-tasks.json` + `src/hermia/schemas.py`):
 - Follow the existing test case structure — `id`, `dimension`, `description`, `system`, `prompt`
 - Add a corresponding schema checker in `schemas.py` using the `_keys_ok()` helper
 - Map the test to at least one framework reference (OWASP, ATLAS, MAESTRO, or NIST AI RMF)

--- a/README.md
+++ b/README.md
@@ -217,9 +217,10 @@ See [docs/roadmap.md](docs/roadmap.md) for the full plan.
 
 **v0.2.0** — stable and tested. The core eval suite, fleet mode, TUI, audit trail, and
 findings analysis pipeline are all shipping. Cross-stack reproducibility evidence
-(Metal x CUDA x ROCm) is being captured in an n=3 dataset and will publish alongside the
-v0.2.0 release notes. The security pipeline (gitleaks, trivy, bandit, pip-audit, ruff,
-mypy) is more rigorous than a research tool strictly needs to be. That was intentional.
+(Metal × CUDA × ROCm) is being captured as an ongoing dataset, published on a rolling
+basis across the v0.2.x series rather than as a single launch snapshot. The security
+pipeline (gitleaks, trivy, bandit, pip-audit, ruff, mypy) is more rigorous than a
+research tool strictly needs to be. That was intentional.
 
 Available on [PyPI](https://pypi.org/project/hermia/): `pipx install hermia`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,7 @@ Out of scope:
 ## A Note on the Nature of This Tool
 
 Hermia runs adversarial prompts against language models by design. If you're reviewing
-the eval test datasets (`test-datasets/agentic-tasks.json`) and see what look like
+the eval test datasets (`src/hermia/test-datasets/agentic-tasks.json`) and see what look like
 prompt injection attempts or instructions to exfiltrate credentials — that's intentional.
 Those are the test cases. The tool is supposed to send them to models; it is not supposed
 to act on them itself.

--- a/scripts/add_corpus_hash_column.sql
+++ b/scripts/add_corpus_hash_column.sql
@@ -1,0 +1,10 @@
+-- Release-prep for v0.2.0 (hermia-khq): stamp corpus_sha256 on every result row.
+-- Stores the SHA-256 hex digest of the shipped agentic-tasks.json so a result
+-- can be tied to the exact corpus that produced it — the row-level half of the
+-- roadmap's provenance promise (hermia_version + corpus hash). Makes corpus
+-- drift self-evident and underwrites the "reproducible by anyone" claim at the
+-- row level, without git archaeology.
+-- Idempotent: safe to run multiple times.
+
+ALTER TABLE hermia_results
+    ADD COLUMN IF NOT EXISTS corpus_sha256 TEXT;

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -54,6 +54,7 @@ _PG_COLUMNS = (
     "raw_prompt",
     "raw_response",
     "hermia_version",
+    "corpus_sha256",
     "gpu_arch",
     "runtime_version",
     "backend_stack",

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -1,5 +1,6 @@
 """Ollama model management and test execution."""
 
+import hashlib
 import json
 import os
 import threading
@@ -226,6 +227,28 @@ def load_framework_versions() -> dict[str, str]:
     return dict(_FRAMEWORK_VERSIONS_CACHE)
 
 
+_CORPUS_SHA256_CACHE: str | None = None
+
+
+def corpus_sha256() -> str:
+    """Return the SHA-256 hex digest of the shipped ``agentic-tasks.json``.
+
+    Stamped onto every result row so a row can be tied to the exact corpus that
+    produced it — the row-level half of the roadmap's provenance promise
+    (``hermia_version`` + corpus hash). Because the corpus file is held to a
+    canonical serialization (enforced by ``tests/unit/test_dataset_format.py``),
+    hashing the raw bytes is stable and any content change — a test edit, a
+    framework-version bump, anything — yields a new digest, making corpus drift
+    self-evident. Module-cached: the file does not change during a process
+    lifetime.
+    """
+    global _CORPUS_SHA256_CACHE
+    if _CORPUS_SHA256_CACHE is None:
+        path = PACKAGE_DIR / "test-datasets" / "agentic-tasks.json"
+        _CORPUS_SHA256_CACHE = hashlib.sha256(path.read_bytes()).hexdigest()
+    return _CORPUS_SHA256_CACHE
+
+
 def _play_turns(
     transport: Any,
     model: str,
@@ -419,6 +442,7 @@ def run_test(
         "turn_count": len(user_turns),
         "raw_turns": user_turns,
         "hermia_version": __version__,
+        "corpus_sha256": corpus_sha256(),
         "sampling": {k: _EVAL_SAMPLING.get(k) for k in _SAMPLING_SCHEMA_KEYS},
         "stack_fingerprint": _fp,
         "_provenance": _prov,

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -45,6 +45,7 @@ SUBMIT_WHITELIST: frozenset[str] = frozenset(
         "is_cold",
         "cold_warm_delta_tps",
         "signals",
+        "corpus_sha256",
     }
 )
 

--- a/src/hermia/tui/test_catalog.py
+++ b/src/hermia/tui/test_catalog.py
@@ -2,7 +2,7 @@
 
 Source of truth:
     - schemas.TEST_IDS               — canonical ordered list of test IDs
-    - test-datasets/agentic-tasks.json[agentic_test_cases][*].frameworks
+    - src/hermia/test-datasets/agentic-tasks.json[agentic_test_cases][*].frameworks
       → dict with keys: owasp_llm_top10, mitre_atlas, csa_maestro, nist_ai_rmf
       → non-empty list = test belongs to that framework
 

--- a/tests/unit/test_corpus_hash.py
+++ b/tests/unit/test_corpus_hash.py
@@ -1,0 +1,54 @@
+"""Corpus-hash provenance stamping — hermia-khq.
+
+Every result row carries ``corpus_sha256`` (the SHA-256 of the shipped
+``agentic-tasks.json``) so a row can be tied to the exact corpus that produced
+it without git archaeology, and corpus drift becomes self-evident. This is the
+row-level half of the roadmap's Track 1 provenance promise
+("hermia_version + corpus-hash stamping on every row"); the human-readable
+``corpus_version`` string is the complementary label.
+"""
+
+import hashlib
+
+from hermia.export import _PG_COLUMNS
+from hermia.runner import PACKAGE_DIR, corpus_sha256
+from hermia.sink.anonymize import anonymize_row
+
+_CORPUS_PATH = PACKAGE_DIR / "test-datasets" / "agentic-tasks.json"
+
+
+def test_corpus_sha256_is_64_char_lowercase_hex():
+    h = corpus_sha256()
+    assert isinstance(h, str)
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_corpus_sha256_matches_raw_file_bytes():
+    expected = hashlib.sha256(_CORPUS_PATH.read_bytes()).hexdigest()
+    assert corpus_sha256() == expected
+
+
+def test_corpus_sha256_is_stable_across_calls():
+    # Module-cached: two calls must return the identical value.
+    assert corpus_sha256() == corpus_sha256()
+
+
+def test_corpus_sha256_survives_anonymization():
+    # Provenance must reach the community dataset — the anonymizer is an
+    # allowlist, so a non-allowlisted field would be silently dropped.
+    sentinel = "ab12cd34" * 8  # 64-char stand-in hash
+    row = {
+        "test_id": "credential-leak-resistance",
+        "model": "m",
+        "corpus_sha256": sentinel,
+        "host": "secret-internal-host",  # must NOT survive
+    }
+    out = anonymize_row(row)
+    assert out.get("corpus_sha256") == sentinel
+    assert "host" not in out  # sanity: allowlist still default-denies
+
+
+def test_corpus_sha256_is_a_persisted_pg_column():
+    # Guards the export wiring so a row's provenance reaches Postgres.
+    assert "corpus_sha256" in _PG_COLUMNS

--- a/tests/unit/test_workstream_a_fixes.py
+++ b/tests/unit/test_workstream_a_fixes.py
@@ -93,6 +93,32 @@ def test_openai_non_dict_choices_and_usage_do_not_crash() -> None:
         assert resp.tokens == 0
 
 
+def test_ollama_non_dict_body_coerces_to_empty_response() -> None:
+    """A 200 with a non-object JSON body (bare list/string/bool) must coerce to
+    an empty Response, not AttributeError on the top-level ``data``."""
+    from hermia.transport.ollama import OllamaTransport
+
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = ["unexpected", "list", "body"]
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        resp = transport.generate("m", [{"role": "user", "content": "hi"}])
+        assert resp.text == ""
+        assert resp.tokens == 0
+
+
+def test_openai_non_dict_body_coerces_to_empty_response() -> None:
+    from hermia.transport.openai_compat import OpenAICompatTransport
+
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value.json.return_value = "unexpected-bare-string-body"
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        resp = transport.generate("m", [{"role": "user", "content": "hi"}])
+        assert resp.text == ""
+        assert resp.tokens == 0
+
+
 # ── Finding #7 + base: in-body errors raise a typed TransportError ────────────
 
 def test_ollama_in_body_error_raises_transport_error() -> None:


### PR DESCRIPTION
## What

Release-prep for the v0.2.0 cut, from the 2026-07-02 readiness review. Three commits:

1. **docs(release-prep)** — CHANGELOG `[0.2.0]` entry (was missing entirely; 180 dev commits undocumented); README n=3 reword; doc-path drift fix; docker `:latest` clarifying comment.
2. **feat(provenance)** — `corpus_sha256` stamped on every result row (roadmap Track 1 tight-base item that was never built).
3. **test(transport)** — the one LOW-severity coverage gap the review flagged.

## Why

Readiness review found the release *gate* (Track 5 corpus audit) and 3/4 tight-base items already cleared and CI-enforced (1757 tests green). The gaps were: a missing changelog, an unbuilt corpus-hash provenance stamp, an unfulfillable n=3 README promise, and doc-path drift. This PR closes all of them.

### Corpus-hash provenance (the substantive change)
`hermia_version` was already stamped per row; the corpus hash — the half that ties a row to a *known-correct* corpus (the reason Track 5 gated the release) — was missing. The only corpus identity was a static `CORPUS_VERSION="v0.2"` string that doesn't change when the corpus is edited, giving no drift evidence.
- `runner.corpus_sha256()` — module-cached SHA-256 of the shipped `agentic-tasks.json` raw bytes (stable because the file is held to a canonical serialization by `test_dataset_format.py`).
- Stamped on every row; added to the anonymizer allowlist (provenance must reach the community dataset; it's non-PII); added to `export._PG_COLUMNS` + idempotent migration.
- Underwrites the "reproducible by anyone with the hardware" North Star claim at the row level.

### n=3 decision
Holding the dataset and publishing on a rolling basis across v0.2.x (tracked in hermia-1np) rather than as a launch snapshot. README reworded so it no longer promises a dataset "alongside the v0.2.0 release notes" that isn't shipping at launch.

## Test plan
- [x] Full suite green: **1757 passed** (+7: 5 corpus-hash, 2 transport)
- [x] ruff + mypy clean on changed source
- [x] corpus_sha256: digest shape, matches-file-bytes, cache stability, survives-anonymization, is-a-pg-column
- [ ] CI green on this PR

## Security checklist
- [x] `corpus_sha256` is a hash of public corpus content — non-PII; safe to allowlist into submissions.
- [x] No secrets; no new deps (stdlib `hashlib`).
- [x] Anonymizer remains default-deny; the new field is explicitly allowlisted, not a widening of what passes through.
- [x] Postgres migration is idempotent (`ADD COLUMN IF NOT EXISTS`).

## Notes for reviewer
- Base is `dev` per convention.
- Related beads: hermia-khq (corpus-hash, this PR), hermia-1np (post-cut fresh dataset run), hermia-b7v (closed as false-positive — docker `:latest` auto-publishes via metadata-action; see the docker-release.yml comment).
- Readiness review also confirmed: Track 5 audit gate cleared (`hermia-11w` closed, CI-enforced 30/30 sign-off), coverage is risk-adequate (grading + anonymizer exceptionally tested), and the two remaining P1s reduce to just the mechanical cut (hermia-4e8) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results now include a corpus provenance hash, helping tie outputs to the exact evaluation dataset used.
  * Provenance is preserved in submitted and exported records.

* **Bug Fixes**
  * Improved handling of malformed backend responses so empty outputs are returned instead of errors.
  * Release tagging behavior is clarified for non-prerelease versions.

* **Documentation**
  * Updated project, security, and contributor docs with the current dataset location and release/status guidance.

* **Tests**
  * Added coverage for corpus hash stability and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->