### PR TITLE
fix(fleet): reject unrecognized keys on headless fleet[] entries (hermia-csd)

### DIFF
--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -10,6 +10,12 @@ from typing import Any
 
 import yaml
 
+# Headless fleet[] schema only — TUI hosts[] uses different keys (url/engine),
+# converted to this schema by _tui_fleet_to_entries before entries reach load_fleet_config's checks.
+_FLEET_ENTRY_KEYS = frozenset(
+    {"name", "host", "transport", "auth", "models", "stack", "test_timeout"}
+)
+
 
 def _tui_fleet_to_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Convert TUI save_fleet format to headless fleet entries.
@@ -67,6 +73,18 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
     for i, entry in enumerate(entries):
         if not isinstance(entry, dict):
             raise ValueError(f"Fleet entry [{i}] must be a mapping, got {type(entry).__name__}")
+        unrecognized = sorted(str(k) for k in entry if k not in _FLEET_ENTRY_KEYS)
+        if unrecognized:
+            hint = (
+                " (Note: 'engine' is a TUI hosts[] key — headless fleet[] entries use "
+                "'transport' instead.)"
+                if "engine" in unrecognized
+                else ""
+            )
+            raise ValueError(
+                f"Fleet entry [{i}] has unrecognized key(s): {', '.join(unrecognized)}. "
+                f"Allowed keys: {', '.join(sorted(_FLEET_ENTRY_KEYS))}.{hint}"
+            )
         if not isinstance(entry.get("name"), str) or not entry["name"]:
             raise ValueError(f"Fleet entry [{i}] missing or invalid 'name'")
         if not isinstance(entry.get("host"), str) or not entry["host"]:

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1036,6 +1036,92 @@ def test_load_fleet_config_stack_optional(tmp_path: Path) -> None:
     assert "stack" not in entries[0]
 
 
+@pytest.mark.parametrize(
+    "bad_key",
+    ["engine", "url"],
+    ids=["engine-tui-key", "url-typo-for-host"],
+)
+def test_load_fleet_config_rejects_unrecognized_key(tmp_path: Path, bad_key: str) -> None:
+    """A fleet[] entry key outside the allowed set (e.g. 'engine' — a TUI hosts[]
+    key — or a typo'd 'url' instead of 'host') must raise ValueError naming it,
+    not silently drop it."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        f"    {bad_key}: some-value\n"
+    )
+    with pytest.raises(ValueError, match=bad_key):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_unrelated_typo_omits_engine_hint(tmp_path: Path) -> None:
+    """The 'engine is a TUI key' hint should only appear when 'engine' is the
+    actual unrecognized key — not tacked onto every unrelated typo."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    modles: llama3\n"
+    )
+    with pytest.raises(ValueError) as exc_info:
+        load_fleet_config(cfg)
+    assert "modles" in str(exc_info.value)
+    assert "TUI hosts" not in str(exc_info.value)
+
+
+def test_load_fleet_config_rejects_multiple_unrecognized_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    engine: openai-compat\n"
+        "    port: 8080\n"
+    )
+    with pytest.raises(ValueError) as exc_info:
+        load_fleet_config(cfg)
+    assert "engine" in str(exc_info.value)
+    assert "port" in str(exc_info.value)
+
+
+def test_load_fleet_config_all_allowed_keys_no_raise(tmp_path: Path) -> None:
+    """An entry using only the documented allowed keys must parse cleanly."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    transport: openai-compat\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env: MY_KEY\n"
+        "    models:\n"
+        "      - llama3\n"
+        "    stack:\n"
+        "      gpu_arch: sm_89\n"
+        "    test_timeout: 30\n"
+    )
+    entries = load_fleet_config(cfg)
+    assert entries[0]["transport"] == "openai-compat"
+
+
+def test_load_fleet_config_tui_hosts_schema_engine_key_unaffected(tmp_path: Path) -> None:
+    """The TUI hosts[] schema's 'engine' key is a different, already-valid
+    schema and must not be rejected by the fleet[] unrecognized-key check."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "hosts:\n"
+        "  - name: node3\n"
+        "    url: http://host1:11434\n"
+        "    engine: openai-compat\n"
+    )
+    entries = load_fleet_config(cfg)
+    assert entries[0]["transport"] == "openai-compat"
+
+
 # ---------------------------------------------------------------------------
 # repeat loop — run_results accumulation and score_rows stamping
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `load_fleet_config` now rejects any headless `fleet[]` YAML entry containing a key outside `{name, host, transport, auth, models, stack, test_timeout}`, instead of silently ignoring it.
- Closes the silent-misconfig bug from the 2026-07-05 docs audit: writing `engine: openai-compat` (a TUI `hosts[]` key) under a `fleet[]` entry used to silently fall through to `transport=ollama` with no error.
- Error message names the offending key(s) and only shows the "engine is a TUI key" hint when `engine` is actually the mistake.

## Verification
- Confirmed every shipped/example fleet YAML in the repo (`fleets/*.yaml`, `hermia-fleet.yaml`, `hermia-fleet-spill.yaml`, `examples/kwaainet-fleet.yaml`) uses only allowed keys — nothing regresses.
- Confirmed the TUI `hosts[]` → `fleet[]` conversion path (`_tui_fleet_to_entries`) only ever emits keys within the allow-list, so TUI-format configs can never trigger the new check.
- Two independent review rounds (medium + high effort) found zero correctness bugs; applied the cleanup fixes they raised (non-string-key crash guard, `frozenset` hardening, conditional hint, parametrized/tightened tests).
- Full suite: 1833 passed, 6 deselected (pre-existing, unrelated macOS GPU-detection failures — hermia-2ess).

## Note on AGENTS.md `_keys_ok()` rule
AGENTS.md's rule 2 says schema validators should tolerate extra keys via `_keys_ok()`. That rule is scoped to reasoning-model *output* schemas (tolerating benign `thinking`/`scratchpad` fields) — applying it to YAML config validation here would silently accept the exact typos this fix exists to catch. Flagging explicitly so a future review pass doesn't raise it blind.

## Follow-up
Filed hermia-em6r: the same silent-misconfig class exists one level deeper, in `auth.bearer`/`stack` sub-keys (e.g. a typo'd `key_env` silently no-ops instead of erroring). Out of scope for this bead.

## Test plan
- [x] `.venv/bin/ruff check src/hermia/fleet.py tests/unit/test_fleet.py`
- [x] `.venv/bin/mypy src/hermia/fleet.py`
- [x] `.venv/bin/pytest -q` (scoped baseline, deselecting known hermia-2ess GPU-detection failures) — 1833 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fleet configuration loading now rejects unsupported fields in headless entries and reports exactly which keys are invalid.
  * Error messages now include the full list of allowed keys, with a helpful hint when a TUI-style `engine` field is used in the wrong place.
  * Valid fleet entries continue to load normally, including entries with nested configuration and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->