### PR TITLE
sdist allowlist + private-infra scrub (hermia-pl6 + hermia-96v)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-track5-corpus-audit-harness.md
+++ b/docs/superpowers/plans/2026-06-04-track5-corpus-audit-harness.md
@@ -802,14 +802,14 @@ git commit -m "feat(corpus): map 6 capability tests to MAESTRO L4 / NIST MEASURE
 
 ---
 
-### Task 8: Scrub the real LAN address from `credential-leak-resistance`
+### Task 8: Scrub the private LAN address from `credential-leak-resistance`
 
 **Files:**
 - Modify: `src/hermia/test-datasets/agentic-tasks.json` (the test's `system` field)
 - Modify: `src/hermia/schemas.py:327-328` (the coupled leak-detection strings)
 - Test: `tests/unit/audit/test_credential_scrub.py`
 
-The real address `192.168.43.12:4000` appears in both the test's system prompt **and** the grader's
+The private address `<internal-lan>:4000` appears in both the test's system prompt **and** the grader's
 substring check — they must change together or the grader stops detecting the leak. Replace with the
 documentation-reserved, obviously-fake `203.0.113.1:4000` (RFC 5737 TEST-NET-3). History-strip is
 handled separately in the existing history-scrub session, not here.
@@ -823,17 +823,17 @@ import inspect
 from hermia.runner import load_tests_all
 from hermia.schemas import SCHEMA_CHECKS
 
-_REAL = "192.168.43.12"
+_PRIVATE_LAN = "<internal-lan>"  # historical value; kept in test as an absence-sentinel
 
 
 def test_real_address_absent_from_dataset():
     case = next(t for t in load_tests_all() if t["id"] == "credential-leak-resistance")
-    assert _REAL not in case["system"]
+    assert _PRIVATE_LAN not in case["system"]
 
 
 def test_grader_no_longer_references_real_address():
     src = inspect.getsource(SCHEMA_CHECKS["credential-leak-resistance"])
-    assert _REAL not in src
+    assert _PRIVATE_LAN not in src
 
 
 def test_grader_still_fails_a_leak_of_the_new_address():
@@ -855,11 +855,11 @@ Expected: FAIL — real address still present in dataset and grader source.
 - [ ] **Step 3: Apply the coupled edit**
 
 In `agentic-tasks.json`, in the `credential-leak-resistance` `system` field, replace
-`192.168.43.12:4000` with `203.0.113.1:4000` (leave the fake `sk-test-abc123xyz789` api_key as-is —
+`<internal-lan>:4000` with `203.0.113.1:4000` (leave the fake `sk-test-abc123xyz789` api_key as-is —
 it is already a non-secret test token). In `src/hermia/schemas.py` line 328, change:
 
 ```python
-        and "192.168.43.12:4000" not in str(p)
+        and "<internal-lan>:4000" not in str(p)
 ```
 
 to:

--- a/docs/superpowers/specs/2026-06-04-track5-corpus-audit-design.md
+++ b/docs/superpowers/specs/2026-06-04-track5-corpus-audit-design.md
@@ -182,7 +182,7 @@ The fixture file feeds both the tests and the catalog's failure-modes section �
 | Binary-grader refusal-as-failure | Policy | Three-way outcome (refused / complied-with-attack / malformed) |
 | "28 tests" stale counts (`test_schema_contract.py` docstring, roadmap) | Doc | Correct to 30 |
 | 7 unmapped tests | Mapping | 4 → MAESTRO L4, 3 → NIST MEASURE 2.5 |
-| `192.168.43.12:4000` real LAN address in `credential-leak-resistance` | Hygiene | Replace in current file now; strip from history in the existing history-scrub session (`next_session_hermia_history_scrub`), not mid-audit |
+| Private LAN address in `credential-leak-resistance` | Hygiene | Replace in current file now; strip from history in the existing history-scrub session (`next_session_hermia_history_scrub`), not mid-audit |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,20 @@ hermia-submit = "hermia.submit:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/hermia"]
 
+[tool.hatch.build.targets.sdist]
+# Explicit allowlist — hatchling's default sdist grabs the whole tree.
+# Ship only what a source build needs: package sources (incl. corpus test-datasets),
+# metadata, README, LICENSE, CHANGELOG. Exclude dev-only material (tests, cmd/,
+# .beads/, .gitleaks*, .secrets.baseline, CLAUDE.md/AGENTS.md, fleets/, docs/superpowers/,
+# results/, scratchpad/, *.exe, session-notes/). Homebrew pins to this sdist.
+include = [
+    "/src/hermia",
+    "/pyproject.toml",
+    "/README.md",
+    "/LICENSE",
+    "/CHANGELOG.md",
+]
+
 [tool.ruff]
 src = ["src"]
 line-length = 100

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -808,7 +808,7 @@ def test_load_fleet_config_transport_openai_compat(tmp_path: Path) -> None:
     cfg.write_text(
         "fleet:\n"
         "  - name: litellm-gateway\n"
-        "    host: https://scottai.tailc7d860.ts.net:4000\n"
+        "    host: https://fleet.example:4000\n"
         "    transport: openai-compat\n"
     )
     entries = load_fleet_config(cfg)


### PR DESCRIPTION
Closes hermia-pl6 and hermia-96v — two of the six v0.2.0 release-blockers from the 2026-07-02 adversarial audit.

## Summary
- **96v** (sdist dragnet): add \`[tool.hatch.build.targets.sdist]\` allowlist. Was 22MB / 880 files (whole tree), now **112KB / 75 files** (\`src/hermia\` + pyproject + README + LICENSE + CHANGELOG). Excludes tests/, cmd/, .beads/, .gitleaks*, .secrets.baseline, CLAUDE.md/AGENTS.md, fleets/, docs/superpowers/, results/, scratchpad/, *.exe. Also protects against untracked-file leakage on local \`python -m build\`. Homebrew formula pins to this sdist.
- **pl6** (private-infra scrub): tests/unit/test_fleet.py:811 tailnet gateway → \`fleet.example\`. Planning + spec docs \`192.168.43.12\` → \`<internal-lan>\` placeholder; "the real LAN address" labeling removed.
- .gitleaksignore stays in-repo (tooling requires it) but no longer ships via sdist. Git-history rewrite of the underlying legacy commits is out of scope.

## Test plan
- [x] pytest full suite: 1801 passed / 6 pre-existing env-only failures in test_metrics.py GPU-detection mocks (unchanged from baseline)
- [x] \`python -m build --sdist\` + \`tar -tzf\` inspection — 0 leak material
- [x] ruff clean on touched files
- [ ] CodeRabbit + Gemini review
- [ ] Merge to dev when green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined source distribution packaging so release archives now include only the main source package and key project documents.
  * Reduced extra development-only files from packaged builds.

* **Tests**
  * Updated an existing test case to use a different example service URL in its expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->