### PR TITLE
ci: promote badge fix to main (CI + Security run on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
       - "fix/**"
       - "chore/**"
       - "dev"
+      - "main"        # run on the default branch so the README CI badge reflects main
   pull_request:
     branches:
       - dev
       - main
+  workflow_dispatch:  # allow manual re-runs (e.g. to refresh the badge after a promotion)
 
 jobs:
   lint-and-test:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,16 @@
 name: Security
 
 on:
+  push:
+    branches:
+      - main        # scan the default branch on every merge so the README Security badge reflects main
   pull_request:
     branches:
       - main        # full security gate before anything hits main
       - dev         # catch issues before promotion, not after
   schedule:
     - cron: "0 6 * * 1"  # weekly Monday 06:00 UTC — scans main regardless of activity
+  workflow_dispatch:  # allow manual re-runs (e.g. to refresh the badge after a promotion)
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Promotes the CI/Security badge fix (#148) to main. Once merged, the push to main triggers fresh ci.yml + security.yml runs on the default branch, updating the stale README badges to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)