### PR TITLE
ci: run CI + Security on push to main (fix stale README badges)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
       - "fix/**"
       - "chore/**"
       - "dev"
+      - "main"        # run on the default branch so the README CI badge reflects main
   pull_request:
     branches:
       - dev
       - main
+  workflow_dispatch:  # allow manual re-runs (e.g. to refresh the badge after a promotion)
 
 jobs:
   lint-and-test:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,16 @@
 name: Security
 
 on:
+  push:
+    branches:
+      - main        # scan the default branch on every merge so the README Security badge reflects main
   pull_request:
     branches:
       - main        # full security gate before anything hits main
       - dev         # catch issues before promotion, not after
   schedule:
     - cron: "0 6 * * 1"  # weekly Monday 06:00 UTC — scans main regardless of activity
+  workflow_dispatch:  # allow manual re-runs (e.g. to refresh the badge after a promotion)
 
 jobs:
   gitleaks:


### PR DESCRIPTION
The README CI/Security badges reflect the last run of each workflow on `main`. Neither ran on pushes to main (ci.yml: feature/dev only; security.yml: PR + weekly cron), so the badges showed stale failures from the old v0.1.x main lineage (ci.yml last ran on main 2026-04-19; weekly security scans of old-main failed on the pre-scrub private-infra). Adds a `main` push trigger + `workflow_dispatch` to both so the badges reflect main's real, current (green) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks to run on additional branch updates, including `main`.
  * Added manual trigger support so workflows can be re-run on demand.
  * Broadened security scanning coverage to include updates pushed to `main`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->