### PR TITLE
fix(provenance): stamp git_sha alongside hermia_version (hermia-c38b)

### DIFF
--- a/scripts/add_git_sha_column.sql
+++ b/scripts/add_git_sha_column.sql
@@ -1,0 +1,9 @@
+-- Add git_sha column (hermia-c38b provenance fix).
+-- Idempotent — safe to run multiple times.
+--
+-- hermia_version reads frozen editable-install dist-info metadata, which
+-- goes stale the moment a checkout moves to a different commit without a
+-- reinstall. git_sha is stamped independently and freshly on every run, so
+-- stale hermia_version data is self-diagnosing.
+
+ALTER TABLE hermia_results ADD COLUMN IF NOT EXISTS git_sha TEXT;

--- a/src/hermia/__init__.py
+++ b/src/hermia/__init__.py
@@ -1,8 +1,34 @@
 """Hermia — LLM agentic evaluation TUI."""
 
+import subprocess
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 try:
     __version__ = version("hermia")
 except PackageNotFoundError:
     __version__ = "dev"
+
+
+def _detect_git_sha() -> str:
+    """Short git commit SHA of the running checkout, or "unknown" if unavailable.
+
+    __version__ reads frozen editable-install dist-info metadata, which goes
+    stale the moment a checkout moves to a different commit without a
+    reinstall (see hermia-c38b). __git_sha__ is computed independently and
+    freshly on every import, so stale __version__ data is self-diagnosing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+__git_sha__ = _detect_git_sha()

--- a/src/hermia/export.py
+++ b/src/hermia/export.py
@@ -54,6 +54,7 @@ _PG_COLUMNS = (
     "raw_prompt",
     "raw_response",
     "hermia_version",
+    "git_sha",
     "corpus_sha256",
     "gpu_arch",
     "runtime_version",

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 import requests
 
-from hermia import __version__
+from hermia import __git_sha__, __version__
 from hermia.fingerprint.cache import FingerprintCache
 from hermia.metrics import MetricsSampler, get_gpu_stats
 from hermia.normalize import strip_fences
@@ -475,6 +475,7 @@ def run_test(
         "turn_count": len(user_turns),
         "raw_turns": user_turns,
         "hermia_version": __version__,
+        "git_sha": __git_sha__,
         "corpus_sha256": corpus_sha256(),
         "sampling": {k: _EVAL_SAMPLING.get(k) for k in _SAMPLING_SCHEMA_KEYS},
         "stack_fingerprint": _fp,

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from hermia import __version__
+from hermia import __git_sha__, __version__
 
 # Explicit whitelist of fields safe to share.  Default-deny: anything NOT
 # listed here is dropped, including future fields not yet imagined.
@@ -88,9 +88,10 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
     """Return an anonymized copy of *row* safe for community submission.
 
     Only whitelisted fields are copied.  ``failure_reason`` is replaced by
-    ``failure_category`` (the prefix only).  The Hermia version is stamped
-    in ``hermia_version``.  No host identity, raw text, client hardware
-    metrics, run ids, or timestamps are ever emitted.
+    ``failure_category`` (the prefix only).  The Hermia version and git
+    commit are stamped in ``hermia_version`` and ``git_sha``.  No host
+    identity, raw text, client hardware metrics, run ids, or timestamps
+    are ever emitted.
     """
     out: dict[str, Any] = {k: row[k] for k in SUBMIT_WHITELIST if k in row}
 
@@ -121,4 +122,5 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
 
     out["failure_category"] = _categorize_failure(row.get("failure_reason"))
     out["hermia_version"] = __version__
+    out["git_sha"] = __git_sha__
     return out

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 import psutil
 import requests
 
-from hermia import __version__
+from hermia import __git_sha__, __version__
 from hermia.metrics import detect_gpu
 from hermia.results import load_jsonl
 from hermia.sink.anonymize import anonymize_row
@@ -291,6 +291,7 @@ def build_payload(
     return {
         "install_id": install_id,
         "hermia_version": __version__,
+        "git_sha": __git_sha__,
         "corpus_version": CORPUS_VERSION,
         "host_class": host_class,
         "unified_memory_gb": unified_memory_gb,

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -33,7 +33,7 @@ FORBIDDEN_KEYS = {
 }
 
 # The complete set of keys the anonymizer is ever allowed to emit.
-_ALLOWED_OUTPUT_KEYS = SUBMIT_WHITELIST | {"failure_category", "hermia_version"}
+_ALLOWED_OUTPUT_KEYS = SUBMIT_WHITELIST | {"failure_category", "hermia_version", "git_sha"}
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +131,13 @@ def test_hermia_version_stamped() -> None:
     out = anonymize_row({"model": "x"})
     assert "hermia_version" in out
     assert out["hermia_version"]  # non-empty
+
+
+def test_git_sha_stamped() -> None:
+    """The output must always carry git_sha (hermia-c38b provenance fix)."""
+    out = anonymize_row({"model": "x"})
+    assert "git_sha" in out
+    assert out["git_sha"]  # non-empty
 
 
 def test_whitelist_fields_pass_through() -> None:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -643,6 +643,10 @@ def test_pg_columns_includes_hermia_version() -> None:
     assert "hermia_version" in _PG_COLUMNS
 
 
+def test_pg_columns_includes_git_sha() -> None:
+    assert "git_sha" in _PG_COLUMNS
+
+
 def test_pg_columns_includes_backend_stack_fields() -> None:
     assert "gpu_arch" in _PG_COLUMNS
     assert "runtime_version" in _PG_COLUMNS
@@ -658,6 +662,13 @@ def test_build_record_projects_hermia_version() -> None:
     row = {**_ROW, "hermia_version": "0.2.0"}
     rec = _build_record(row)
     assert rec["hermia_version"] == "0.2.0"
+
+
+def test_build_record_projects_git_sha() -> None:
+    from hermia.export import _build_record
+    row = {**_ROW, "git_sha": "abc1234"}
+    rec = _build_record(row)
+    assert rec["git_sha"] == "abc1234"
 
 
 def test_build_record_projects_backend_fields() -> None:
@@ -679,6 +690,7 @@ def test_build_record_backend_fields_default_none() -> None:
     from hermia.export import _build_record
     rec = _build_record(_ROW)
     assert rec["hermia_version"] is None
+    assert rec["git_sha"] is None
     assert rec["gpu_arch"] is None
     assert rec["runtime_version"] is None
     assert rec["backend_stack"] is None

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -293,6 +293,23 @@ def test_run_test_stamps_hermia_version() -> None:
     assert result["hermia_version"]  # non-empty
 
 
+def test_run_test_stamps_git_sha() -> None:
+    """Every result row must carry git_sha (hermia-c38b: hermia_version alone
+    goes stale on editable installs; git_sha is an independent, always-fresh check).
+    """
+    payload = '{"action": "search_documentation", "params": {}}'
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        result = run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+    assert "git_sha" in result
+    assert isinstance(result["git_sha"], str)
+    assert result["git_sha"]  # non-empty
+
+
 def test_run_test_peak_metrics_in_result() -> None:
     transport = MagicMock()
     transport.generate.return_value = TransportResponse(

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -436,6 +436,12 @@ def test_build_payload_hermia_version_present() -> None:
     assert len(payload["hermia_version"]) > 0
 
 
+def test_build_payload_git_sha_present() -> None:
+    payload = build_payload("uuid-1234", "local:cpu", None, [])
+    assert isinstance(payload["git_sha"], str)
+    assert len(payload["git_sha"]) > 0
+
+
 def test_build_payload_none_unified_memory_allowed() -> None:
     payload = build_payload("uuid-1234", "local:other", None, [])
     assert payload["unified_memory_gb"] is None

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,32 @@
+"""Tests for git-sha provenance stamping (hermia-c38b).
+
+__version__ reads frozen editable-install dist-info metadata, which goes
+stale the moment a checkout moves without a reinstall. __git_sha__ is
+stamped independently, computed fresh from the actual checkout, so stale
+version data is self-diagnosing.
+"""
+import subprocess
+
+from hermia import _detect_git_sha
+
+
+def test_detect_git_sha_returns_nonempty_string() -> None:
+    sha = _detect_git_sha()
+    assert isinstance(sha, str)
+    assert sha
+
+
+def test_detect_git_sha_falls_back_to_unknown_when_git_missing(monkeypatch) -> None:
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    assert _detect_git_sha() == "unknown"
+
+
+def test_detect_git_sha_falls_back_to_unknown_on_non_git_checkout(monkeypatch) -> None:
+    def _raise(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, "git")
+
+    monkeypatch.setattr(subprocess, "run", _raise)
+    assert _detect_git_sha() == "unknown"


### PR DESCRIPTION
## Summary
- `hermia_version` reads frozen editable-install dist-info metadata via `importlib.metadata`, which silently goes stale the moment a checkout moves to a different commit without a reinstall — root cause of the 0708/0709 eval runs stamping `hermia_version=0.1.0` while gateway was actually on pyproject 0.1.3.
- Adds `__git_sha__`, computed fresh from the checkout on every import, so stale `hermia_version` data is self-diagnosing instead of silently misleading.
- Plumbed through the same path as `hermia_version`: `runner.py` eval rows, `submit.py` payload, `anonymize.py`'s default-deny whitelist, `export.py`'s Postgres column set + migration script.

Closes hermia-c38b (code half — gateway checkout remediation is a separate ops step).

## Test plan
- [x] TDD: each new field added with a failing test first (`tests/unit/test_version.py`, `test_runner.py`, `test_submit.py`, `test_anonymize.py`, `test_export.py`)
- [x] `.venv/bin/pytest -q` — 1863 passed, same 6 pre-existing macOS GPU-detection failures as baseline (hermia-2ess), no regressions
- [x] `.venv/bin/ruff check` / `.venv/bin/mypy` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git commit identifiers to test results, anonymized submissions, exports, and submission payloads.
  * Added database support for storing Git commit identifiers.
  * Git identifiers gracefully fall back when unavailable.

* **Tests**
  * Added coverage verifying Git identifiers are generated, propagated, exported, and handled when Git metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->