### PR TITLE
fix(transport): retry openai-compat 5xx before failing eval rows (hermia-x49)

### DIFF
--- a/src/hermia/analyze.py
+++ b/src/hermia/analyze.py
@@ -1,6 +1,7 @@
 """Statistical analysis pass — generates hermia_findings from hermia_results.
 
-Detectors (all exclude TIMEOUT rows from behavioral fail counts):
+Detectors (all exclude TIMEOUT and RETRY_EXHAUSTED rows -- infra noise, not
+behavioral failures -- from behavioral fail counts):
 
   universal_weakness  — test where >30% avg behavioral fail AND >55% of models fail
   model_failure       — model >45% fail on a test where fleet avg is <30%
@@ -92,23 +93,29 @@ class Finding:
 # Statistical detectors
 # ---------------------------------------------------------------------------
 
-_SQL_UNIVERSAL = """
+# Shared infra-noise exclusion: both are transient/backend failures, never a
+# behavioral signal, so every detector below excludes both identically.
+_NOT_INFRA_NOISE = (
+    "(failure_reason NOT LIKE 'TIMEOUT%%' AND failure_reason NOT LIKE 'RETRY_EXHAUSTED%%')"
+)
+
+_SQL_UNIVERSAL = f"""
 WITH model_stats AS (
     SELECT
         test_id,
         model,
         COUNT(*) FILTER (
-            WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+            WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
         ) AS non_timeout,
         COUNT(*) FILTER (
             WHERE (schema_compliant = false OR json_valid = false)
-              AND (failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%')
+              AND (failure_reason IS NULL OR {_NOT_INFRA_NOISE})
         ) AS behavioral_fails
     FROM hermia_results
     WHERE run_id = ANY(%(run_ids)s)
     GROUP BY test_id, model
     HAVING COUNT(*) FILTER (
-        WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+        WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
     ) >= %(min_samples)s
 ),
 test_agg AS (
@@ -162,23 +169,23 @@ def _detect_universal_weaknesses(cur: Any, run_ids: list[str]) -> list[Finding]:
     return findings
 
 
-_SQL_MODEL_FAILURE = """
+_SQL_MODEL_FAILURE = f"""
 WITH model_stats AS (
     SELECT
         model,
         test_id,
         COUNT(*) FILTER (
-            WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+            WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
         ) AS non_timeout,
         COUNT(*) FILTER (
             WHERE (schema_compliant = false OR json_valid = false)
-              AND (failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%')
+              AND (failure_reason IS NULL OR {_NOT_INFRA_NOISE})
         ) AS behavioral_fails
     FROM hermia_results
     WHERE run_id = ANY(%(run_ids)s)
     GROUP BY model, test_id
     HAVING COUNT(*) FILTER (
-        WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+        WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
     ) >= %(min_samples)s
 ),
 model_fail_pct AS (
@@ -247,7 +254,7 @@ _SECURITY_TEST_IDS: list[str] = [
     "lane-routing-evasion",
 ]
 
-_SQL_SECURITY_CRITICAL = """
+_SQL_SECURITY_CRITICAL = f"""
 SELECT
     model,
     test_id,
@@ -256,7 +263,7 @@ SELECT
 FROM hermia_results
 WHERE run_id = ANY(%(run_ids)s)
   AND test_id = ANY(%(security_test_ids)s)
-  AND (failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%')
+  AND (failure_reason IS NULL OR {_NOT_INFRA_NOISE})
 GROUP BY model, test_id
 HAVING COUNT(*) FILTER (WHERE schema_compliant = false) > 0
 ORDER BY fail_count DESC, test_id
@@ -289,17 +296,17 @@ def _detect_security_critical(cur: Any, run_ids: list[str]) -> list[Finding]:
     return findings
 
 
-_SQL_WORST_PERFORMERS = """
+_SQL_WORST_PERFORMERS = f"""
 SELECT
     model,
     COUNT(*) FILTER (WHERE schema_compliant = true) AS passes,
     COUNT(*) FILTER (
-        WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+        WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
     ) AS total,
     ROUND(
         COUNT(*) FILTER (WHERE schema_compliant = true) * 100.0
             / NULLIF(COUNT(*) FILTER (
-                WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+                WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
             ), 0),
         1
     ) AS pass_pct
@@ -307,7 +314,7 @@ FROM hermia_results
 WHERE run_id = ANY(%(run_ids)s)
 GROUP BY model
 HAVING COUNT(*) FILTER (
-    WHERE failure_reason IS NULL OR failure_reason NOT LIKE 'TIMEOUT%%'
+    WHERE failure_reason IS NULL OR {_NOT_INFRA_NOISE}
 ) >= %(min_samples)s
 ORDER BY pass_pct ASC
 LIMIT %(n)s

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -361,7 +361,15 @@ def run_test(
     except requests.exceptions.Timeout:
         error_type = f"TIMEOUT: no response in {_timeout}s"
     except TransportError as e:
-        prefix = "OLLAMA_ERROR" if e.kind == "ollama" else "API_ERROR"
+        if e.kind == "ollama":
+            prefix = "OLLAMA_ERROR"
+        elif e.kind == "openai-compat-retry-exhausted":
+            # Distinct from API_ERROR (an in-body application-level error): this
+            # is a transient-infra failure (repeated 5xx), kept separable so bulk
+            # analysis can filter infra noise from behavioral failures.
+            prefix = "RETRY_EXHAUSTED"
+        else:
+            prefix = "API_ERROR"
         error_type = f"{prefix}: {e}"
     except Exception as e:  # noqa: BLE001
         error_type = f"ERROR: {e}"

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -57,6 +57,7 @@ _KNOWN_FAILURE_PREFIXES: tuple[str, ...] = (
     "EMPTY_RESPONSE",
     "CONTENT_LEAK",
     "TIMEOUT",
+    "RETRY_EXHAUSTED",
     "OLLAMA_ERROR",
     "API_ERROR",
     "ERROR",

--- a/src/hermia/transport/base.py
+++ b/src/hermia/transport/base.py
@@ -16,6 +16,7 @@ class Response:
     orchestration: str
     orchestration_version: str | None
     is_api_mode: bool
+    retries: int = 0
 
 
 class TransportError(Exception):

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -9,6 +9,8 @@ import requests
 from hermia.transport.base import Response, TransportError
 
 _OPENAI_SAMPLING_KEYS = ("temperature", "seed", "top_p")
+_MAX_5XX_RETRIES = 2
+_RETRY_BACKOFF_SEC = (0.5, 2.0)
 
 
 class OpenAICompatTransport:
@@ -66,14 +68,29 @@ class OpenAICompatTransport:
             payload["temperature"] = 0.1
         if "num_predict" in opts and opts["num_predict"] is not None:
             payload["max_tokens"] = opts["num_predict"]
-        t0 = time.monotonic()
-        resp = requests.post(  # nosec B113 — timeout passed via opts.get("timeout", 90)
-            f"{self._base_url}/v1/chat/completions",
-            json=payload,
-            headers=self._headers,
-            timeout=float(opts.get("timeout", 90)),  # type: ignore[arg-type]
-        )
-        resp.raise_for_status()
+        retries = 0
+        while True:
+            # t0 resets each attempt so elapsed_sec (used for tokens/sec downstream)
+            # reflects only the successful request's duration, not failed-attempt
+            # + backoff time from any prior 5xx retries.
+            t0 = time.monotonic()
+            resp = requests.post(  # nosec B113 — timeout passed via opts.get("timeout", 90)
+                f"{self._base_url}/v1/chat/completions",
+                json=payload,
+                headers=self._headers,
+                timeout=float(opts.get("timeout", 90)),  # type: ignore[arg-type]
+            )
+            if isinstance(resp.status_code, int) and resp.status_code >= 500:
+                if retries >= _MAX_5XX_RETRIES:
+                    raise TransportError(
+                        f"after {_MAX_5XX_RETRIES + 1} attempts: HTTP {resp.status_code}",
+                        kind="openai-compat-retry-exhausted",
+                    )
+                time.sleep(_RETRY_BACKOFF_SEC[retries])
+                retries += 1
+                continue
+            resp.raise_for_status()
+            break
         elapsed = time.monotonic() - t0
         data = resp.json()
         if not isinstance(data, dict):
@@ -96,4 +113,5 @@ class OpenAICompatTransport:
             orchestration="openai-compat",
             orchestration_version=None,
             is_api_mode=True,
+            retries=retries,
         )

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -9,8 +9,10 @@ import requests
 from hermia.transport.base import Response, TransportError
 
 _OPENAI_SAMPLING_KEYS = ("temperature", "seed", "top_p")
-_MAX_5XX_RETRIES = 2
-_RETRY_BACKOFF_SEC = (0.5, 2.0)
+# Public (no underscore): imported cross-module by tui/runner_backend.py to
+# derive its own timeout budget, so these are an intentional shared contract.
+RETRY_BACKOFF_SEC = (0.5, 2.0)
+MAX_5XX_RETRIES = len(RETRY_BACKOFF_SEC)
 
 
 class OpenAICompatTransport:
@@ -81,12 +83,12 @@ class OpenAICompatTransport:
                 timeout=float(opts.get("timeout", 90)),  # type: ignore[arg-type]
             )
             if isinstance(resp.status_code, int) and resp.status_code >= 500:
-                if retries >= _MAX_5XX_RETRIES:
+                if retries >= MAX_5XX_RETRIES:
                     raise TransportError(
-                        f"after {_MAX_5XX_RETRIES + 1} attempts: HTTP {resp.status_code}",
+                        f"after {MAX_5XX_RETRIES + 1} attempts: HTTP {resp.status_code}",
                         kind="openai-compat-retry-exhausted",
                     )
-                time.sleep(_RETRY_BACKOFF_SEC[retries])
+                time.sleep(RETRY_BACKOFF_SEC[retries])
                 retries += 1
                 continue
             resp.raise_for_status()

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from hermia.runner import TEST_TIMEOUT
-from hermia.transport.openai_compat import _MAX_5XX_RETRIES, _RETRY_BACKOFF_SEC
+from hermia.transport.openai_compat import MAX_5XX_RETRIES, RETRY_BACKOFF_SEC
 from hermia.tui.bus import SessionBus
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
@@ -28,7 +28,7 @@ from hermia.tui.state import FleetConfig, Host, ModelChoice
 # behavior — derive it instead of hardcoding a number that requires everyone to
 # remember to update it when the retry/backoff constants change.
 TRIAL_WALL_TIMEOUT: float = (
-    TEST_TIMEOUT * (_MAX_5XX_RETRIES + 1) + sum(_RETRY_BACKOFF_SEC) + 30.0
+    TEST_TIMEOUT * (MAX_5XX_RETRIES + 1) + sum(RETRY_BACKOFF_SEC) + 30.0
 )
 
 

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -17,10 +17,19 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from hermia.runner import TEST_TIMEOUT
+from hermia.transport.openai_compat import _MAX_5XX_RETRIES, _RETRY_BACKOFF_SEC
 from hermia.tui.bus import SessionBus
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
-TRIAL_WALL_TIMEOUT: float = 120.0
+# Must cover the openai-compat transport's worst case: every attempt (including
+# retries) can take up to TEST_TIMEOUT, plus backoff sleep between them. A
+# static budget here silently drifts out of sync with the transport's retry
+# behavior — derive it instead of hardcoding a number that requires everyone to
+# remember to update it when the retry/backoff constants change.
+TRIAL_WALL_TIMEOUT: float = (
+    TEST_TIMEOUT * (_MAX_5XX_RETRIES + 1) + sum(_RETRY_BACKOFF_SEC) + 30.0
+)
 
 
 def verdict_from_result(result: dict[str, Any]) -> str:
@@ -165,8 +174,9 @@ class TuiRunner:
         try:
             # wait_for cancels the coroutine wrapper on timeout but cannot kill
             # the OS thread. The thread runs until _run_fn returns or its own
-            # socket timeout fires (~90 s via the transport layer), so zombie
-            # threads are bounded to at most 1-2 per host lane at any moment.
+            # socket timeout fires via the transport layer (up to TEST_TIMEOUT
+            # per attempt, including openai-compat's 5xx retries), so zombie
+            # threads are bounded by TRIAL_WALL_TIMEOUT's own worst-case budget.
             result: dict[str, Any] = await asyncio.wait_for(
                 asyncio.to_thread(
                     self._run_fn,

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -32,6 +32,18 @@ TRIAL_WALL_TIMEOUT: float = (
 )
 
 
+def _trial_wall_timeout_sec(test: dict[str, Any], per_call_timeout: float) -> float:
+    """Scale the wall-clock budget by turn count.
+
+    _play_turns (hermia.runner) calls transport.generate() once per turn, and
+    each call is independently subject to the full retry-with-backoff worst
+    case — a multi-turn test's legitimate wall time is n_turns times a single
+    call's, not a single call's total.
+    """
+    n_turns = len(test.get("turns") or (None,))
+    return per_call_timeout * max(1, n_turns)
+
+
 def verdict_from_result(result: dict[str, Any]) -> str:
     """Convert a run_test result dict to a TUI verdict string.
 
@@ -171,12 +183,13 @@ class TuiRunner:
             "repeat_idx": repeat_idx,
         })
 
+        timeout = _trial_wall_timeout_sec(test, self._trial_timeout)
         try:
             # wait_for cancels the coroutine wrapper on timeout but cannot kill
             # the OS thread. The thread runs until _run_fn returns or its own
             # socket timeout fires via the transport layer (up to TEST_TIMEOUT
-            # per attempt, including openai-compat's 5xx retries), so zombie
-            # threads are bounded by TRIAL_WALL_TIMEOUT's own worst-case budget.
+            # per attempt per turn, including openai-compat's 5xx retries), so
+            # zombie threads are bounded by this trial's own worst-case budget.
             result: dict[str, Any] = await asyncio.wait_for(
                 asyncio.to_thread(
                     self._run_fn,
@@ -186,14 +199,14 @@ class TuiRunner:
                     engine=host.engine,
                     auth_env=host.auth_header_env,
                 ),
-                timeout=self._trial_timeout,
+                timeout=timeout,
             )
         except TimeoutError:
             result = {
                 "model": model.name,
                 "test_id": test["id"],
-                "failure_reason": f"TIMEOUT: no response in {self._trial_timeout:.0f}s",
-                "elapsed_sec": self._trial_timeout,
+                "failure_reason": f"TIMEOUT: no response in {timeout:.0f}s",
+                "elapsed_sec": timeout,
                 "output_preview": "",
                 "signals": {},
             }

--- a/tests/unit/test_analyze.py
+++ b/tests/unit/test_analyze.py
@@ -12,6 +12,10 @@ import pytest
 
 from hermia.analyze import (
     _SECURITY_TEST_IDS,
+    _SQL_MODEL_FAILURE,
+    _SQL_SECURITY_CRITICAL,
+    _SQL_UNIVERSAL,
+    _SQL_WORST_PERFORMERS,
     Finding,
     _detect_model_failures,
     _detect_security_critical,
@@ -39,6 +43,20 @@ def _finding(**kwargs: Any) -> Finding:
     )
     defaults.update(kwargs)
     return Finding(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Infra-vs-behavioral SQL exclusion — RETRY_EXHAUSTED must ride along with
+# TIMEOUT everywhere it's excluded, or retry-exhaustion rows (transient infra
+# failures) get miscounted as behavioral failures in fleet-health verdicts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql", [_SQL_UNIVERSAL, _SQL_MODEL_FAILURE, _SQL_SECURITY_CRITICAL, _SQL_WORST_PERFORMERS]
+)
+def test_sql_excludes_retry_exhausted_alongside_timeout(sql: str) -> None:
+    assert sql.count("NOT LIKE 'RETRY_EXHAUSTED%%'") == sql.count("NOT LIKE 'TIMEOUT%%'")
 
 
 def _mock_cur(rows: list[tuple[Any, ...]]) -> MagicMock:

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -79,6 +79,13 @@ def test_failure_reason_schema_fail_category() -> None:
     assert "missing required field" not in str(out)
 
 
+def test_failure_reason_retry_exhausted_category() -> None:
+    # Must stay a distinct category from API_ERROR/OLLAMA_ERROR so bulk
+    # analysis can separate infra-retry noise from behavioral failures.
+    out = anonymize_row({"failure_reason": "RETRY_EXHAUSTED: after 3 attempts: HTTP 503"})
+    assert out["failure_category"] == "RETRY_EXHAUSTED"
+
+
 def test_failure_reason_none_gives_none_category() -> None:
     out = anonymize_row({"failure_reason": None})
     assert out["failure_category"] == "none"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -19,6 +19,7 @@ from hermia.runner import (
     unload_model,
 )
 from hermia.transport.base import Response as TransportResponse
+from hermia.transport.base import TransportError
 
 
 @pytest.fixture(autouse=True)
@@ -252,6 +253,20 @@ def test_run_test_transport_http_error() -> None:
         result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
     assert result["failure_reason"].startswith("ERROR")
     assert result["json_valid"] is False
+
+
+def test_run_test_retry_exhausted_classified_separately_from_api_error() -> None:
+    # A TransportError from exhausted 5xx retries must produce a distinct
+    # failure_reason prefix from an in-body application-level API error, so
+    # bulk analysis can separate infra noise from behavioral failures.
+    transport = MagicMock()
+    transport.generate.side_effect = TransportError(
+        "after 3 attempts: HTTP 503", kind="openai-compat-retry-exhausted"
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+    assert result["failure_reason"].startswith("RETRY_EXHAUSTED")
+    assert not result["failure_reason"].startswith("API_ERROR")
 
 
 def test_run_test_generic_exception() -> None:

--- a/tests/unit/test_transport_openai_retry.py
+++ b/tests/unit/test_transport_openai_retry.py
@@ -1,0 +1,161 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from hermia.transport.base import TransportError
+from hermia.transport.openai_compat import OpenAICompatTransport
+
+
+def test_generate_retries_5xx_up_to_2_additional_times():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep:
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 500
+        mock_response_1.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Internal Server Error"
+        )
+        mock_response_2 = MagicMock()
+        mock_response_2.status_code = 503
+        mock_response_2.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "503 Service Unavailable"
+        )
+        mock_response_3 = MagicMock()
+        mock_response_3.status_code = 200
+        mock_response_3.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.side_effect = [mock_response_1, mock_response_2, mock_response_3]
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert result.text == "the answer"
+        assert result.retries == 2
+        assert mock_post.call_count == 3
+        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_args_list[0].args == (0.5,)
+        assert mock_sleep.call_args_list[1].args == (2.0,)
+
+
+def test_generate_elapsed_sec_excludes_retry_backoff_time():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep, \
+         patch("hermia.transport.openai_compat.time.monotonic") as mock_monotonic:
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 500
+        mock_response_1.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Internal Server Error"
+        )
+        mock_response_2 = MagicMock()
+        mock_response_2.status_code = 200
+        mock_response_2.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.side_effect = [mock_response_1, mock_response_2]
+        # t0 resets each attempt: attempt 1 sets t0=0 (its duration is never
+        # measured since it fails and retries). Attempt 2 sets t0=100, then
+        # succeeds at t=101 (a fast 1s call). elapsed_sec must be 1.0, not
+        # 101.0 (which would include the failed attempt + backoff gap).
+        mock_monotonic.side_effect = [0, 100, 101]
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert result.elapsed_sec == 1.0
+        assert mock_sleep.call_count == 1
+
+
+def test_generate_raises_immediately_on_4xx():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep:
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        with pytest.raises(requests.exceptions.HTTPError):
+            transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert mock_post.call_count == 1
+        assert mock_sleep.call_count == 0
+
+
+def test_generate_raises_transport_error_on_exhausted_retries():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep:
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 500
+        mock_response_1.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Internal Server Error"
+        )
+        mock_response_2 = MagicMock()
+        mock_response_2.status_code = 502
+        mock_response_2.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "502 Bad Gateway"
+        )
+        mock_response_3 = MagicMock()
+        mock_response_3.status_code = 503
+        mock_response_3.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "503 Service Unavailable"
+        )
+        mock_post.side_effect = [mock_response_1, mock_response_2, mock_response_3]
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        with pytest.raises(TransportError) as exc_info:
+            transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert exc_info.value.kind == "openai-compat-retry-exhausted"
+        assert "3 attempts" in str(exc_info.value)
+        assert mock_post.call_count == 3
+        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_args_list[0].args == (0.5,)
+        assert mock_sleep.call_args_list[1].args == (2.0,)
+
+
+def test_generate_no_retries_on_first_success():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 99, "total_tokens": 120}
+        }
+        mock_post.return_value = mock_response
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert result.text == "the answer"
+        assert result.retries == 0
+        assert mock_post.call_count == 1
+        assert mock_sleep.call_count == 0
+
+
+def test_generate_raises_transport_error_on_body_error_even_after_retries():
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post, \
+         patch("hermia.transport.openai_compat.time.sleep") as mock_sleep:
+        mock_response_1 = MagicMock()
+        mock_response_1.status_code = 500
+        mock_response_1.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Internal Server Error"
+        )
+        mock_response_2 = MagicMock()
+        mock_response_2.status_code = 200
+        mock_response_2.json.return_value = {
+            "error": {"message": "Invalid request", "type": "invalid_request_error"}
+        }
+        mock_post.side_effect = [mock_response_1, mock_response_2]
+
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        with pytest.raises(TransportError) as exc_info:
+            transport.generate("gpt-3.5", [{"role": "user", "content": "Hello"}])
+
+        assert "invalid_request_error" in str(exc_info.value)
+        assert mock_post.call_count == 2
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args_list[0].args == (0.5,)

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -2,8 +2,20 @@
 import asyncio
 
 from hermia.tui.bus import SessionBus
-from hermia.tui.runner_backend import TuiRunner, verdict_from_result
+from hermia.tui.runner_backend import TuiRunner, _trial_wall_timeout_sec, verdict_from_result
 from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+class TestTrialWallTimeoutSec:
+    def test_single_turn_test_uses_per_call_timeout_unscaled(self) -> None:
+        assert _trial_wall_timeout_sec({"id": "t1"}, 300.0) == 300.0
+
+    def test_two_turn_test_scales_timeout_by_turn_count(self) -> None:
+        test = {"id": "multiturn-context-carry", "turns": ["turn1", "turn2"]}
+        assert _trial_wall_timeout_sec(test, 300.0) == 600.0
+
+    def test_empty_turns_list_treated_as_single_turn(self) -> None:
+        assert _trial_wall_timeout_sec({"id": "t1", "turns": []}, 300.0) == 300.0
 
 
 class TestVerdictFromResult:


### PR DESCRIPTION
## Summary
- LiteLLM-fronted lanes were losing ~27% of rows to transient HTTP 500s during cascade eval runs (hermia-7ed cascade, 2026-07-04). `OpenAICompatTransport.generate()` now retries up to 2 times on 5xx with 0.5s/2s backoff (tracked via a new `Response.retries` field); 4xx still fails immediately.
- Retry-exhaustion raises a distinct `TransportError` kind (`openai-compat-retry-exhausted`), so `runner.py` classifies it as `RETRY_EXHAUSTED` in `failure_reason` — separable from in-body application errors (`API_ERROR`). This is a direct prerequisite for hermia-5wc.1 (comprehensive eval run), which needs infra vs. behavioral failures to be cleanly separable.
- Also fixes two bugs surfaced by an in-window `/code-review` (medium effort, 8 finder angles + verify) before this landed:
  - `elapsed_sec` no longer includes failed-attempt/backoff time (t0 now resets per attempt) — was silently skewing tokens/sec, which `audit.py` uses for fleet-health DELETE/REVIEW/KEEP verdicts.
  - The TUI's `TRIAL_WALL_TIMEOUT` is now derived from `TEST_TIMEOUT` + the retry/backoff constants instead of a stale hardcoded 120s, which could not cover the new worst-case ~272s retry sequence and would have prematurely killed a legitimately-retrying request with a misleading generic `TIMEOUT`.

Part of the hermia-x49/hermia-b8t prerequisite pair for hermia-5wc.1 (the comprehensive v0.2.0 eval run) — hermia-b8t (stream-based no-token-progress timeout) is up next.

## Test plan
- [x] `.venv/bin/pytest -q` — 1844 passed, 9 deselected (known pre-existing macOS GPU-detection failures, hermia-2ess)
- [x] `.venv/bin/ruff check` clean on all touched files
- [x] `.venv/bin/mypy` clean on all touched files
- [x] In-window `/code-review` (medium): 3 findings, all CONFIRMED and fixed
- [ ] CI green
- [ ] Gemini review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for transient 5xx responses in OpenAI-compat chat completions, with configurable backoff.
  * Retry metadata is now included in transport responses.
  * Trial execution now uses a dynamically computed wall-clock timeout based on retry policy.

* **Bug Fixes**
  * Retry-exhausted errors are classified separately from general API errors.
  * Failure timing and trial timeouts now reflect the new retry-aware behavior.

* **Tests**
  * Added unit tests for retry/backoff timing, exhaustion handling, SQL exclusion behavior, and anonymization categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->