### PR TITLE
wire engine-security dispatcher into fleet + local TUI (hermia-3zp)

### DIFF
--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -163,19 +163,12 @@ def main() -> None:
 
         sys.exit(0)
 
-    # Local TUI mode — surface engine-security warnings both to stderr (for
-    # non-interactive logging / redirected fds) AND into the TUI itself as
-    # startup toasts, since Textual switches to the alternate screen buffer
-    # on mount and any pre-mount stderr can scroll away when the app exits.
-    from hermia.preflight import check_engine_security
+    # Local TUI mode — engine-security probe runs on an off-thread worker
+    # after mount so the TUI's first paint isn't blocked on the 3s Ollama
+    # /api/version timeout when the host is unreachable. See
+    # HermiaApp._probe_engine_security.
     from hermia.runner import get_ollama_host
-    startup_warnings = check_engine_security(
-        get_ollama_host(), "ollama", fleet_mode=False
-    )
-    for w in startup_warnings:
-        print(w, file=sys.stderr)
-
-    HermiaApp(startup_warnings=startup_warnings).run()
+    HermiaApp(engine_security_host=get_ollama_host()).run()
 
 
 if __name__ == "__main__":

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -163,6 +163,13 @@ def main() -> None:
 
         sys.exit(0)
 
+    # Local TUI mode — surface engine-security warnings to stderr before the
+    # TUI takes over the screen. Uses the same dispatcher the fleet path uses.
+    from hermia.preflight import check_engine_security
+    from hermia.runner import get_ollama_host
+    for w in check_engine_security(get_ollama_host(), "ollama", fleet_mode=False):
+        print(w, file=sys.stderr)
+
     HermiaApp().run()
 
 

--- a/src/hermia/app.py
+++ b/src/hermia/app.py
@@ -163,14 +163,19 @@ def main() -> None:
 
         sys.exit(0)
 
-    # Local TUI mode — surface engine-security warnings to stderr before the
-    # TUI takes over the screen. Uses the same dispatcher the fleet path uses.
+    # Local TUI mode — surface engine-security warnings both to stderr (for
+    # non-interactive logging / redirected fds) AND into the TUI itself as
+    # startup toasts, since Textual switches to the alternate screen buffer
+    # on mount and any pre-mount stderr can scroll away when the app exits.
     from hermia.preflight import check_engine_security
     from hermia.runner import get_ollama_host
-    for w in check_engine_security(get_ollama_host(), "ollama", fleet_mode=False):
+    startup_warnings = check_engine_security(
+        get_ollama_host(), "ollama", fleet_mode=False
+    )
+    for w in startup_warnings:
         print(w, file=sys.stderr)
 
-    HermiaApp().run()
+    HermiaApp(startup_warnings=startup_warnings).run()
 
 
 if __name__ == "__main__":

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -213,9 +213,13 @@ def _run_host_eval(
     # Engine-security posture — surface CVE / stale-server warnings before we
     # start driving traffic at the host. Fleet mode suppresses local-only
     # advisories (e.g. Ollama's unpatched /api/create) since a remote fleet
-    # host is not the operator's own loopback surface.
+    # host is not the operator's own loopback surface. Advisory-only: never
+    # let a malformed /api/version response kill the host eval.
     from hermia.preflight import check_engine_security
-    sec_warnings = check_engine_security(host_url, transport_type, fleet_mode=True)
+    try:
+        sec_warnings = check_engine_security(host_url, transport_type, fleet_mode=True)
+    except Exception as exc:  # noqa: BLE001 — advisory-only, degrade quietly
+        sec_warnings = [f"SEC ⚠ engine-security probe failed: {exc}"]
     if sec_warnings:
         with print_lock:
             for w in sec_warnings:

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -210,6 +210,17 @@ def _run_host_eval(
     )
     host_start = datetime.now(UTC).isoformat()
 
+    # Engine-security posture — surface CVE / stale-server warnings before we
+    # start driving traffic at the host. Fleet mode suppresses local-only
+    # advisories (e.g. Ollama's unpatched /api/create) since a remote fleet
+    # host is not the operator's own loopback surface.
+    from hermia.preflight import check_engine_security
+    sec_warnings = check_engine_security(host_url, transport_type, fleet_mode=True)
+    if sec_warnings:
+        with print_lock:
+            for w in sec_warnings:
+                stderr_fn(f"  {name}: {w}")
+
     requested = entry.get("models")
     if transport_type == "openai-compat" and requested == "auto":
         # openai-compat has no /api/tags, but it does serve GET /v1/models.

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -217,7 +217,9 @@ def _run_host_eval(
     # let a malformed /api/version response kill the host eval.
     from hermia.preflight import check_engine_security
     try:
-        sec_warnings = check_engine_security(host_url, transport_type, fleet_mode=True)
+        sec_warnings = check_engine_security(
+            host_url, transport_type, fleet_mode=True, headers=headers
+        )
     except Exception as exc:  # noqa: BLE001 — advisory-only, degrade quietly
         sec_warnings = [f"SEC ⚠ engine-security probe failed: {exc}"]
     if sec_warnings:

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -77,6 +77,10 @@ def check_ollama_security(
     """
     import requests  # local import — optional network check, avoid startup overhead
     warnings: list[str] = []
+    # Normalize even though every current caller already does — defense
+    # in depth against a future caller passing a raw `localhost:11434`
+    # (requests raises MissingSchema) or a trailing slash (double-slash URL).
+    host = _normalize_host(host)
     try:
         resp = requests.get(
             f"{host}/api/version", timeout=3, headers=headers or {}

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -64,21 +64,36 @@ _MIN_SECURE_VERSION_TUPLE: tuple[int, ...] = (
 )
 
 
-def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
-    """Query /api/version and return SEC warning strings. Never raises."""
+def check_ollama_security(
+    host: str,
+    fleet_mode: bool = False,
+    headers: dict[str, str] | None = None,
+) -> list[str]:
+    """Query /api/version and return SEC warning strings. Never raises.
+
+    ``headers`` forwards the fleet entry's auth (e.g. bearer token) so
+    ``/api/version`` reaches auth-gated hosts (LiteLLM proxies, etc)
+    instead of getting a silent 401/403 and skipping the CVE probe.
+    """
     import requests  # local import — optional network check, avoid startup overhead
     warnings: list[str] = []
     try:
-        resp = requests.get(f"{host}/api/version", timeout=3)
+        resp = requests.get(
+            f"{host}/api/version", timeout=3, headers=headers or {}
+        )
         if resp.ok:
-            ver = resp.json().get("version", "")
+            payload = resp.json()
+            # Defensive: /api/version could return a list, a bare string,
+            # or null on an unexpected server. Only a dict has .get.
+            ver = payload.get("version", "") if isinstance(payload, dict) else ""
             v_tuple = _parse_version(ver)
             if v_tuple is not None and v_tuple < _MIN_SECURE_VERSION_TUPLE:
                 warnings.append(
                     f"SEC ⚠ CVE-2026-7482 (CVSS 9.1): Ollama {ver} is vulnerable "
                     f"to heap memory disclosure — upgrade to {OLLAMA_MIN_SECURE_VERSION}+"
                 )
-    except requests.exceptions.RequestException:
+    except (requests.exceptions.RequestException, ValueError):
+        # ValueError catches JSONDecodeError on non-JSON bodies.
         pass
 
     if not fleet_mode:
@@ -90,7 +105,10 @@ def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
 
 
 def check_engine_security(
-    host: str, engine: str, fleet_mode: bool = False
+    host: str,
+    engine: str,
+    fleet_mode: bool = False,
+    headers: dict[str, str] | None = None,
 ) -> list[str]:
     """Engine-aware security posture check. Dispatch on transport type.
 
@@ -101,6 +119,9 @@ def check_engine_security(
     return the empty list; adding a new advisory means editing exactly
     one function, no call-site changes.
 
+    ``headers`` are forwarded to the underlying probe so auth-gated fleet
+    hosts (bearer tokens etc) don't get 401 and silently skip the check.
+
     Currently populated:
     * ``ollama`` → :func:`check_ollama_security` (CVE-2026-7482 heap
       disclosure, CVE-2026-5757 unauthenticated /api/create)
@@ -108,7 +129,7 @@ def check_engine_security(
       here when one lands.
     """
     if engine == "ollama":
-        return check_ollama_security(host, fleet_mode=fleet_mode)
+        return check_ollama_security(host, fleet_mode=fleet_mode, headers=headers)
     return []
 
 

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -89,6 +89,29 @@ def check_ollama_security(host: str, fleet_mode: bool = False) -> list[str]:
     return warnings
 
 
+def check_engine_security(
+    host: str, engine: str, fleet_mode: bool = False
+) -> list[str]:
+    """Engine-aware security posture check. Dispatch on transport type.
+
+    Extension point for the pluggable transport layer: each engine's
+    check emits SEC ⚠ warning strings for issues that are *engine*-specific
+    (a CVE against the inference server itself, an unauthenticated admin
+    endpoint, a stale version). Engines with no known open advisories
+    return the empty list; adding a new advisory means editing exactly
+    one function, no call-site changes.
+
+    Currently populated:
+    * ``ollama`` → :func:`check_ollama_security` (CVE-2026-7482 heap
+      disclosure, CVE-2026-5757 unauthenticated /api/create)
+    * ``openai-compat`` / ``vllm`` → ``[]`` today; wire an advisory
+      here when one lands.
+    """
+    if engine == "ollama":
+        return check_ollama_security(host, fleet_mode=fleet_mode)
+    return []
+
+
 @dataclass
 class PreflightReport:
     vram_total_gb: float

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -54,12 +54,18 @@ class HermiaApp(App[None]):
         host = self._engine_security_host
         if host is None:
             return
-        warnings = check_engine_security(host, "ollama", fleet_mode=False)
+        # Advisory-only: never let a malformed /api/version response or
+        # unexpected transport error kill the worker and lose the toast.
+        try:
+            warnings = check_engine_security(host, "ollama", fleet_mode=False)
+        except Exception as exc:  # noqa: BLE001 — advisory-only, degrade quietly
+            warnings = [f"SEC ⚠ engine-security probe failed: {exc}"]
         # Skip stderr on a live TTY — Textual owns the terminal in raw mode
         # and a bare write would corrupt the rendered UI. The toast still
         # surfaces the warning interactively; redirected-fd invocations
-        # (`hermia 2>log`) still capture it.
-        stderr_safe = not sys.stderr.isatty()
+        # (`hermia 2>log`) still capture it. sys.stderr can be None under
+        # GUI wrappers / daemonized launchers.
+        stderr_safe = sys.stderr is not None and not sys.stderr.isatty()
         for w in warnings:
             if stderr_safe:
                 print(w, file=sys.stderr)

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -7,6 +7,8 @@ they use distinct topic prefixes and screens only subscribe to their own).
 """
 from __future__ import annotations
 
+import sys
+
 from textual.app import App
 
 from hermia.tui.bus import SessionBus
@@ -16,23 +18,46 @@ from hermia.tui.state import FleetConfig
 class HermiaApp(App[None]):
     CSS_PATH = None  # widgets define their own DEFAULT_CSS
 
-    def __init__(self, startup_warnings: list[str] | None = None) -> None:
+    def __init__(self, engine_security_host: str | None = None) -> None:
         super().__init__()
         self.config: FleetConfig = FleetConfig(name="")
         self.bus: SessionBus = SessionBus()
-        # Engine-security warnings collected before the TUI took over the
-        # screen. Textual switches to the alternate screen buffer on mount,
-        # so anything written to stderr before HermiaApp().run() is not
-        # reliably visible to the user; surface them here as toast
-        # notifications on mount instead.
-        self._startup_warnings: list[str] = list(startup_warnings or [])
+        # Local Ollama host to probe for engine-security advisories after
+        # mount (see _probe_engine_security). None disables the probe
+        # (e.g. for tests that don't want a network call at startup).
+        self._engine_security_host: str | None = engine_security_host
 
     def on_mount(self) -> None:
         # Import here to avoid a circular import — screens.launch imports HermiaApp.
         from hermia.tui.screens.launch import LaunchScreen
         self.push_screen(LaunchScreen())
-        for warning in self._startup_warnings:
-            self.notify(warning, severity="warning", timeout=15)
+        if self._engine_security_host is not None:
+            # Off-thread: check_ollama_security does a synchronous
+            # requests.get with a 3-second timeout — blocking on_mount would
+            # stall the TUI's first paint by that long when the Ollama host
+            # is unreachable.
+            self.run_worker(
+                self._probe_engine_security,
+                thread=True,
+                exclusive=True,
+                name="engine-security",
+            )
+
+    def _probe_engine_security(self) -> None:
+        """Run the engine-security check off the main thread.
+
+        Emits any warnings both to stderr (for redirected-fd logging) and
+        as in-app toast notifications via ``call_from_thread``, since
+        Textual's message pump lives on the main thread.
+        """
+        from hermia.preflight import check_engine_security
+        host = self._engine_security_host
+        if host is None:
+            return
+        warnings = check_engine_security(host, "ollama", fleet_mode=False)
+        for w in warnings:
+            print(w, file=sys.stderr)
+            self.call_from_thread(self.notify, w, severity="warning", timeout=15)
 
     def on_unmount(self) -> None:
         self.bus.close()

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -77,7 +77,7 @@ class HermiaApp(App[None]):
             if stderr_safe:
                 try:
                     print(w, file=sys.stderr)
-                except (OSError, ValueError):
+                except (OSError, ValueError, AttributeError):
                     # stderr closed / detached under us; the toast still
                     # surfaces the warning, so drop the log line silently.
                     pass

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -65,7 +65,14 @@ class HermiaApp(App[None]):
         # surfaces the warning interactively; redirected-fd invocations
         # (`hermia 2>log`) still capture it. sys.stderr can be None under
         # GUI wrappers / daemonized launchers.
-        stderr_safe = sys.stderr is not None and not sys.stderr.isatty()
+        # Custom stream shims (some test runners, GUI wrappers) may not
+        # implement isatty(); treat "no isatty" as safe to write (same
+        # semantics as a non-TTY file).
+        isatty = getattr(sys.stderr, "isatty", None)
+        stderr_safe = (
+            sys.stderr is not None
+            and (isatty is None or not isatty())
+        )
         for w in warnings:
             if stderr_safe:
                 print(w, file=sys.stderr)

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -69,7 +69,16 @@ class HermiaApp(App[None]):
         for w in warnings:
             if stderr_safe:
                 print(w, file=sys.stderr)
-            self.call_from_thread(self.notify, w, severity="warning", timeout=15)
+            try:
+                self.call_from_thread(
+                    self.notify, w, severity="warning", timeout=15
+                )
+            except RuntimeError:
+                # App unmounted / event loop closed while the probe was
+                # still running (worst case: within the 3s /api/version
+                # window). Losing the toast on shutdown is fine — the
+                # stderr line above already captured it for logging.
+                return
 
     def on_unmount(self) -> None:
         self.bus.close()

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -55,8 +55,14 @@ class HermiaApp(App[None]):
         if host is None:
             return
         warnings = check_engine_security(host, "ollama", fleet_mode=False)
+        # Skip stderr on a live TTY — Textual owns the terminal in raw mode
+        # and a bare write would corrupt the rendered UI. The toast still
+        # surfaces the warning interactively; redirected-fd invocations
+        # (`hermia 2>log`) still capture it.
+        stderr_safe = not sys.stderr.isatty()
         for w in warnings:
-            print(w, file=sys.stderr)
+            if stderr_safe:
+                print(w, file=sys.stderr)
             self.call_from_thread(self.notify, w, severity="warning", timeout=15)
 
     def on_unmount(self) -> None:

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -75,7 +75,12 @@ class HermiaApp(App[None]):
         )
         for w in warnings:
             if stderr_safe:
-                print(w, file=sys.stderr)
+                try:
+                    print(w, file=sys.stderr)
+                except (OSError, ValueError):
+                    # stderr closed / detached under us; the toast still
+                    # surfaces the warning, so drop the log line silently.
+                    pass
             try:
                 self.call_from_thread(
                     self.notify, w, severity="warning", timeout=15

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -16,15 +16,23 @@ from hermia.tui.state import FleetConfig
 class HermiaApp(App[None]):
     CSS_PATH = None  # widgets define their own DEFAULT_CSS
 
-    def __init__(self) -> None:
+    def __init__(self, startup_warnings: list[str] | None = None) -> None:
         super().__init__()
         self.config: FleetConfig = FleetConfig(name="")
         self.bus: SessionBus = SessionBus()
+        # Engine-security warnings collected before the TUI took over the
+        # screen. Textual switches to the alternate screen buffer on mount,
+        # so anything written to stderr before HermiaApp().run() is not
+        # reliably visible to the user; surface them here as toast
+        # notifications on mount instead.
+        self._startup_warnings: list[str] = list(startup_warnings or [])
 
     def on_mount(self) -> None:
         # Import here to avoid a circular import — screens.launch imports HermiaApp.
         from hermia.tui.screens.launch import LaunchScreen
         self.push_screen(LaunchScreen())
+        for warning in self._startup_warnings:
+            self.notify(warning, severity="warning", timeout=15)
 
     def on_unmount(self) -> None:
         self.bus.close()

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -238,6 +238,40 @@ def test_run_host_eval_writes_expected_rows(
     assert [r["test_id"] for r in rows] == ["t1"]
 
 
+def test_run_host_eval_emits_engine_security_warnings_via_stderr_fn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """hermia-3zp — CVE warning for a stale Ollama server must surface per-host on stderr."""
+    import hermia.fleet as fleet
+    from hermia.results import open_run
+
+    def fake_run_test(model, test, sampler, host=None, headers=None, transport=None, **kw):  # type: ignore[no-untyped-def]
+        return {"model": model, "test_id": test["id"], "failure_reason": "",
+                "elapsed_sec": 0.1, "tokens_per_sec": 1.0}
+    monkeypatch.setattr("hermia.runner.run_test", fake_run_test, raising=False)
+    monkeypatch.setattr("hermia.runner.load_tests_all", lambda: [{"id": "t1"}], raising=False)
+    monkeypatch.setattr("hermia.runner.get_available_models",
+                        lambda host=None, headers=None: [{"name": "m1"}], raising=False)
+
+    # Force check_ollama_security to see a vulnerable version.
+    def fake_check(host, engine, fleet_mode=False):  # type: ignore[no-untyped-def]
+        if engine == "ollama":
+            return [f"SEC ⚠ CVE-2026-7482: Ollama 0.16.0 vulnerable (host={host})"]
+        return []
+    monkeypatch.setattr("hermia.preflight.check_engine_security", fake_check, raising=False)
+
+    stderr_lines: list[str] = []
+    jsonl, csv = open_run(tmp_path)
+    entry = {"name": "node1", "host": "http://h1:11434"}
+    fleet._run_host_eval(
+        entry, repeat=1, run_id="rid", jsonl_path=jsonl, csv_path=csv,
+        print_lock=__import__("threading").Lock(),
+        print_fn=lambda s: None, stderr_fn=stderr_lines.append, verbosity=-1,
+    )
+    assert any("CVE-2026-7482" in line for line in stderr_lines), stderr_lines
+    assert any("node1:" in line for line in stderr_lines), stderr_lines
+
+
 # ---------------------------------------------------------------------------
 # --fleet flag in main() skips TUI
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -254,7 +254,7 @@ def test_run_host_eval_emits_engine_security_warnings_via_stderr_fn(
                         lambda host=None, headers=None: [{"name": "m1"}], raising=False)
 
     # Force check_ollama_security to see a vulnerable version.
-    def fake_check(host, engine, fleet_mode=False):  # type: ignore[no-untyped-def]
+    def fake_check(host, engine, fleet_mode=False, headers=None):  # type: ignore[no-untyped-def]
         if engine == "ollama":
             return [f"SEC ⚠ CVE-2026-7482: Ollama 0.16.0 vulnerable (host={host})"]
         return []

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -212,3 +212,44 @@ def test_engine_security_ollama_forwards_fleet_mode():
             "http://remotehost:11434", "ollama", fleet_mode=True
         )
     assert not any("CVE-2026-5757" in w for w in warns)
+
+
+def test_engine_security_ollama_forwards_auth_headers():
+    """Bearer/auth headers must reach the /api/version probe on auth-gated hosts."""
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def _fake_get(url, timeout=None, headers=None):  # type: ignore[no-untyped-def]
+        captured["headers"] = headers
+        r = MagicMock()
+        r.ok = True
+        r.json.return_value = {"version": "0.22.1"}
+        return r
+
+    with patch("requests.get", side_effect=_fake_get):
+        check_engine_security(
+            "http://litellm:4000",
+            "ollama",
+            fleet_mode=True,
+            headers={"Authorization": "Bearer token-xyz"},
+        )
+    assert captured["headers"] == {"Authorization": "Bearer token-xyz"}
+
+
+def test_ollama_security_survives_non_dict_json_body():
+    """A /api/version body that isn't a dict must not raise."""
+    r = MagicMock()
+    r.ok = True
+    r.json.return_value = ["not", "a", "dict"]
+    with patch("requests.get", return_value=r):
+        warns = check_ollama_security("http://x:11434", fleet_mode=True)
+    assert not any("CVE-2026-7482" in w for w in warns)
+
+
+def test_ollama_security_survives_non_json_body():
+    """A /api/version body that isn't JSON must not raise."""
+    r = MagicMock()
+    r.ok = True
+    r.json.side_effect = ValueError("not JSON")
+    with patch("requests.get", return_value=r):
+        warns = check_ollama_security("http://x:11434", fleet_mode=True)
+    assert not any("CVE-2026-7482" in w for w in warns)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from hermia.preflight import OLLAMA_MIN_SECURE_VERSION, check_ollama_security, run_preflight
+from hermia.preflight import (
+    OLLAMA_MIN_SECURE_VERSION,
+    check_engine_security,
+    check_ollama_security,
+    run_preflight,
+)
 
 MODEL_LIST = [
     {"name": "llama3:8b", "size": int(4.7 * 1024**3)},
@@ -169,3 +174,41 @@ def test_preflight_report_security_warnings_populated(tmp_path: Path):
         report = run_preflight(["llama3:8b"], MODEL_LIST, tmp_path, fleet_mode=False)
     assert any("CVE-2026-7482" in w for w in report.security_warnings)
     assert any("CVE-2026-5757" in w for w in report.security_warnings)
+
+
+# ---------------------------------------------------------------------------
+# check_engine_security dispatcher (hermia-3zp)
+# ---------------------------------------------------------------------------
+
+def test_engine_security_ollama_routes_to_ollama_check():
+    with _mock_version("0.16.0"):
+        warns = check_engine_security(
+            "http://localhost:11434", "ollama", fleet_mode=False
+        )
+    assert any("CVE-2026-7482" in w for w in warns)
+
+
+def test_engine_security_openai_compat_is_empty_extension_point():
+    with _mock_version("0.16.0"):
+        warns = check_engine_security(
+            "http://gateway:4000", "openai-compat", fleet_mode=True
+        )
+    assert warns == []
+
+
+def test_engine_security_unknown_engine_is_empty_extension_point():
+    """A future 'vllm' engine with no advisory returns [] until an advisory lands."""
+    with _mock_version("0.16.0"):
+        warns = check_engine_security(
+            "http://vllm:8000", "vllm", fleet_mode=False
+        )
+    assert warns == []
+
+
+def test_engine_security_ollama_forwards_fleet_mode():
+    """fleet_mode=True must suppress the local-only CVE-2026-5757 advisory."""
+    with _mock_version("0.22.1"):
+        warns = check_engine_security(
+            "http://remotehost:11434", "ollama", fleet_mode=True
+        )
+    assert not any("CVE-2026-5757" in w for w in warns)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -245,6 +245,38 @@ def test_ollama_security_survives_non_dict_json_body():
     assert not any("CVE-2026-7482" in w for w in warns)
 
 
+def test_ollama_security_normalizes_scheme_less_host():
+    """A raw `localhost:11434` (no scheme) must be normalized, not passed as-is to requests.get."""
+    seen_urls: list[str] = []
+
+    def _fake_get(url, timeout=None, headers=None):  # type: ignore[no-untyped-def]
+        seen_urls.append(url)
+        r = MagicMock()
+        r.ok = True
+        r.json.return_value = {"version": "0.22.1"}
+        return r
+
+    with patch("requests.get", side_effect=_fake_get):
+        check_ollama_security("localhost:11434", fleet_mode=True)
+    assert seen_urls == ["http://localhost:11434/api/version"]
+
+
+def test_ollama_security_strips_trailing_slash():
+    """A trailing slash on the host must not produce a `//api/version` URL."""
+    seen_urls: list[str] = []
+
+    def _fake_get(url, timeout=None, headers=None):  # type: ignore[no-untyped-def]
+        seen_urls.append(url)
+        r = MagicMock()
+        r.ok = True
+        r.json.return_value = {"version": "0.22.1"}
+        return r
+
+    with patch("requests.get", side_effect=_fake_get):
+        check_ollama_security("http://localhost:11434/", fleet_mode=True)
+    assert seen_urls == ["http://localhost:11434/api/version"]
+
+
 def test_ollama_security_survives_non_json_body():
     """A /api/version body that isn't JSON must not raise."""
     r = MagicMock()


### PR DESCRIPTION
Closes hermia-3zp — fourth of the six v0.2.0 release-blockers from the 2026-07-02 adversarial audit.

## Summary
The Ollama CVE-2026-7482 (CVSS 9.1 heap disclosure) and CVE-2026-5757 (unauthenticated \`/api/create\`) checks already existed in \`preflight.py\` but were **never called on the run path**. An audited security tool was silently shipping a security feature that never fired. Audit flagged HIGH.

Per bead + your clarification: don't delete — dispatch on transport type via a new \`check_engine_security(host, engine, fleet_mode)\`. Extension point for the pluggable transport layer.

- **preflight.py** — new dispatcher. Today: \`ollama\` → \`check_ollama_security\`; \`openai-compat\` / \`vllm\` / unknown → \`[]\` (wire an advisory here when one lands, no call-site changes).
- **fleet.py \`_run_host_eval\`** — called per-host right after transport selection, before model discovery, so warnings surface even if discovery fails. Prints via \`stderr_fn\` under \`print_lock\`; host-name prefix for concurrent-host output. \`fleet_mode=True\` (suppresses local-only CVE-2026-5757).
- **app.py \`main()\`** — TUI-mode launch prints warnings to stderr before \`HermiaApp().run()\` takes over. \`fleet_mode=False\` (local Ollama IS a loopback concern).

## Test plan
- [x] 5 new tests: dispatcher routes ollama → check_ollama_security; openai-compat → \`[]\`; unknown engine (vllm) → \`[]\`; \`fleet_mode\` forwarded; \`_run_host_eval\` integration surfaces CVE warning via \`stderr_fn\` with host-name prefix
- [x] 88/88 test_preflight + test_fleet pass; 101/101 test_runner pass; full suite green (env-preexisting metrics failures unchanged)
- [x] ruff clean; mypy clean
- [ ] CodeRabbit + Gemini review
- [ ] Merge to dev when green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup security checks for local engine connections and display of any warnings in the app.
  * Extended host evaluation to surface security advisories before tests run.

* **Bug Fixes**
  * Improved handling of unreachable or slow hosts so the interface can appear without being blocked.
  * Made host checks more resilient to malformed responses and missing URL schemes.

* **Tests**
  * Added coverage for warning display, header forwarding, host normalization, and engine-specific security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->