### PR TITLE
soften corpus_sha256 provenance claims to match reality (hermia-5oe)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ Three claims that nobody else can credibly make:
 
 1. **We don't sell anything.** The methodology is not also a sales channel for inference, training, or services.
 2. **We test the stack, not just the model.** Hardware telemetry, backend tagging, cross-backend divergence — model behavior depends on the inference stack underneath, and nobody else captures it.
-3. **Our scores are reproducible by anyone with the same hardware and stack.** Local-first, deterministic-where-possible, full corpus and rubric in the repo. Reproducibility rests on running the same eval code against the same corpus at the same sampling settings; it is not enforced by cryptographic row-signing today, and corpus-hash stamping detects *drift* (given an authoritative reference), not *forgery* — see the row-level provenance notes for the honest bounds.
+3. **Our scores are reproducible by anyone with the same hardware and stack.** Local-first, deterministic-where-possible, full corpus and rubric in the repo. Reproducibility rests on running the same eval code against the same corpus at the same sampling settings; it is not enforced by cryptographic row-signing today, and corpus-hash stamping detects *drift* (given an authoritative reference), not *forgery* — see the row-level provenance notes in `src/hermia/runner.py` (`corpus_sha256`) for the honest bounds.
 
 ### The eval-bus thesis
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ Three claims that nobody else can credibly make:
 
 1. **We don't sell anything.** The methodology is not also a sales channel for inference, training, or services.
 2. **We test the stack, not just the model.** Hardware telemetry, backend tagging, cross-backend divergence — model behavior depends on the inference stack underneath, and nobody else captures it.
-3. **Our scores are reproducible by anyone with the hardware.** Local-first, deterministic-where-possible, full corpus and rubric in the repo.
+3. **Our scores are reproducible by anyone with the same hardware and stack.** Local-first, deterministic-where-possible, full corpus and rubric in the repo. Reproducibility rests on running the same eval code against the same corpus at the same sampling settings; it is not enforced by cryptographic row-signing today, and corpus-hash stamping detects *drift* (given an authoritative reference), not *forgery* — see the row-level provenance notes for the honest bounds.
 
 ### The eval-bus thesis
 

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -238,9 +238,24 @@ def corpus_sha256() -> str:
     (``hermia_version`` + corpus hash). Because the corpus file is held to a
     canonical serialization (enforced by ``tests/unit/test_dataset_format.py``),
     hashing the raw bytes is stable and any content change — a test edit, a
-    framework-version bump, anything — yields a new digest, making corpus drift
-    self-evident. Module-cached: the file does not change during a process
-    lifetime.
+    framework-version bump, anything — yields a new digest.
+
+    Scope + honest limits (see hermia-5oe):
+
+    * **What this detects.** Accidental corpus drift, provided the reader has
+      an authoritative reference digest to compare against; hermia does not
+      publish a canonical one, so drift detection currently depends on
+      out-of-band coordination.
+    * **What this does NOT detect.** The digest covers only the corpus
+      *data* — not ``schemas.py`` or any other eval code. A run whose graders
+      have been silently rewritten still emits the same ``corpus_sha256`` as
+      a stock run. Nor does the digest give forgery resistance: it is an
+      unkeyed hash of a public file, so any actor can produce a row whose
+      hash matches the shipped corpus regardless of how (or whether) it was
+      graded.
+    * Row-signing / hashing the eval code is deferred to v0.3.
+
+    Module-cached: the file does not change during a process lifetime.
     """
     global _CORPUS_SHA256_CACHE
     if _CORPUS_SHA256_CACHE is None:

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -243,7 +243,7 @@ def corpus_sha256() -> str:
     Scope + honest limits (see hermia-5oe):
 
     * **What this detects.** Accidental corpus drift, provided the reader has
-      an authoritative reference digest to compare against; hermia does not
+      an authoritative reference digest to compare against; Hermia does not
       publish a canonical one, so drift detection currently depends on
       out-of-band coordination.
     * **What this does NOT detect.** The digest covers only the corpus


### PR DESCRIPTION
Closes hermia-5oe (P2 → done at v0.2.0 as the audit-required SOFTEN step; row-signing / code-hashing deferred to v0.3).

## Summary
The corpus_sha256 stamp is real and useful for detecting accidental drift, but the surrounding language overclaimed on two axes flagged by the 2026-07-02 adversarial audits:

1. **"Making corpus drift self-evident"** — implies unilateral detection, but drift is only detectable if the reader has an authoritative reference digest. Hermia doesn't publish one; today drift detection requires out-of-band coordination.
2. **The digest hashes DATA only.** A run whose graders were silently rewritten emits the same corpus_sha256 as a stock run. And it's an unkeyed hash of a public file — zero forgery resistance.

Softens:
- \`src/hermia/runner.py\` \`corpus_sha256()\` docstring — spells out honest scope: what it detects (accidental data drift with a reference), what it doesn't (code changes, forgery). Points to v0.3 as the row-signing / code-hashing horizon.
- \`docs/roadmap.md\` line 25 — "reproducible by anyone with the hardware" → "with the same hardware and stack"; one sentence tying reproducibility to running the same eval code at the same sampling settings, and explicitly notes drift ≠ forgery.

No code change, no behavior change.

## Test plan
- [x] 101/101 test_runner tests pass
- [x] ruff clean on touched files
- [ ] CodeRabbit + Gemini review
- [ ] Merge to dev when green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified reproducibility guidance to better explain when results can be reproduced locally and what conditions must match.
  * Added a more detailed explanation of checksum-based drift detection, including its limits and what it does not verify.
  * Expanded user-facing notes on reproducibility to set clearer expectations around evaluation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->