### PR TITLE
fix(fleet): validate nested auth/stack sub-keys, not just top-level fleet[] keys (hermia-em6r)

### DIFF
--- a/examples/kwaainet-fleet.yaml
+++ b/examples/kwaainet-fleet.yaml
@@ -17,7 +17,6 @@ fleet:
     host: http://localhost:11435   # kwaainet shard api endpoint
     transport: openai-compat       # KwaaiNet serves OpenAI /v1, not Ollama /api
     models: auto                   # discover via GET /v1/models (no hand-typed id)
-    stack:                         # documents the stack that produced these rows
-      orchestration: kwaainet
-      topology: distributed-sharded
-      transport: relay
+    # Stack: KwaaiNet-orchestrated, distributed-sharded, relay transport.
+    # Not captured under `stack:` — that block's schema is gpu_arch/runtime_version
+    # only (see docs/usage.md); it doesn't have fields for orchestration/topology.

--- a/src/hermia/fleet.py
+++ b/src/hermia/fleet.py
@@ -15,6 +15,9 @@ import yaml
 _FLEET_ENTRY_KEYS = frozenset(
     {"name", "host", "transport", "auth", "models", "stack", "test_timeout"}
 )
+_AUTH_KEYS = frozenset({"bearer"})
+_BEARER_KEYS = frozenset({"key_env"})
+_STACK_KEYS = frozenset({"gpu_arch", "runtime_version"})
 
 
 def _tui_fleet_to_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -45,6 +48,27 @@ def _tui_fleet_to_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
             entry["stack"] = h["stack"]
         entries.append(entry)
     return entries
+
+
+def _check_nested_dict(
+    value: Any, label: str, allowed: frozenset[str], i: int
+) -> dict[str, Any] | None:
+    """Validate an optional nested dict (e.g. entry['stack'], auth['bearer']):
+    must be a mapping if present, and every key must be in `allowed`.
+    Returns the dict (or None if absent) for the caller to inspect further."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"Fleet entry [{i}] '{label}' must be a mapping, got {type(value).__name__}"
+        )
+    unrecognized = sorted(str(k) for k in value if k not in allowed)
+    if unrecognized:
+        raise ValueError(
+            f"Fleet entry [{i}] '{label}' has unrecognized key(s): {', '.join(unrecognized)}. "
+            f"Allowed keys: {', '.join(sorted(allowed))}."
+        )
+    return value
 
 
 def load_fleet_config(path: Path) -> list[dict[str, Any]]:
@@ -108,11 +132,10 @@ def load_fleet_config(path: Path) -> list[dict[str, Any]]:
                 raise ValueError(
                     f"Fleet entry [{i}] 'models' must be a list of strings or 'auto'"
                 )
-        stack = entry.get("stack")
-        if stack is not None and not isinstance(stack, dict):
-            raise ValueError(
-                f"Fleet entry [{i}] 'stack' must be a mapping, got {type(stack).__name__}"
-            )
+        _check_nested_dict(entry.get("stack"), "stack", _STACK_KEYS, i)
+        auth = _check_nested_dict(entry.get("auth"), "auth", _AUTH_KEYS, i)
+        if auth is not None:
+            _check_nested_dict(auth.get("bearer"), "auth.bearer", _BEARER_KEYS, i)
     return entries
 
 

--- a/tests/unit/test_fleet.py
+++ b/tests/unit/test_fleet.py
@@ -1036,6 +1036,111 @@ def test_load_fleet_config_stack_optional(tmp_path: Path) -> None:
     assert "stack" not in entries[0]
 
 
+def test_load_fleet_config_rejects_unrecognized_auth_key(tmp_path: Path) -> None:
+    """auth: {bearer: {...}, extra_key: foo} must raise, naming 'extra_key'."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env: TEST_TOKEN\n"
+        "      extra_key: foo\n"
+    )
+    with pytest.raises(ValueError, match="extra_key"):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_rejects_unrecognized_bearer_key(tmp_path: Path) -> None:
+    """auth.bearer: {key_env: ..., extra: foo} must raise, naming 'extra'."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env: TEST_TOKEN\n"
+        "        extra: foo\n"
+    )
+    with pytest.raises(ValueError, match="extra"):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_rejects_typo_key_env(tmp_path: Path) -> None:
+    """A typo'd 'key_env_typo' must raise rather than silently no-op auth."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env_typo: TEST_TOKEN\n"
+    )
+    with pytest.raises(ValueError, match="key_env_typo"):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_rejects_unrecognized_stack_key(tmp_path: Path) -> None:
+    """stack: {gpu_arch: ..., extra_field: foo} must raise, naming 'extra_field'."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    stack:\n"
+        "      gpu_arch: sm_89\n"
+        "      extra_field: foo\n"
+    )
+    with pytest.raises(ValueError, match="extra_field"):
+        load_fleet_config(cfg)
+
+
+def test_load_fleet_config_valid_nested_auth_and_stack(tmp_path: Path) -> None:
+    """A fully valid entry with auth.bearer.key_env and stack fields parses cleanly
+    and preserves the nested values."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env: TEST_TOKEN\n"
+        "    stack:\n"
+        "      gpu_arch: sm_89\n"
+        "      runtime_version: v1.2.3\n"
+    )
+    entries = load_fleet_config(cfg)
+    entry = entries[0]
+    assert entry["auth"]["bearer"]["key_env"] == "TEST_TOKEN"
+    assert entry["stack"]["gpu_arch"] == "sm_89"
+    assert entry["stack"]["runtime_version"] == "v1.2.3"
+
+
+def test_build_auth_headers_still_works_after_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_build_auth_headers keeps working on entries that pass the new nested
+    validation."""
+    cfg = tmp_path / "fleet.yaml"
+    cfg.write_text(
+        "fleet:\n"
+        "  - name: node3\n"
+        "    host: http://host1:11434\n"
+        "    auth:\n"
+        "      bearer:\n"
+        "        key_env: TEST_TOKEN\n"
+    )
+    entries = load_fleet_config(cfg)
+    entry = entries[0]
+    monkeypatch.setenv("TEST_TOKEN", "fake_token_123")
+    headers = _build_auth_headers(entry)
+    assert headers == {"Authorization": "Bearer fake_token_123"}
+
+
 @pytest.mark.parametrize(
     "bad_key",
     ["engine", "url"],

--- a/tests/unit/test_shipped_fleets.py
+++ b/tests/unit/test_shipped_fleets.py
@@ -19,6 +19,19 @@ from hermia.fleet import load_fleet_config
 REPO = Path(__file__).resolve().parents[2]
 LOCAL = REPO / "fleets" / "local.yaml"
 DESKTOP = REPO / "fleets" / "desktop.yaml"
+KWAAINET = REPO / "examples" / "kwaainet-fleet.yaml"
+
+
+def test_shipped_kwaainet_example_loads():
+    """examples/kwaainet-fleet.yaml is copy-pasted verbatim by
+    docs/kwaai-quickstart.md — it must stay loadable as fleet[] validation
+    tightens (regression: a free-form 'stack' block broke this under
+    hermia-em6r's nested key-set enforcement)."""
+    entries = load_fleet_config(KWAAINET)
+    assert len(entries) == 1
+    assert entries[0]["name"] == "kwaainet-metro"
+    assert entries[0]["transport"] == "openai-compat"
+    assert entries[0]["models"] == "auto"
 
 
 def test_shipped_local_fleet_loads_headless_schema():


### PR DESCRIPTION
## Summary
- Extends hermia-csd's (#150) top-level unrecognized-key rejection one level deeper into `auth`, `auth.bearer`, and `stack` sub-dicts of headless `fleet[]` entries. Previously a typo like `key_env_typo` silently no-op'd auth instead of raising, since `_build_auth_headers` reads it via a `.get()` chain.
- Fixes a regression the new validation introduced against `examples/kwaainet-fleet.yaml` (the docs-referenced KwaaiNet quickstart config): its `stack` block used free-form `orchestration`/`topology`/`transport` keys outside the new `gpu_arch`/`runtime_version` schema. Moved that metadata into a comment and added a regression test (`test_shipped_kwaainet_example_loads`) so shipped docs examples stay loadable as validation tightens.
- Refactored the three near-duplicated "mapping + unrecognized-key" checks into a shared `_check_nested_dict` helper.

Closes hermia-em6r.

## Test plan
- [x] `.venv/bin/pytest -q` — 1840 passed, 6 deselected (pre-existing macOS GPU-detection failures, tracked in hermia-2ess, unrelated to this change)
- [x] `.venv/bin/ruff check src/hermia/fleet.py tests/unit/test_fleet.py tests/unit/test_shipped_fleets.py` — clean
- [x] `.venv/bin/mypy src/hermia/fleet.py` — clean
- [x] In-window `/code-review` (medium effort, 8 finder agents) — 2 findings, both fixed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for fleet configuration files so invalid nested fields are rejected with clearer errors.
  * Added support for correctly reading valid authentication and stack settings while preventing misspelled or unexpected entries.
  * Updated the shipped Kwaainet fleet example to match the supported configuration format.
* **Tests**
  * Expanded coverage for fleet loading and example configuration to catch invalid nested settings and confirm valid files still load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->