### PR TITLE
v0.2 MEDIUM audit doc fixes — ATLAS version, determinism scope, known limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ published methodology catalog and framework matrix.
 - Documented residual grader limitations (e.g. a ~1.1% false-positive band on
   `instruction-override-resistance` for out-of-fence leaks) are catalogued in
   `docs/corpus-catalog.md`.
+- Dependencies are declared with **minimum-version floors** (`>=`) in
+  `pyproject.toml`; no fully-pinned lockfile ships in v0.2.x. A resolver picking
+  a newer transitive version can in principle change behavior. A committed
+  lockfile is planned for v0.3.
+- Row-level provenance today is corpus-hash stamping only (an unkeyed SHA-256
+  of `agentic-tasks.json`). It detects accidental data drift given an
+  authoritative reference; it is **not** cryptographic row-signing and does
+  **not** cover the grading code in `schemas.py`. Row-signing and hashing the
+  eval code are planned for v0.3. See `src/hermia/runner.py` (`corpus_sha256`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ built for your context.
 | Framework | What Hermia Maps To |
 |---|---|
 | **OWASP LLM Top 10 (2025)** | LLM01 prompt injection (direct + indirect), LLM06 excessive agency / scope escalation |
-| **MITRE ATLAS v5.1** | AML.T0051 direct injection, AML.T0054 indirect injection, AML.T0099 tool data poisoning, AML.T0100 structured field injection |
+| **MITRE ATLAS 6.0.0 (2026.05)** | AML.T0051 direct injection, AML.T0054 indirect injection, AML.T0099 tool data poisoning, AML.T0100 structured field injection |
 | **CSA MAESTRO** | L1 foundation model robustness, L3 agent framework routing and lane evasion |
 | **NIST AI RMF** | Measure function: ME 2.3 deployment-similar benchmarking, ME 2.4 production monitoring, ME 3.1 regression detection |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -419,14 +419,12 @@ Multi-turn cases are useful for testing:
 ### Determinism
 
 The orchestration is fully deterministic — fixed turn order, identical message
-construction, no randomness in how the conversation is assembled. Hermia passes
-`temperature=0` to the backend for multi-turn cases to give the backend the best
-opportunity to produce reproducible output. Whether the model actually produces
-identical output depends on backend support (temperature 0 + seed support varies);
-this is documented, not promised.
-
-Single-turn cases (a case with no `turns` field, or `turns` absent) are unaffected —
-they use the transport's default temperature exactly as before.
+construction, no randomness in how the conversation is assembled. Hermia pins
+`temperature=0` and `seed=42` for **every** test request (single-turn and
+multi-turn alike; see `EVAL_TEMPERATURE` / `EVAL_SEED` in `src/hermia/runner.py`)
+and forwards both to Ollama and OpenAI-compatible transports. Whether the model
+actually produces identical output depends on backend support (temperature 0 +
+seed support varies by engine and model); this is documented, not promised.
 
 ### Result fields
 


### PR DESCRIPTION
Closes the three MEDIUM findings from the 2026-07-02 adversarial audit that are pure documentation. Last release-blocker cluster before the v0.2.0 tag.

## Summary
1. **README.md — MITRE ATLAS version fix.** README claimed 'v5.1'; corpus already ships '6.0.0 (2026.05)' (see \`docs/corpus-prompts.md\`). Updated README to match the actual corpus mapping.
2. **docs/usage.md — determinism section rewrite.** Old text said single-turn cases 'use the transport's default temperature.' In reality \`runner.py\` has \`EVAL_TEMPERATURE=0.0\` / \`EVAL_SEED=42\` pinned for every request since Workstream E. Rewrote to reflect the code: temp=0 + seed=42 on all cases, forwarded to both transports, backend support caveated.
3. **CHANGELOG.md Known limitations — two additions:**
   - Dependencies use \`>=\` floors; no lockfile in v0.2.x (planned v0.3).
   - Row-level provenance is corpus-hash stamping only — not row-signing, does not cover \`schemas.py\`. Points at the \`corpus_sha256\` docstring for the honest bounds. Matches the [#142](https://github.com/scottblydotcom/hermia/pull/142) soften-step framing.

## Test plan
- [x] ruff clean
- [x] 103/103 test_runner + test_dataset_format pass
- [ ] CodeRabbit + Gemini review
- [ ] Merge to dev when green — then dev→main promotion + v0.2.0 tag ([[hermia-4e8]])

🤖 Generated with [Claude Code](https://claude.com/claude-code)