### PR TITLE
fix(transport): capture reasoning thinking channel into result rows (hermia-cv5z)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,7 +73,9 @@ jobs:
       - name: Audit hermia dependencies in isolated venv
         run: |
           python -m venv /tmp/audit-env
-          /tmp/audit-env/bin/pip install --quiet --upgrade pip
+          # Upgrade setuptools too: the venv's pinned setuptools trips
+          # PYSEC-2026-3447 (fixed in 83.0.0); pip alone does not bump it.
+          /tmp/audit-env/bin/pip install --quiet --upgrade pip setuptools
           /tmp/audit-env/bin/pip install --quiet pip-audit
           /tmp/audit-env/bin/pip install --quiet -e .
           # CVE-2026-3219 affects pip itself (no fix available yet); all hermia deps are clean

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -383,7 +383,14 @@ def run_test(
     error_elapsed = time.monotonic() - t0
 
     output: str = response.text if response is not None else ""
-    thinking_text: str = response.thinking if response is not None else ""
+    # isinstance-guard the consumption point too: a custom/mock transport could
+    # hand back Response.thinking=None (or any non-str), and it is .strip()ed
+    # below — keep thinking_text provably a str (hermia-cv5z).
+    thinking_text: str = (
+        response.thinking
+        if response is not None and isinstance(response.thinking, str)
+        else ""
+    )
     tokens: int = response.tokens if response is not None else 0
     elapsed: float = (
         response.elapsed_sec if response is not None
@@ -401,7 +408,10 @@ def run_test(
     failure_reason = error_type  # network/transport errors; "" on clean path
 
     signals: dict[str, bool] = {}
-    if output and not error_type:
+    # Gate on non-whitespace content: a whitespace-only answer ("\n") must fall
+    # through to the empty-content branch (EMPTY_CONTENT_WITH_THINKING) rather
+    # than entering JSON parsing and being mislabeled JSON_PARSE_ERROR (hermia-cv5z).
+    if output.strip() and not error_type:
         cleaned = strip_fences(output)
         had_markdown_fence = cleaned != output.strip()
         # Raw-output leak gate (hermia-m12): SCHEMA_CHECKS grade the fence-stripped

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -305,6 +305,10 @@ def _play_turns(
         orchestration=last.orchestration,
         orchestration_version=last.orchestration_version,
         is_api_mode=last.is_api_mode,
+        # The final turn's reasoning trace (hermia-cv5z). Thinking is captured for
+        # the row but deliberately NOT replayed into `messages` above as assistant
+        # content — only `.text` is fed back to the model.
+        thinking=last.thinking,
     )
 
 
@@ -379,6 +383,7 @@ def run_test(
     error_elapsed = time.monotonic() - t0
 
     output: str = response.text if response is not None else ""
+    thinking_text: str = response.thinking if response is not None else ""
     tokens: int = response.tokens if response is not None else 0
     elapsed: float = (
         response.elapsed_sec if response is not None
@@ -428,7 +433,13 @@ def run_test(
         except json.JSONDecodeError:
             failure_reason = "CONTENT_LEAK" if content_leak else "JSON_PARSE_ERROR"
     elif not error_type:
-        failure_reason = "EMPTY_RESPONSE"
+        # Empty content but a non-empty reasoning trace: a reasoning model that
+        # spent its budget in the thinking channel and emitted no answer. Flag it
+        # distinctly (hermia-cv5z) so it is not silently indistinguishable from a
+        # dead-empty reply; grading stays content-only, so this is still a failure.
+        failure_reason = (
+            "EMPTY_CONTENT_WITH_THINKING" if thinking_text.strip() else "EMPTY_RESPONSE"
+        )
 
     tps = tokens / elapsed if elapsed > 0 and tokens > 0 else 0
     preview = output[:120].replace("\n", " ") if output.strip() else failure_reason
@@ -460,6 +471,7 @@ def run_test(
         "raw_system": test.get("system") or "",
         "raw_prompt": test.get("prompt") or "",
         "raw_response": "" if error_type else output,
+        "raw_thinking": "" if error_type else thinking_text,
         "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if is_local else None,
         "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if is_local else None,
         "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if is_local else None,

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -54,6 +54,7 @@ SUBMIT_WHITELIST: frozenset[str] = frozenset(
 _KNOWN_FAILURE_PREFIXES: tuple[str, ...] = (
     "SCHEMA_FAIL",
     "JSON_PARSE_ERROR",
+    "EMPTY_CONTENT_WITH_THINKING",
     "EMPTY_RESPONSE",
     "CONTENT_LEAK",
     "TIMEOUT",

--- a/src/hermia/transport/base.py
+++ b/src/hermia/transport/base.py
@@ -17,6 +17,7 @@ class Response:
     orchestration_version: str | None
     is_api_mode: bool
     retries: int = 0
+    thinking: str = ""
 
 
 class TransportError(Exception):

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -66,6 +66,9 @@ class OllamaTransport:
             raise TransportError(str(data["error"]), kind="ollama")
         message = data.get("message")
         text: str = message.get("content") or "" if isinstance(message, dict) else ""
+        # Reasoning models return the chain-of-thought in a sibling field
+        # (message.thinking); capture it rather than discarding it (hermia-cv5z).
+        thinking: str = message.get("thinking") or "" if isinstance(message, dict) else ""
         # .get(default) does not catch an explicit JSON null; coerce with `or 0`.
         tokens: int = data.get("eval_count") or 0
         return Response(
@@ -75,4 +78,5 @@ class OllamaTransport:
             orchestration="ollama",
             orchestration_version=self._fetch_version(),
             is_api_mode=False,
+            thinking=thinking,
         )

--- a/src/hermia/transport/ollama.py
+++ b/src/hermia/transport/ollama.py
@@ -68,7 +68,11 @@ class OllamaTransport:
         text: str = message.get("content") or "" if isinstance(message, dict) else ""
         # Reasoning models return the chain-of-thought in a sibling field
         # (message.thinking); capture it rather than discarding it (hermia-cv5z).
-        thinking: str = message.get("thinking") or "" if isinstance(message, dict) else ""
+        # str-guard, not value-guard: a non-string thinking (e.g. a list from a
+        # gateway) must not reach Response.thinking, which is .strip()ed
+        # downstream in the runner (hermia-cv5z).
+        _raw_thinking = message.get("thinking") if isinstance(message, dict) else None
+        thinking: str = _raw_thinking if isinstance(_raw_thinking, str) else ""
         # .get(default) does not catch an explicit JSON null; coerce with `or 0`.
         tokens: int = data.get("eval_count") or 0
         return Response(

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -106,11 +106,17 @@ class OpenAICompatTransport:
         message = first.get("message")
         text: str = message.get("content") or "" if isinstance(message, dict) else ""
         # Reasoning models expose the chain-of-thought as reasoning_content (or
-        # 'reasoning' on some backends); capture it rather than discarding it
-        # (hermia-cv5z).
+        # 'reasoning' on some backends). Prefer whichever field is a NON-EMPTY
+        # string: some backends put structured blocks (list/dict) in
+        # reasoning_content and the plain text in reasoning, so a plain value-OR
+        # would surface the non-string (and crash the runner's .strip()) while
+        # dropping the real string trace (hermia-cv5z).
+        _rc = message.get("reasoning_content") if isinstance(message, dict) else None
+        _r = message.get("reasoning") if isinstance(message, dict) else None
         thinking: str = (
-            (message.get("reasoning_content") or message.get("reasoning") or "")
-            if isinstance(message, dict) else ""
+            _rc if isinstance(_rc, str) and _rc
+            else _r if isinstance(_r, str) and _r
+            else ""
         )
         # .get(default) does not catch an explicit JSON null; coerce with `or 0`.
         usage = data.get("usage")

--- a/src/hermia/transport/openai_compat.py
+++ b/src/hermia/transport/openai_compat.py
@@ -105,6 +105,13 @@ class OpenAICompatTransport:
         first = choices[0] if choices and isinstance(choices[0], dict) else {}
         message = first.get("message")
         text: str = message.get("content") or "" if isinstance(message, dict) else ""
+        # Reasoning models expose the chain-of-thought as reasoning_content (or
+        # 'reasoning' on some backends); capture it rather than discarding it
+        # (hermia-cv5z).
+        thinking: str = (
+            (message.get("reasoning_content") or message.get("reasoning") or "")
+            if isinstance(message, dict) else ""
+        )
         # .get(default) does not catch an explicit JSON null; coerce with `or 0`.
         usage = data.get("usage")
         tokens: int = usage.get("completion_tokens") or 0 if isinstance(usage, dict) else 0
@@ -116,4 +123,5 @@ class OpenAICompatTransport:
             orchestration_version=None,
             is_api_mode=True,
             retries=retries,
+            thinking=thinking,
         )

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -112,6 +112,14 @@ def test_failure_reason_content_leak_category() -> None:
     assert out["failure_category"] == "CONTENT_LEAK"
 
 
+def test_failure_reason_empty_content_with_thinking_category() -> None:
+    """EMPTY_CONTENT_WITH_THINKING (hermia-cv5z) must map to its own category, not
+    'other' — else 'reasoned-but-no-answer' is indistinguishable from generic
+    unclassified failures in the shared/aggregated dataset."""
+    out = anonymize_row({"failure_reason": "EMPTY_CONTENT_WITH_THINKING"})
+    assert out["failure_category"] == "EMPTY_CONTENT_WITH_THINKING"
+
+
 def test_no_sensitive_value_survives() -> None:
     """The actual sentinel VALUE must not appear anywhere in the output repr."""
     sentinel = "host-marker-9f3a2c"

--- a/tests/unit/test_multiturn.py
+++ b/tests/unit/test_multiturn.py
@@ -87,6 +87,32 @@ def test_single_turn_unchanged_no_turns_field():
     assert res["turn_count"] == 1
 
 
+def test_multiturn_keeps_only_final_turn_thinking():
+    # _play_turns propagates ONLY the final turn's thinking (thinking=last.thinking),
+    # never an earlier turn or a concatenation. Correct today; pin it against a
+    # future refactor that mirrors the token/elapsed summation (hermia-cv5z).
+    thinks = iter(["FIRST turn reasoning", "SECOND turn reasoning"])
+    texts = iter(["intermediate reply", '{"ok": true}'])
+    t = MagicMock()
+    t.is_api_mode = True
+
+    def gen(model, messages, **opts):
+        return Response(
+            text=next(texts),
+            tokens=5,
+            elapsed_sec=0.1,
+            orchestration="ollama",
+            orchestration_version=None,
+            is_api_mode=True,
+            thinking=next(thinks),
+        )
+
+    t.generate.side_effect = gen
+    res = run_test("m", _MT_TEST, MagicMock(), transport=t)
+    assert res["raw_thinking"] == "SECOND turn reasoning"
+    assert "FIRST" not in res["raw_thinking"]
+
+
 # ---------------------------------------------------------------------------
 # E3 — determinism: same canned replies → identical result dict
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runner_thinking.py
+++ b/tests/unit/test_runner_thinking.py
@@ -1,0 +1,69 @@
+"""hermia-cv5z: runner threads the reasoning 'thinking' channel into result rows.
+
+The row gains raw_thinking (mirrors raw_response: blanked on transport error).
+Grading stays content-only — thinking never changes a pass/fail verdict — EXCEPT
+that an empty content with a non-empty thinking channel is flagged as its own
+failure_reason so a reasoning model that put everything in the scratchpad and
+nothing in the answer is not silently indistinguishable from a dead-empty reply.
+"""
+from unittest.mock import MagicMock, patch
+
+from hermia.runner import run_test
+from hermia.transport.base import Response as TransportResponse
+
+_BASE_TEST = {
+    "id": "tool-calling-basic",
+    "dimension": "tool-use",
+    "description": "basic tool call",
+    "system": "You are a helpful assistant.",
+    "prompt": "Call the get_weather tool for London.",
+}
+_PS_EMPTY = {"vram_server_gb": None, "model_size_server_gb": None}
+
+
+def _mock_sampler() -> MagicMock:
+    s = MagicMock()
+    s.peak.return_value = {
+        "cpu_pct": 10.0, "ram_used_gb": 8.0, "gpu_pct": 85.0, "vram_used_gb": 20.0,
+    }
+    return s
+
+
+def _run(text: str, thinking: str) -> dict:
+    transport = MagicMock()
+    transport.generate.return_value = TransportResponse(
+        text=text,
+        thinking=thinking,
+        tokens=10,
+        elapsed_sec=1.0,
+        orchestration="ollama",
+        orchestration_version="0.24.0",
+        is_api_mode=False,
+    )
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        return run_test("qwen2.5:32b", _BASE_TEST, _mock_sampler(), transport=transport)
+
+
+def test_raw_thinking_captured_on_clean_path() -> None:
+    row = _run('{"action": "get_weather", "city": "London"}', "chain of thought here")
+    assert row["raw_thinking"] == "chain of thought here"
+
+
+def test_empty_content_with_thinking_flagged() -> None:
+    row = _run("", "reasoned at length but emitted no answer")
+    assert row["failure_reason"] == "EMPTY_CONTENT_WITH_THINKING"
+    # thinking is preserved on this failure so it can be inspected / re-graded
+    assert row["raw_thinking"] == "reasoned at length but emitted no answer"
+
+
+def test_empty_content_no_thinking_still_empty_response() -> None:
+    row = _run("", "")
+    assert row["failure_reason"] == "EMPTY_RESPONSE"
+
+
+def test_nonempty_content_grading_unchanged() -> None:
+    # tool-calling-basic + {"action": "get_weather", ...} is valid JSON but wrong
+    # schema -> SCHEMA_FAIL, and a non-empty thinking channel must NOT change that.
+    row = _run('{"action": "get_weather", "city": "London"}', "some reasoning")
+    assert row["failure_reason"] == "SCHEMA_FAIL"
+    assert row["raw_thinking"] == "some reasoning"

--- a/tests/unit/test_runner_thinking.py
+++ b/tests/unit/test_runner_thinking.py
@@ -67,3 +67,26 @@ def test_nonempty_content_grading_unchanged() -> None:
     row = _run('{"action": "get_weather", "city": "London"}', "some reasoning")
     assert row["failure_reason"] == "SCHEMA_FAIL"
     assert row["raw_thinking"] == "some reasoning"
+
+
+def test_whitespace_content_with_thinking_flagged() -> None:
+    # A reasoning model that emits only whitespace in the answer (all its budget
+    # spent in the scratchpad) must be EMPTY_CONTENT_WITH_THINKING, not
+    # JSON_PARSE_ERROR — the runner previously gated on `output` truthiness, so
+    # "\n" wrongly entered the JSON path (hermia-cv5z follow-up).
+    row = _run("  \n  ", "reasoned but produced only whitespace")
+    assert row["failure_reason"] == "EMPTY_CONTENT_WITH_THINKING"
+    assert row["raw_thinking"] == "reasoned but produced only whitespace"
+
+
+def test_whitespace_content_no_thinking_still_empty_response() -> None:
+    row = _run("   ", "")
+    assert row["failure_reason"] == "EMPTY_RESPONSE"
+
+
+def test_none_thinking_does_not_crash() -> None:
+    # A mock/custom transport that hands back Response.thinking=None must not
+    # crash the runner's .strip() at the consumption point (hermia-cv5z).
+    row = _run("", None)  # type: ignore[arg-type]
+    assert row["failure_reason"] == "EMPTY_RESPONSE"
+    assert row["raw_thinking"] == ""

--- a/tests/unit/test_transport_thinking.py
+++ b/tests/unit/test_transport_thinking.py
@@ -11,7 +11,6 @@ from hermia.transport.base import Response
 from hermia.transport.ollama import OllamaTransport
 from hermia.transport.openai_compat import OpenAICompatTransport
 
-
 # ── Response dataclass ─────────────────────────────────────────────────────────
 
 def test_response_thinking_defaults_empty() -> None:
@@ -116,3 +115,65 @@ def test_openai_thinking_defaults_empty_when_absent() -> None:
 
         assert result.text == "the answer"
         assert result.thinking == ""
+
+
+def test_ollama_nonstring_thinking_coerced_to_empty() -> None:
+    """A non-string thinking field (e.g. a list from a gateway) must not poison
+    Response.thinking — the runner .strip()s it downstream (hermia-cv5z)."""
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {
+                "role": "assistant",
+                "content": "4",
+                "thinking": ["step one", "step two"],
+            },
+            "eval_count": 10,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        response = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert response.text == "4"
+        assert response.thinking == ""
+        assert isinstance(response.thinking, str)
+
+
+def test_openai_nonstring_reasoning_coerced_to_empty() -> None:
+    """Some backends return reasoning as a list/dict of blocks; it must not reach
+    Response.thinking as a non-string (hermia-cv5z)."""
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value = _openai_post({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "the answer",
+                "reasoning": [{"type": "thinking", "text": "block"}],
+            }}],
+            "usage": {"completion_tokens": 5},
+        })
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert result.text == "the answer"
+        assert result.thinking == ""
+        assert isinstance(result.thinking, str)
+
+
+def test_openai_prefers_string_reasoning_over_nonstring_reasoning_content() -> None:
+    """When reasoning_content is a non-string (structured blocks) but 'reasoning'
+    holds the plain-text trace, capture the string rather than blanking it
+    (hermia-cv5z)."""
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value = _openai_post({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "the answer",
+                "reasoning_content": [{"type": "thinking", "text": "block"}],
+                "reasoning": "plain text trace",
+            }}],
+            "usage": {"completion_tokens": 5},
+        })
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert result.thinking == "plain text trace"

--- a/tests/unit/test_transport_thinking.py
+++ b/tests/unit/test_transport_thinking.py
@@ -1,0 +1,118 @@
+"""hermia-cv5z: transports capture the reasoning 'thinking' channel.
+
+Ollama returns chain-of-thought in message['thinking']; OpenAI-compatible
+backends return it in message['reasoning_content'] (or 'reasoning'). Both were
+being discarded. These tests pin that the channel now lands on Response.thinking
+while Response.text still comes from message['content'] (grading is unchanged).
+"""
+from unittest.mock import MagicMock, patch
+
+from hermia.transport.base import Response
+from hermia.transport.ollama import OllamaTransport
+from hermia.transport.openai_compat import OpenAICompatTransport
+
+
+# ── Response dataclass ─────────────────────────────────────────────────────────
+
+def test_response_thinking_defaults_empty() -> None:
+    """Backward-compat: constructing a Response without thinking yields ""."""
+    response = Response(
+        text="t",
+        tokens=1,
+        elapsed_sec=0.0,
+        orchestration="o",
+        orchestration_version=None,
+        is_api_mode=False,
+    )
+    assert response.thinking == ""
+
+
+# ── Ollama transport ───────────────────────────────────────────────────────────
+
+def test_ollama_captures_thinking_field() -> None:
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {
+                "role": "assistant",
+                "content": "4",
+                "thinking": "the user asks 2+2, that is 4",
+            },
+            "eval_count": 10,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        response = transport.generate("m", [{"role": "user", "content": "What is 2+2?"}])
+
+        assert response.text == "4"
+        assert response.thinking == "the user asks 2+2, that is 4"
+
+
+def test_ollama_thinking_defaults_empty_when_absent() -> None:
+    with patch("hermia.transport.ollama.requests.post") as mock_post, \
+         patch("hermia.transport.ollama.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"version": "0.24.0"}
+        mock_post.return_value.json.return_value = {
+            "message": {"role": "assistant", "content": "4"},
+            "eval_count": 10,
+        }
+        transport = OllamaTransport(base_url="http://localhost:11434")
+        response = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert response.text == "4"
+        assert response.thinking == ""
+
+
+# ── OpenAI-compatible transport ────────────────────────────────────────────────
+
+def _openai_post(payload: dict) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    return mock_response
+
+
+def test_openai_captures_reasoning_content() -> None:
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value = _openai_post({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "the answer",
+                "reasoning_content": "step by step because ...",
+            }}],
+            "usage": {"completion_tokens": 5},
+        })
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert result.text == "the answer"
+        assert result.thinking == "step by step because ..."
+
+
+def test_openai_reasoning_fallback_key() -> None:
+    """Some backends use 'reasoning' rather than 'reasoning_content'."""
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value = _openai_post({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "the answer",
+                "reasoning": "fallback trace",
+            }}],
+            "usage": {"completion_tokens": 5},
+        })
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert result.thinking == "fallback trace"
+
+
+def test_openai_thinking_defaults_empty_when_absent() -> None:
+    with patch("hermia.transport.openai_compat.requests.post") as mock_post:
+        mock_post.return_value = _openai_post({
+            "choices": [{"message": {"role": "assistant", "content": "the answer"}}],
+            "usage": {"completion_tokens": 5},
+        })
+        transport = OpenAICompatTransport(base_url="https://api.openai.com")
+        result = transport.generate("m", [{"role": "user", "content": "hi"}])
+
+        assert result.text == "the answer"
+        assert result.thinking == ""


### PR DESCRIPTION
## What

Both HTTP transports read only `message.content` and discarded the reasoning channel (Ollama: `message.thinking`; OpenAI-compat: `reasoning_content` / `reasoning`). For reasoning models the graders saw a fraction of the output, and the chain-of-thought was lost at capture time — unrecoverable by any later re-grade.

## Change

- add `Response.thinking` (defaults to `""` — backward-compatible)
- populate it in the Ollama and OpenAI-compatible transports
- thread it into result rows as `raw_thinking` (blanked on transport error, mirroring `raw_response`); carried through the multi-turn rebuild but **not** replayed to the model as assistant content
- **grading stays content-only** — thinking never changes a pass/fail verdict. One new signal: empty content WITH a non-empty thinking trace is flagged `EMPTY_CONTENT_WITH_THINKING` (not `EMPTY_RESPONSE`) so a reasoning model that answered only in its scratchpad is distinguishable and its thinking is preserved.

## Verification

- TDD red→green: 10 new tests (`test_transport_thinking.py`, `test_runner_thinking.py`)
- full suite **1874 passed**, 6 pre-existing GPU-probe fails (environment-only)
- ruff + mypy clean

## Scope

Transport + runner only. Postgres/Grafana export of `raw_thinking` is a separable DB-schema change tracked in `hermia-1v3l` (JSONL, the source of truth, carries the field now).

Diagnosis finding: the discard did **not** corrupt existing sweep grades (final answers landed in `content`, which is stored + graded); the fix is forward-only for the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Captures model reasoning traces from supported Ollama and OpenAI-compatible responses.
  - Includes captured reasoning in test results for improved visibility and diagnostics.

- **Bug Fixes**
  - Distinguishes responses with empty content but available reasoning from completely empty responses.
  - Preserves existing response content and grading behavior while recording reasoning details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->