### PR TITLE
docs(agents): replace retired Gemini gate with Antigravity in review-gate sequence (hermia-07o.5)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 - [ ] Bandit/pip-audit clean (CI will verify)
 
 ## Notes for reviewer
-<!-- Anything Gemini Code Assist or a human reviewer should pay particular attention to. -->
+<!-- Anything CodeRabbit, the Antigravity review, or a human reviewer should pay particular attention to. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ These are grounded in actual git history. Violations have caused real rework.
    *(Evidence: fix/reasoning-model-extra-keys and fix/reasoning-model-extra-keys-v2
    both exist in history.)*
 
-8. **Run the outside-family review gate after every push.**
+8. **Clear the outside-family review gate before merging.**
    Gemini Code Assist was RETIRED 2026-07-17 — the `/gemini review` PR comment is dead.
    CodeRabbit fires automatically on push; the outside-family adversary gate is now
    **Antigravity (`agy`)**, run in a container against the pushed diff (recipe: global

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,15 +52,18 @@ These are grounded in actual git history. Violations have caused real rework.
    *(Evidence: fix/reasoning-model-extra-keys and fix/reasoning-model-extra-keys-v2
    both exist in history.)*
 
-8. **Never assume Gemini re-review auto-triggers after a push.**
-   It does not. After pushing fixes to an open PR, immediately post `/gemini review`
-   as a PR comment. Do not proceed with other work until this is done.
+8. **Run the outside-family review gate after every push.**
+   Gemini Code Assist was RETIRED 2026-07-17 — the `/gemini review` PR comment is dead.
+   CodeRabbit fires automatically on push; the outside-family adversary gate is now
+   **Antigravity (`agy`)**, run in a container against the pushed diff (recipe: global
+   CLAUDE.md "Antigravity PR Review"). **Verify every finding against the code —
+   Antigravity over-flags; never auto-apply.** Do not proceed to merge until this is done.
 
-9. **Call diminishing returns on Gemini after the first substantive round.**
-    Fix all HIGH-priority comments every round. After the first round, if subsequent
+9. **Call diminishing returns after the first substantive round.**
+    Fix all HIGH-priority findings every round. After the first round, if subsequent
     rounds contain only MEDIUM or LOW items, use judgment: apply what's genuinely
     worth it, skip pure style nits, and merge rather than chasing infinite feedback.
-    Gemini will loop forever on style. One or two rounds of MEDIUMs is fine; more
+    Outside tools loop forever on style. One or two rounds of MEDIUMs is fine; more
     than that is diminishing returns — merge.
 
 10. **Never write CI/workflow jobs with assumed permissions.**
@@ -166,10 +169,10 @@ A task is not done until every applicable gate below is cleared, in order.
    └─ gitleaks + trivy + bandit + pip-audit
    └─ Runs on PRs to main and weekly
 
-4. Gemini Code Assist review completed
-   └─ Required on every PR — do NOT merge without it
-   └─ Does NOT auto-trigger on post-PR pushes
-   └─ After any push to an open PR: post /gemini review as a PR comment immediately
+4. Outside-family adversarial review completed
+   └─ Antigravity (`agy`) review on the diff — required before merge; verify findings (it over-flags)
+   └─ CodeRabbit fires automatically on push; Gemini Code Assist retired 2026-07-17
+   └─ Runs at user privilege — safe only on a read-only mount of this (public) repo in a throwaway container
 
 5. Opus on-demand review (for complex or security-sensitive changes)
    └─ Triggered via /review slash command in Claude Code
@@ -209,6 +212,6 @@ This project uses a layered security review pipeline. Before submitting a PR:
 - Do not add dependencies without opening a GitHub Issue to discuss first
 - Schema validators must use the `_keys_ok()` pattern — see `schemas.py` for reference
 - CLI entrypoints must be tested via direct CLI invocation, not just function calls
-- PRs require Gemini Code Assist review before merge — maintainer will trigger this
+- PRs require an outside-family adversarial review before merge (CodeRabbit auto-fires; the maintainer runs the Antigravity pass) — Gemini Code Assist retired 2026-07-17
 
 Welcome to the project. The eval framework is intentionally adversarial. That's the point.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ mypy src/
 feature/* or fix/* or chore/*
     ↓  PR → CI (ruff, mypy, pytest)
    dev  ← target for all feature PRs
-    ↓  PR → CI + security gate + Gemini review
+    ↓  PR → CI + security gate + CodeRabbit + Antigravity review
   main  ← branch protection active; releases cut from here
 ```
 
@@ -88,8 +88,8 @@ Types: `feat`, `fix`, `refactor`, `test`, `ci`, `docs`, `chore`
 - Target `dev`, not `main`
 - Fill out the PR template — it exists for a reason
 - CI must be green before requesting review
-- Gemini Code Assist will review your PR automatically; the maintainer will
-  not merge until that review is complete
+- CodeRabbit will review your PR automatically; the maintainer also runs an
+  Antigravity (`agy`) adversarial pass and will not merge until review is complete
 - Reference the GitHub Issue number in your PR description
 
 ---
@@ -98,7 +98,7 @@ Types: `feat`, `fix`, `refactor`, `test`, `ci`, `docs`, `chore`
 
 Every PR gets:
 1. CI — ruff, mypy, pytest
-2. Gemini Code Assist — logic and architecture review
+2. CodeRabbit + Antigravity — automated logic/architecture + adversarial review
 3. Maintainer review — security correctness, framework mapping accuracy,
    schema checker quality
 

--- a/docs/GIT_GOVERNANCE.md
+++ b/docs/GIT_GOVERNANCE.md
@@ -12,7 +12,7 @@ repeat, and the procedure to recover if work is ever lost again.
 ### Tier 1 — Prevent (GitHub)
 - **Branch protection on `main` and `dev`:** PR required, status checks strict
   (`lint-and-test`), **force-push blocked, deletion blocked**, admins included,
-  0 required approvals (solo-maintainer friendly — CI + Gemini/Aikido + in-window
+  0 required approvals (solo-maintainer friendly — CI + CodeRabbit/Antigravity/Aikido + in-window
   Opus are the gates).
 - **Merge-only branch deletion:** repo setting "Automatically delete head branches"
   is enabled — it fires *only on merge*, never on close. Feature branches are never

--- a/docs/security-framework-research.md
+++ b/docs/security-framework-research.md
@@ -223,7 +223,7 @@ For agentic systems, **ME 2.4** is the critical subcategory: a model that passed
 | ME 2.3 Benchmark similar to deployment | ✅ Hermia runs on a local GPU node against live Ollama | Eval prompts are static; real-world prompt distribution not sampled |
 | ME 2.4 Production monitoring | ✅ Grafana: CPU, RAM, GPU%, VRAM, inference latency | ❌ No eval accuracy metrics in Grafana (schema pass rate, security test pass rate) |
 | ME 3.1 Track emergent risks | ❌ None | Results stored in JSONL but no regression detection or alerting |
-| ME 1.3 Independent review | ✅ Gemini Code Assist reviews PRs | Reviews code only, not model behavior changes |
+| ME 1.3 Independent review | ✅ CodeRabbit + Antigravity (`agy`) review PRs | Reviews code only, not model behavior changes |
 | MA 4.1 Post-deployment monitoring | ✅ Prometheus scrapes node_exporter | ❌ No model-behavior alerting; no incident response runbook for model regression |
 | MA 2.2 Risk response plans | ❌ None | No documented response for "safe-lane model fails security test" |
 


### PR DESCRIPTION
Closes hermia-07o.5.

Gemini Code Assist consumer PR review was **retired 2026-07-17** — AGENTS.md still named it as the required PR gate. This updates AGENTS.md to reflect the current outside-family gate: **Antigravity (`agy`)**, run in a container against the diff, with **CodeRabbit** auto-firing on push.

### Changes (AGENTS.md only)
- **Rules 8 & 9** — the post-push review discipline now describes CodeRabbit (auto) + the containerized Antigravity pass, with "verify — it over-flags, never auto-apply."
- **Ready-to-merge checklist item 4** — "Gemini Code Assist review" → "Outside-family adversarial review (Antigravity + CodeRabbit)," plus the user-privilege / public-repo-only caution.
- **Contributor note** — external-contributor line updated (CodeRabbit auto-fires; maintainer runs the Antigravity pass).

### Context
The gate was validated end-to-end on #155/#156 this session (it caught 2 real bugs CodeRabbit + a Claude fan-out both missed). Global `~/.claude/CLAUDE.md` pipeline + model table were updated separately (untracked, personal operating doc). Production gating of *untrusted* code still awaits the R0/R1 container sandbox harness (hermia-ryh7.1).

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and review-review workflow guidance to reflect the current automated code review and adversarial verification process.
  * Added “Notes for reviewer” guidance to the pull request template to help focus attention on flagged items.
  * Refined branch-protection (required checks/approvals) documentation for the main branches.
  * Updated the security framework research mapping to align independent review references with the current review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->