### PR TITLE
fix(provenance): don't trust git_sha from an untracked enclosing repo (hermia-2a9o)

### DIFF
--- a/src/hermia/__init__.py
+++ b/src/hermia/__init__.py
@@ -19,16 +19,19 @@ def _detect_git_sha() -> str:
     freshly on every import, so stale __version__ data is self-diagnosing.
     """
     try:
-        file_path = str(Path(__file__).resolve())
-        pkg_dir = str(Path(__file__).resolve().parent)
+        resolved_path = Path(__file__).resolve()
+        pkg_dir = str(resolved_path.parent)
         # git rev-parse searches upward for the nearest .git — if this file
         # sits inside an unrelated enclosing repo (e.g. a venv nested inside
         # a stale checkout), that repo's HEAD would be reported instead.
         # Confirm the file is actually tracked here before trusting HEAD.
+        # Pass the bare filename (not the absolute path) since MSYS Git on
+        # Windows can mismatch absolute Windows paths against its internal
+        # virtual path scheme.
         subprocess.run(
-            ["git", "-C", pkg_dir, "ls-files", "--error-unmatch", file_path],
-            capture_output=True,
-            text=True,
+            ["git", "-C", pkg_dir, "ls-files", "--error-unmatch", resolved_path.name],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             timeout=5,
             check=True,
         )

--- a/src/hermia/__init__.py
+++ b/src/hermia/__init__.py
@@ -19,8 +19,21 @@ def _detect_git_sha() -> str:
     freshly on every import, so stale __version__ data is self-diagnosing.
     """
     try:
+        file_path = str(Path(__file__).resolve())
+        pkg_dir = str(Path(__file__).resolve().parent)
+        # git rev-parse searches upward for the nearest .git — if this file
+        # sits inside an unrelated enclosing repo (e.g. a venv nested inside
+        # a stale checkout), that repo's HEAD would be reported instead.
+        # Confirm the file is actually tracked here before trusting HEAD.
+        subprocess.run(
+            ["git", "-C", pkg_dir, "ls-files", "--error-unmatch", file_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
         result = subprocess.run(
-            ["git", "-C", str(Path(__file__).resolve().parent), "rev-parse", "--short", "HEAD"],
+            ["git", "-C", pkg_dir, "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -30,3 +30,20 @@ def test_detect_git_sha_falls_back_to_unknown_on_non_git_checkout(monkeypatch) -
 
     monkeypatch.setattr(subprocess, "run", _raise)
     assert _detect_git_sha() == "unknown"
+
+
+def test_detect_git_sha_falls_back_to_unknown_when_file_untracked_in_enclosing_repo(
+    monkeypatch,
+) -> None:
+    """git rev-parse searches upward for the nearest .git — if the package
+    happens to sit inside an unrelated enclosing repo (e.g. a venv nested
+    inside a stale checkout), that repo's HEAD must not be reported as
+    hermia's git_sha."""
+
+    def _fake_run(cmd, **kwargs):
+        if "ls-files" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="deadbeef\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    assert _detect_git_sha() == "unknown"


### PR DESCRIPTION
## Summary
- `_detect_git_sha()` used `git -C <pkg_dir> rev-parse --short HEAD`, which searches upward for the nearest `.git` — so an install sitting inside an unrelated enclosing repo (e.g. a venv nested inside a stale checkout) silently reported that repo's HEAD instead of failing safe.
- Found while verifying hermia-c38b's gateway remediation: gateway's install reported its outer repo's `main` HEAD instead of the actually-installed `dev` commit.
- Fix: confirm the file is git-tracked at the discovered location (`git ls-files --error-unmatch`) before trusting `rev-parse`'s output.

## Test plan
- [x] TDD: RED test added (`test_detect_git_sha_falls_back_to_unknown_when_file_untracked_in_enclosing_repo`), confirmed failing for the expected reason, then GREEN
- [x] Full suite: `1864 passed`, same 6 pre-existing `test_metrics.py::test_detect_gpu_*` macOS failures as baseline (hermia-2ess, unrelated)
- [x] Manually verified against the real repo: `_detect_git_sha()` returns the correct local HEAD
- [x] 8-angle code review + verification pass run; 2 minor findings survived (doesn't fully close the bug class for a vendored/monorepo edge case — follow-up filed as hermia-vmum; doubles subprocess spawn count — noted, not blocking)

Closes hermia-2a9o.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version reporting to identify the correct Git commit for the running checkout.
  - Prevented unrelated enclosing repositories from being used when determining version information.
  - When the commit cannot be reliably identified, version reporting continues to use the existing “unknown” fallback.

- **Tests**
  - Added coverage for scenarios where package files are not tracked by an enclosing repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->