### PR TITLE
fix(tui): hydrate trial screens from run state and surface full responses (hermia-mo4a, hermia-2ke3)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-tui-trials-visibility.md
+++ b/docs/superpowers/plans/2026-08-05-tui-trials-visibility.md
@@ -1,0 +1,92 @@
+# Plan — TUI trials visibility (hermia-mo4a + hermia-2ke3)
+
+**Branch:** `feature/hermia-mo4a-2ke3-tui-trials` (off `dev`)
+**Scope:** `src/hermia/tui/**` only. No corpus, no CLI writer, no published number.
+
+## Why these two together
+
+Both defects live on the same drill-down path (L1 runner → L2 trials → L3 detail) and both
+have the same consequence: **the UI asserts something it does not know.** L2 asserts
+"pending" for trials that already finished; L3 asserts a 120-character string is the model's
+answer. Fixing one without the other still leaves the audit path unusable.
+
+## Root causes (read from source, not inferred)
+
+### hermia-mo4a — L2 renders a completed run as pending
+
+1. **No replay.** `tui/bus.py:36` — `subscribe()` allocates a *fresh empty queue*. The bus is a
+   pure delta channel with no history. `runner_trials.py:81-97` builds every `_TrialRow` at the
+   dataclass default `state="pending"` and *then* subscribes, so every event published before
+   the user drilled in is gone. Drill in after 13 of 17 trials → the screen shows 4.
+2. **No terminal state.** `runner_trials.py` subscribes only to `run.trial_started` /
+   `run.trial_finished` — never `run.completed` / `run.aborted`. A finished run therefore has
+   no end state and reads as frozen. (L1 `RunnerScreen` *does* subscribe to both and stayed
+   accurate.)
+
+Both halves are required. Replay alone still leaves a finished run looking in-progress.
+
+### hermia-2ke3 — L3 shows a 120-char preview, not the response
+
+- `runner.py:455` — `preview = output[:120].replace("\n", " ")`
+- `runner_detail.py:73` — renders `t.output_preview`, never `raw_response`.
+- `runner_backend.py:147,219` — the TUI backend truncates to 120 *independently*.
+- **The `run.trial_finished` event does not carry `raw_response` at all**
+  (`runner_backend.py:225-234`). The event contract must be widened; a detail-screen-only
+  change cannot work.
+- Data is not lost: `runner.py:483` stores `raw_response` / `raw_prompt` / `raw_system` /
+  `raw_thinking` (the last since hermia-cv5z).
+
+## Design decision: run-state store, not a bus replay buffer
+
+The handoff offered two directions. **Chosen: an app-level `RunState` that screens hydrate
+from on mount; the bus keeps carrying deltas only.**
+
+Rejected — a per-topic replay buffer in `SessionBus`:
+
+- A bounded buffer silently drops the oldest events, so trials whose results aged out render
+  as "pending" forever. That is *exactly* the recurring failure shape (a confident non-answer)
+  reproduced inside the fix for it.
+- An unbounded buffer accumulates every event for the process lifetime, and after this change
+  each `trial_finished` carries the full `raw_response` — megabytes on a real fleet run.
+- Replay would re-deliver a *previous* run's events to a second run's screens.
+
+`RunState` keys one record per `(host, model, test_id, repeat_idx)`, so memory is O(trials)
+by construction, a re-run resets it, and "what is the current state of trial X" is a direct
+lookup rather than a fold the caller has to redo.
+
+**Ordering guarantee:** `TuiRunner` folds each event into `RunState` *before* publishing it,
+through a single `_emit()` choke point. The store can never lag the bus, and there is one
+call site to keep correct instead of six.
+
+## Work items
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `tui/run_state.py` *(new)* | `TrialRecord` + `RunState.apply(topic, event)` fold; `reset()` on `run.started`; `phase` ∈ idle/running/completed/aborted |
+| 2 | `tui/app.py` | `self.run_state = RunState()` alongside `self.bus` |
+| 3 | `tui/runner_backend.py` | `run_state=` kwarg; `_emit()` folds-then-publishes; widen `trial_finished` with `raw_response`/`raw_prompt`/`raw_system`/`raw_thinking`; stop truncating error text |
+| 4 | `tui/screens/config.py` | pass `run_state=self.app.run_state` into `TuiRunner` |
+| 5 | `tui/screens/runner_trials.py` | hydrate grid from `run_state` on mount; subscribe to `run.completed`/`run.aborted`; carry raw fields onto `_TrialRow`; terminal banner; unreported rows stop claiming "pending" |
+| 6 | `tui/screens/runner_detail.py` | render full `raw_response` in a scrollable pane (+ prompt/system/thinking); hydrate from `run_state` on mount; escape Rich markup |
+
+## Honesty rule for terminal state
+
+When the run reaches a terminal phase, rows that never reported must **not** keep rendering as
+`pending` — "pending" implies a result is still coming. They flip to `unreported`, which
+asserts only what is known: no result arrived. The banner states the phase explicitly.
+
+## Test gotchas (cost an hour last session)
+
+- **Use `widget.content`, NOT `widget.renderable`.** On Textual 8.2.8 `renderable` is `None`
+  and a probe reading it silently reports "0 rows rendered".
+- The **mid-run drill is the necessary condition** for reproducing mo4a. A clean harness that
+  pushes L2 and then publishes all events does *not* reproduce it. Tests must publish some
+  events *before* the screen mounts.
+- Model output routinely contains `[...]` (JSON). Assert it survives Rich rendering, not just
+  that it reached the widget.
+
+## Baseline
+
+`.venv/bin/pytest -q` → **1898 passed, 6 failed**. The 6 are `test_detect_gpu_*` in
+`tests/unit/test_metrics.py` — pre-existing, macOS-only, tracked as **hermia-2ess**. Scoped
+green baseline excludes exactly those.

--- a/src/hermia/tui/app.py
+++ b/src/hermia/tui/app.py
@@ -4,6 +4,9 @@ Holds the shared FleetConfig as a mutable attribute. Picker screens read
 and write directly to `app.config`. `app.bus` is the shared SessionBus for
 runner ↔ screen communication (probe topics and run topics share one bus;
 they use distinct topic prefixes and screens only subscribe to their own).
+`app.run_state` is the durable fold of those run events — the bus has no
+replay, so screens hydrate from run_state on mount and use the bus for
+deltas thereafter.
 """
 from __future__ import annotations
 
@@ -12,6 +15,7 @@ import sys
 from textual.app import App
 
 from hermia.tui.bus import SessionBus
+from hermia.tui.run_state import RunState
 from hermia.tui.state import FleetConfig
 
 
@@ -22,6 +26,11 @@ class HermiaApp(App[None]):
         super().__init__()
         self.config: FleetConfig = FleetConfig(name="")
         self.bus: SessionBus = SessionBus()
+        # The bus carries deltas only — subscribe() allocates an empty queue
+        # with no replay, so a screen mounted mid-run cannot recover what it
+        # missed. run_state is the durable fold screens hydrate from on mount
+        # (hermia-mo4a).
+        self.run_state: RunState = RunState()
         # Local Ollama host to probe for engine-security advisories after
         # mount (see _probe_engine_security). None disables the probe
         # (e.g. for tests that don't want a network call at startup).

--- a/src/hermia/tui/run_state.py
+++ b/src/hermia/tui/run_state.py
@@ -1,0 +1,159 @@
+"""RunState — the durable fold of run.* bus events.
+
+`SessionBus.subscribe()` allocates a fresh empty queue with no history: the bus
+is a pure delta channel. A screen mounted mid-run therefore cannot reconstruct
+what it missed from the bus alone, which is why the L2 trials screen rendered a
+finished run as "pending" (hermia-mo4a) — it built its rows at the dataclass
+default and *then* subscribed.
+
+RunState is the store screens hydrate from on mount. `TuiRunner` folds each
+event in here *before* publishing it (one `_emit` choke point), so the store can
+never lag the bus. It also carries the full `raw_response` the L3 detail screen
+needs (hermia-2ke3).
+
+One record per (host, model, test_id, repeat_idx), so memory is O(trials) by
+construction rather than O(events) — and `run.started` resets, so a second run
+in the same session never hydrates screens from the first run's rows.
+
+Pure stdlib by design: no Textual, no asyncio, no hermia imports.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# (host_name, model_name, test_id, repeat_idx)
+TrialKey = tuple[str, str, str, int]
+
+PHASE_IDLE = "idle"
+PHASE_RUNNING = "running"
+PHASE_COMPLETED = "completed"
+PHASE_ABORTED = "aborted"
+
+STATE_PENDING = "pending"
+STATE_RUNNING = "running"
+STATE_ERROR = "error"
+# Terminal-run state for a trial that never reported. Distinct from "pending",
+# which asserts a result is still coming — an assertion the screen has no basis
+# for once the run has ended.
+STATE_UNREPORTED = "unreported"
+
+_TERMINAL_PHASES = frozenset({PHASE_COMPLETED, PHASE_ABORTED})
+
+
+@dataclass
+class TrialRecord:
+    host_name: str
+    model_name: str
+    test_id: str
+    repeat_idx: int
+    state: str = STATE_PENDING
+    elapsed_sec: float | None = None
+    failure_reason: str = ""
+    output_preview: str = ""
+    raw_response: str = ""
+    raw_prompt: str = ""
+    raw_system: str = ""
+    raw_thinking: str = ""
+
+
+def _key(event: dict[str, Any]) -> TrialKey:
+    return (
+        str(event.get("host_name", "")),
+        str(event.get("model_name", "")),
+        str(event.get("test_id", "")),
+        int(event.get("repeat_idx", 0) or 0),
+    )
+
+
+def _opt_float(value: Any) -> float | None:
+    """Coerce an event's elapsed_sec to float, preserving a genuine absence.
+
+    Absent and unparseable both become None rather than 0.0 — a zero would
+    assert "this took no time", which is the confident-non-answer shape.
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class RunState:
+    """Current state of the active run, folded from the run.* event stream."""
+
+    def __init__(self) -> None:
+        self.phase: str = PHASE_IDLE
+        self.error: str = ""
+        # Plain dict: insertion-ordered, so trials_for_host preserves the order
+        # trials were first seen and rows never reshuffle under the cursor.
+        self._trials: dict[TrialKey, TrialRecord] = {}
+
+    # ── Mutation ───────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Drop every trial and return to the idle phase."""
+        self._trials.clear()
+        self.phase = PHASE_IDLE
+        self.error = ""
+
+    def apply(self, topic: str, event: dict[str, Any]) -> None:
+        """Fold one bus event. Unknown topics are ignored."""
+        if topic == "run.started":
+            # Reset first — a second run in the same session must not leave the
+            # previous run's rows visible to a screen that hydrates from here.
+            self.reset()
+            self.phase = PHASE_RUNNING
+        elif topic == "run.trial_started":
+            self._upsert(_key(event)).state = STATE_RUNNING
+        elif topic == "run.trial_finished":
+            rec = self._upsert(_key(event))
+            # `or STATE_ERROR` (not a dict default): an empty or null verdict is
+            # not a verdict, and must not be rendered as one.
+            rec.state = str(event.get("verdict") or STATE_ERROR)
+            rec.elapsed_sec = _opt_float(event.get("elapsed_sec"))
+            rec.failure_reason = str(event.get("failure_reason", ""))
+            rec.output_preview = str(event.get("output_preview", ""))
+            rec.raw_response = str(event.get("raw_response", ""))
+            rec.raw_prompt = str(event.get("raw_prompt", ""))
+            rec.raw_system = str(event.get("raw_system", ""))
+            rec.raw_thinking = str(event.get("raw_thinking", ""))
+        elif topic == "run.completed":
+            self.phase = PHASE_COMPLETED
+        elif topic == "run.aborted":
+            self.phase = PHASE_ABORTED
+            self.error = str(event.get("error", ""))
+
+    def _upsert(self, key: TrialKey) -> TrialRecord:
+        rec = self._trials.get(key)
+        if rec is None:
+            host_name, model_name, test_id, repeat_idx = key
+            rec = TrialRecord(
+                host_name=host_name,
+                model_name=model_name,
+                test_id=test_id,
+                repeat_idx=repeat_idx,
+            )
+            self._trials[key] = rec
+        return rec
+
+    # ── Queries ────────────────────────────────────────────────────────────
+
+    def trial(
+        self,
+        host_name: str,
+        model_name: str,
+        test_id: str,
+        repeat_idx: int,
+    ) -> TrialRecord | None:
+        """Exact lookup. None when this trial has never been seen."""
+        return self._trials.get((host_name, model_name, test_id, repeat_idx))
+
+    def trials_for_host(self, host_name: str) -> list[TrialRecord]:
+        """Every record for one host, in first-seen order."""
+        return [r for r in self._trials.values() if r.host_name == host_name]
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.phase in _TERMINAL_PHASES

--- a/src/hermia/tui/run_state.py
+++ b/src/hermia/tui/run_state.py
@@ -66,7 +66,7 @@ def _key(event: dict[str, Any]) -> TrialKey:
     )
 
 
-def _opt_float(value: Any) -> float | None:
+def opt_float(value: Any) -> float | None:
     """Coerce an event's elapsed_sec to float, preserving a genuine absence.
 
     Absent and unparseable both become None rather than 0.0 — a zero would
@@ -112,7 +112,7 @@ class RunState:
             # `or STATE_ERROR` (not a dict default): an empty or null verdict is
             # not a verdict, and must not be rendered as one.
             rec.state = str(event.get("verdict") or STATE_ERROR)
-            rec.elapsed_sec = _opt_float(event.get("elapsed_sec"))
+            rec.elapsed_sec = opt_float(event.get("elapsed_sec"))
             rec.failure_reason = str(event.get("failure_reason", ""))
             rec.output_preview = str(event.get("output_preview", ""))
             rec.raw_response = str(event.get("raw_response", ""))

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -20,6 +20,7 @@ from typing import Any
 from hermia.runner import TEST_TIMEOUT
 from hermia.transport.openai_compat import MAX_5XX_RETRIES, RETRY_BACKOFF_SEC
 from hermia.tui.bus import SessionBus
+from hermia.tui.run_state import RunState
 from hermia.tui.state import FleetConfig, Host, ModelChoice
 
 # Must cover the openai-compat transport's worst case: every attempt (including
@@ -74,12 +75,14 @@ class TuiRunner:
         bus: SessionBus,
         results_dir: Path | None,
         *,
+        run_state: RunState | None = None,
         run_test_fn: RunTestFn | None = None,
         _tests_override: list[dict[str, Any]] | None = None,  # for tests only
         trial_timeout: float = TRIAL_WALL_TIMEOUT,
     ) -> None:
         self._config = config
         self._bus = bus
+        self._run_state = run_state
         self._results_dir = results_dir
         self._run_fn: RunTestFn = run_test_fn or _real_run_test
         self._tests_override = _tests_override
@@ -104,23 +107,35 @@ class TuiRunner:
 
     # ── Internal ───────────────────────────────────────────────────────────
 
+    async def _emit(self, topic: str, event: dict[str, Any]) -> None:
+        """Fold into RunState, then publish.
+
+        Single choke point for every run.* event. Folding *before* publishing
+        guarantees the store is never behind the bus: any screen that wakes on
+        an event and hydrates from run_state sees at least that event. Six
+        separate publish sites would have drifted (hermia-mo4a).
+        """
+        if self._run_state is not None:
+            self._run_state.apply(topic, event)
+        await self._bus.publish(topic, event)
+
     async def _run(self) -> None:
         try:
             tests = self._load_tests()
         except Exception as exc:  # noqa: BLE001
-            await self._bus.publish("run.started", {
+            await self._emit("run.started", {
                 "run_id": _make_run_id(),
                 "n_hosts": len(self._config.hosts),
                 "n_trials_total": 0,
             })
-            await self._bus.publish("run.aborted", {
+            await self._emit("run.aborted", {
                 "n_completed": 0,
                 "error": str(exc),
             })
             return
 
         n_trials = self._count_trials(tests)
-        await self._bus.publish("run.started", {
+        await self._emit("run.started", {
             "run_id": _make_run_id(),
             "n_hosts": len(self._config.hosts),
             "n_trials_total": n_trials,
@@ -136,7 +151,7 @@ class TuiRunner:
         for host, host_result in zip(self._config.hosts, results, strict=True):
             is_exc = isinstance(host_result, BaseException)
             if is_exc and not isinstance(host_result, asyncio.CancelledError):
-                await self._bus.publish("run.trial_finished", {
+                await self._emit("run.trial_finished", {
                     "host_name": host.name,
                     "model_name": "",
                     "test_id": "",
@@ -145,12 +160,15 @@ class TuiRunner:
                     "elapsed_sec": 0.0,
                     "failure_reason": f"HOST_ERROR: {host_result}",
                     "output_preview": str(host_result)[:120],
+                    # The detail screen is the only place a host failure can be
+                    # read in full; the 120-char preview above is for the row.
+                    "raw_response": f"HOST_ERROR: {host_result}",
                 })
 
         if self._abort_requested:
-            await self._bus.publish("run.aborted", {"n_completed": self._n_completed})
+            await self._emit("run.aborted", {"n_completed": self._n_completed})
         else:
-            await self._bus.publish("run.completed", {
+            await self._emit("run.completed", {
                 "n_trials_total": n_trials,
                 "n_completed": self._n_completed,
             })
@@ -176,7 +194,7 @@ class TuiRunner:
         test: dict[str, Any],
         repeat_idx: int,
     ) -> None:
-        await self._bus.publish("run.trial_started", {
+        await self._emit("run.trial_started", {
             "host_name": host.name,
             "model_name": model.name,
             "test_id": test["id"],
@@ -202,12 +220,14 @@ class TuiRunner:
                 timeout=timeout,
             )
         except TimeoutError:
+            _timeout_msg = f"TIMEOUT: no response in {timeout:.0f}s"
             result = {
                 "model": model.name,
                 "test_id": test["id"],
-                "failure_reason": f"TIMEOUT: no response in {timeout:.0f}s",
+                "failure_reason": _timeout_msg,
                 "elapsed_sec": timeout,
                 "output_preview": "",
+                "raw_response": _timeout_msg,
                 "signals": {},
             }
         except Exception as exc:  # noqa: BLE001
@@ -216,13 +236,17 @@ class TuiRunner:
                 "test_id": test["id"],
                 "failure_reason": f"ERROR: {exc}",
                 "elapsed_sec": 0.0,
+                # output_preview stays truncated for the row; raw_response
+                # keeps the whole message so the detail screen can show a full
+                # traceback-bearing error instead of its first 120 characters.
                 "output_preview": str(exc)[:120],
+                "raw_response": f"ERROR: {exc}",
                 "signals": {},
             }
 
         self._n_completed += 1
 
-        await self._bus.publish("run.trial_finished", {
+        await self._emit("run.trial_finished", {
             "host_name": host.name,
             "model_name": model.name,
             "test_id": test["id"],
@@ -231,6 +255,13 @@ class TuiRunner:
             "elapsed_sec": float(result.get("elapsed_sec") or 0.0),
             "failure_reason": result.get("failure_reason", ""),
             "output_preview": result.get("output_preview", ""),
+            # hermia-2ke3: the event previously carried only the 120-char
+            # preview, so the full response was unreachable from the TUI even
+            # though runner.run_test captures it and writes it to the JSONL.
+            "raw_response": result.get("raw_response", ""),
+            "raw_prompt": result.get("raw_prompt", ""),
+            "raw_system": result.get("raw_system", ""),
+            "raw_thinking": result.get("raw_thinking", ""),
         })
 
         if self._results_dir is not None:

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -176,5 +176,6 @@ class FleetConfigScreen(Screen[None]):
             config=self.app_config,
             bus=self.app.bus,  # type: ignore[attr-defined]
             results_dir=results_dir,
+            run_state=self.app.run_state,  # type: ignore[attr-defined]
         )
         self.app.push_screen(RunnerScreen(runner=runner))

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -1,8 +1,13 @@
 """RunnerDetailScreen (L3) — detail view for one trial.
 
-Receives a _TrialRow at init. If the trial is still pending or running,
-subscribes to run.trial_finished to update when the result arrives. escape
-always pops.
+This is the only surface in the TUI where a model's actual answer can be read,
+so it renders the full `raw_response` (hermia-2ke3). It previously rendered
+`output_preview` — a 120-character, newline-flattened row summary — which meant
+the eval's own output was unreadable from the tool that produced it.
+
+Receives a _TrialRow at init. If that row predates the result, the screen
+hydrates from `app.run_state` on mount and, failing that, subscribes to
+run.trial_finished. escape always pops.
 """
 from __future__ import annotations
 
@@ -10,10 +15,11 @@ import asyncio
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Footer, Static
 
+from hermia.tui.run_state import RunState
 from hermia.tui.screens.runner_trials import _TrialRow
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
@@ -28,6 +34,11 @@ class RunnerDetailScreen(Screen[None]):
         self._trial = trial
         self._listener_task: asyncio.Task[None] | None = None
         self._summary: str = ""
+        self._output: str = ""
+
+    @property
+    def app_run_state(self) -> RunState | None:
+        return getattr(self.app, "run_state", None)
 
     @property
     def breadcrumb_text(self) -> str:
@@ -38,6 +49,11 @@ class RunnerDetailScreen(Screen[None]):
         return self._summary
 
     @property
+    def output_text(self) -> str:
+        """The response text the screen is displaying, verbatim and untruncated."""
+        return self._output
+
+    @property
     def is_awaiting_result(self) -> bool:
         return self._trial.state in _AWAITING_STATES
 
@@ -46,10 +62,18 @@ class RunnerDetailScreen(Screen[None]):
         with Vertical():
             yield Breadcrumb(["hermia", "runner", t.model_name, t.test_id])
             yield Static("", id="detail-summary")
-            yield Static("", id="detail-output")
+            # markup=False: model output is routinely JSON and Rich would
+            # silently DELETE bracketed spans like "[bold]" from the rendered
+            # line. Escaping would work too, but a flag that cannot be forgotten
+            # on the next update() call is the safer contract.
+            with VerticalScroll(id="detail-output-scroll"):
+                yield Static("", id="detail-output", markup=False)
         yield Footer()
 
     def on_mount(self) -> None:
+        # A row handed over before its result arrived is stale by construction.
+        # run_state holds the outcome if it landed while L2 was on screen.
+        self._hydrate()
         self._refresh()
         if self.is_awaiting_result:
             self._listener_task = asyncio.create_task(self._listen_finished())
@@ -57,6 +81,34 @@ class RunnerDetailScreen(Screen[None]):
     def on_unmount(self) -> None:
         if self._listener_task is not None:
             self._listener_task.cancel()
+
+    def _hydrate(self) -> None:
+        rs = self.app_run_state
+        t = self._trial
+        if rs is None:
+            return
+        rec = rs.trial(t.host_name, t.model_name, t.test_id, t.repeat_idx)
+        if rec is None or rec.state in _AWAITING_STATES:
+            return
+        t.state = rec.state
+        t.elapsed_sec = rec.elapsed_sec
+        t.failure_reason = rec.failure_reason
+        t.output_preview = rec.output_preview
+        t.raw_response = rec.raw_response
+        t.raw_prompt = rec.raw_prompt
+        t.raw_system = rec.raw_system
+        t.raw_thinking = rec.raw_thinking
+
+    def _display_text(self) -> str:
+        """Full response, falling back to the preview only when there is none.
+
+        Error and timeout rows carry no raw_response, so the preview is all
+        there is — but it is never preferred over a real response.
+        """
+        t = self._trial
+        if t.raw_response:
+            return t.raw_response
+        return t.output_preview or ""
 
     def _refresh(self) -> None:
         t = self._trial
@@ -69,8 +121,9 @@ class RunnerDetailScreen(Screen[None]):
             summary = f"verdict: {t.state}  elapsed: {elapsed}{reason}"
 
         self._summary = summary
+        self._output = self._display_text()
         self.query_one("#detail-summary", Static).update(summary)
-        self.query_one("#detail-output", Static).update(t.output_preview or "")
+        self.query_one("#detail-output", Static).update(self._output)
 
     async def _listen_finished(self) -> None:
         t = self._trial
@@ -85,6 +138,10 @@ class RunnerDetailScreen(Screen[None]):
                 t.elapsed_sec = ev.get("elapsed_sec")
                 t.failure_reason = ev.get("failure_reason", "")
                 t.output_preview = ev.get("output_preview", "")
+                t.raw_response = ev.get("raw_response", "")
+                t.raw_prompt = ev.get("raw_prompt", "")
+                t.raw_system = ev.get("raw_system", "")
+                t.raw_thinking = ev.get("raw_thinking", "")
                 if self.is_mounted:
                     self._refresh()
                 return

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -12,6 +12,8 @@ run.trial_finished. escape always pops.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -19,11 +21,18 @@ from textual.containers import Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Footer, Static
 
-from hermia.tui.run_state import RunState
+from hermia.tui.run_state import (
+    STATE_ERROR,
+    STATE_PENDING,
+    STATE_RUNNING,
+    STATE_UNREPORTED,
+    RunState,
+    opt_float,
+)
 from hermia.tui.screens.runner_trials import _TrialRow
 from hermia.tui.widgets.breadcrumb import Breadcrumb
 
-_AWAITING_STATES = frozenset({"pending", "running"})
+_AWAITING_STATES = frozenset({STATE_PENDING, STATE_RUNNING})
 
 
 class RunnerDetailScreen(Screen[None]):
@@ -32,7 +41,7 @@ class RunnerDetailScreen(Screen[None]):
     def __init__(self, *, trial: _TrialRow) -> None:
         super().__init__()
         self._trial = trial
-        self._listener_task: asyncio.Task[None] | None = None
+        self._listener_tasks: list[asyncio.Task[None]] = []
         self._summary: str = ""
         self._output: str = ""
 
@@ -71,16 +80,32 @@ class RunnerDetailScreen(Screen[None]):
         yield Footer()
 
     def on_mount(self) -> None:
+        # Register the queues before hydrating — bus.subscribe() is sync but the
+        # consuming task is not scheduled until the loop next runs, so
+        # subscribing inside the task would leave a gap after the snapshot in
+        # which an event is lost by both. See RunnerTrialsScreen.on_mount.
+        bus = self.app.bus  # type: ignore[attr-defined]
+        finished = bus.subscribe("run.trial_finished")
+        completed = bus.subscribe("run.completed")
+        aborted = bus.subscribe("run.aborted")
         # A row handed over before its result arrived is stale by construction.
         # run_state holds the outcome if it landed while L2 was on screen.
         self._hydrate()
         self._refresh()
         if self.is_awaiting_result:
-            self._listener_task = asyncio.create_task(self._listen_finished())
+            self._listener_tasks = [
+                asyncio.create_task(self._listen_finished(finished)),
+                # Without these, a run that ends without ever reporting this
+                # trial leaves L3 asserting "Trial in progress…" forever, while
+                # L2 shows the same trial as unreported — the two screens
+                # contradict each other.
+                asyncio.create_task(self._listen_terminal(completed)),
+                asyncio.create_task(self._listen_terminal(aborted)),
+            ]
 
     def on_unmount(self) -> None:
-        if self._listener_task is not None:
-            self._listener_task.cancel()
+        for task in self._listener_tasks:
+            task.cancel()
 
     def _hydrate(self) -> None:
         rs = self.app_run_state
@@ -89,6 +114,9 @@ class RunnerDetailScreen(Screen[None]):
             return
         rec = rs.trial(t.host_name, t.model_name, t.test_id, t.repeat_idx)
         if rec is None or rec.state in _AWAITING_STATES:
+            # The run may have ended without this trial ever reporting.
+            if rs.is_terminal and t.state in _AWAITING_STATES:
+                t.state = STATE_UNREPORTED
             return
         t.state = rec.state
         t.elapsed_sec = rec.elapsed_sec
@@ -125,26 +153,37 @@ class RunnerDetailScreen(Screen[None]):
         self.query_one("#detail-summary", Static).update(summary)
         self.query_one("#detail-output", Static).update(self._output)
 
-    async def _listen_finished(self) -> None:
+    async def _listen_finished(self, events: AsyncIterator[dict[str, Any]]) -> None:
         t = self._trial
-        async for ev in self.app.bus.subscribe("run.trial_finished"):  # type: ignore[attr-defined]
+        async for ev in events:
             if (
                 ev.get("model_name") == t.model_name
                 and ev.get("test_id") == t.test_id
                 and ev.get("repeat_idx") == t.repeat_idx
                 and (not t.host_name or ev.get("host_name") == t.host_name)
             ):
-                t.state = ev.get("verdict", "error")
-                t.elapsed_sec = ev.get("elapsed_sec")
-                t.failure_reason = ev.get("failure_reason", "")
-                t.output_preview = ev.get("output_preview", "")
-                t.raw_response = ev.get("raw_response", "")
-                t.raw_prompt = ev.get("raw_prompt", "")
-                t.raw_system = ev.get("raw_system", "")
-                t.raw_thinking = ev.get("raw_thinking", "")
+                # Same coercions as RunState.apply — the two paths rendering the
+                # same event differently is its own defect.
+                t.state = str(ev.get("verdict") or STATE_ERROR)
+                t.elapsed_sec = opt_float(ev.get("elapsed_sec"))
+                t.failure_reason = str(ev.get("failure_reason", ""))
+                t.output_preview = str(ev.get("output_preview", ""))
+                t.raw_response = str(ev.get("raw_response", ""))
+                t.raw_prompt = str(ev.get("raw_prompt", ""))
+                t.raw_system = str(ev.get("raw_system", ""))
+                t.raw_thinking = str(ev.get("raw_thinking", ""))
                 if self.is_mounted:
                     self._refresh()
                 return
+
+    async def _listen_terminal(self, events: AsyncIterator[dict[str, Any]]) -> None:
+        """Stop claiming the trial is running once the run itself has ended."""
+        async for _ev in events:
+            if self.is_awaiting_result:
+                self._trial.state = STATE_UNREPORTED
+                if self.is_mounted:
+                    self._refresh()
+            return
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/hermia/tui/screens/runner_detail.py
+++ b/src/hermia/tui/screens/runner_detail.py
@@ -92,16 +92,23 @@ class RunnerDetailScreen(Screen[None]):
         # run_state holds the outcome if it landed while L2 was on screen.
         self._hydrate()
         self._refresh()
-        if self.is_awaiting_result:
-            self._listener_tasks = [
-                asyncio.create_task(self._listen_finished(finished)),
-                # Without these, a run that ends without ever reporting this
-                # trial leaves L3 asserting "Trial in progress…" forever, while
-                # L2 shows the same trial as unreported — the two screens
-                # contradict each other.
-                asyncio.create_task(self._listen_terminal(completed)),
-                asyncio.create_task(self._listen_terminal(aborted)),
-            ]
+        # Every subscription MUST get a consuming task, even when the trial is
+        # already settled and nothing will arrive. SessionBus.subscribe()
+        # registers the queue synchronously, but the registration is only undone
+        # by the finally in SessionBus._consume — which requires the generator to
+        # have been started and then closed. An un-consumed generator leaks its
+        # queue for the life of the app, and publish() keeps filling it (with
+        # full raw_response payloads) forever. Cancelling these on unmount is
+        # what actually unregisters them.
+        self._listener_tasks = [
+            asyncio.create_task(self._listen_finished(finished)),
+            # Without the terminal topics, a run that ends without ever
+            # reporting this trial leaves L3 asserting "Trial in progress…"
+            # forever, while L2 shows the same trial as unreported — the two
+            # screens contradict each other.
+            asyncio.create_task(self._listen_terminal(completed)),
+            asyncio.create_task(self._listen_terminal(aborted)),
+        ]
 
     def on_unmount(self) -> None:
         for task in self._listener_tasks:

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -1,8 +1,13 @@
 """RunnerTrialsScreen (L2) — trial table for one host.
 
-One row per (selected model × test × repeat) combination. Subscribes to
-run.trial_started and run.trial_finished on app.bus; filters to this
-host only. enter drills to L3 for the focused trial. escape always pops.
+One row per (selected model × test × repeat) combination.
+
+The screen hydrates every row from `app.run_state` on mount and *then*
+subscribes to run.* on `app.bus` for deltas. Hydration is not optional: the bus
+allocates a fresh empty queue per subscriber with no replay, so before
+hermia-mo4a every trial that finished while the user was on another screen
+rendered as "pending" forever. It also tracks the run's terminal phase — a
+finished run with no end state read as frozen.
 """
 from __future__ import annotations
 
@@ -17,8 +22,19 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import Footer, Static
 
+from hermia.tui.run_state import (
+    PHASE_ABORTED,
+    STATE_PENDING,
+    STATE_RUNNING,
+    STATE_UNREPORTED,
+    RunState,
+)
 from hermia.tui.state import FleetConfig, Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+# States that mean "no result has arrived". At a terminal phase these stop
+# reading as "pending" — see _apply_terminal.
+_UNSETTLED = frozenset({STATE_PENDING, STATE_RUNNING})
 
 
 @dataclass
@@ -27,10 +43,16 @@ class _TrialRow:
     test_id: str
     repeat_idx: int
     host_name: str = ""
-    state: str = "pending"   # pending | running | defended | error
+    state: str = STATE_PENDING  # pending | running | defended | error | unreported
     elapsed_sec: float | None = None
     failure_reason: str = ""
     output_preview: str = ""
+    # Full payload (hermia-2ke3) — the L3 detail screen renders raw_response;
+    # output_preview above is the 120-char row summary, not the response.
+    raw_response: str = ""
+    raw_prompt: str = ""
+    raw_system: str = ""
+    raw_thinking: str = ""
 
 
 class RunnerTrialsScreen(Screen[None]):
@@ -48,14 +70,25 @@ class RunnerTrialsScreen(Screen[None]):
         self._trials: list[_TrialRow] = []
         self._render_seq: int = 0
         self._listener_tasks: list[asyncio.Task[None]] = []
+        self.run_done: bool = False
+        self._terminal_text: str = ""
 
     @property
     def app_config(self) -> FleetConfig:
         return self.app.config  # type: ignore[attr-defined,no-any-return]
 
     @property
+    def app_run_state(self) -> RunState | None:
+        return getattr(self.app, "run_state", None)
+
+    @property
     def breadcrumb_text(self) -> str:
         return self.query_one(Breadcrumb).text
+
+    @property
+    def terminal_text(self) -> str:
+        """Banner text once the run ends; "" while it is still running."""
+        return self._terminal_text
 
     @property
     def n_trial_rows(self) -> int:
@@ -72,10 +105,11 @@ class RunnerTrialsScreen(Screen[None]):
         with Vertical(id="trials-root"):
             yield Breadcrumb(["hermia", "fleet", name, "runner", self._host.name])
             yield Static(
-                "  ✓ defended   ✗ error   ↺ running     pending\n"
+                "  ✓ defended   ✗ error   ↺ running     pending   ! unreported\n"
                 "  Enter  View trial detail     Esc  Back to runner",
                 id="trials-legend",
             )
+            yield Static("", id="trials-terminal")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -90,21 +124,79 @@ class RunnerTrialsScreen(Screen[None]):
                         repeat_idx=rep,
                         host_name=self._host.name,
                     ))
+        # Hydrate BEFORE subscribing. Anything published before this moment is
+        # unreachable from the bus, so run_state is the only source for it.
+        self._hydrate()
         self._rerender()
         self._listener_tasks = [
             asyncio.create_task(self._listen_started()),
             asyncio.create_task(self._listen_finished()),
+            asyncio.create_task(self._listen_terminal("run.completed", "completed")),
+            asyncio.create_task(self._listen_terminal("run.aborted", "aborted")),
         ]
 
     def on_unmount(self) -> None:
         for t in self._listener_tasks:
             t.cancel()
 
+    # ── Hydration ─────────────────────────────────────────────────────────
+
+    def _hydrate(self) -> None:
+        """Seed rows and terminal state from the app's RunState."""
+        rs = self.app_run_state
+        if rs is None:
+            return
+        for t in self._trials:
+            rec = rs.trial(self._host.name, t.model_name, t.test_id, t.repeat_idx)
+            if rec is None:
+                continue
+            t.state = rec.state
+            t.elapsed_sec = rec.elapsed_sec
+            t.failure_reason = rec.failure_reason
+            t.output_preview = rec.output_preview
+            t.raw_response = rec.raw_response
+            t.raw_prompt = rec.raw_prompt
+            t.raw_system = rec.raw_system
+            t.raw_thinking = rec.raw_thinking
+        if rs.is_terminal:
+            self._apply_terminal(
+                "aborted" if rs.phase == PHASE_ABORTED else "completed",
+                error=rs.error,
+                rerender=False,
+            )
+
+    def _apply_terminal(self, phase: str, *, error: str = "", rerender: bool = True) -> None:
+        """Record the run's end state and stop claiming trials are pending.
+
+        A row still at pending/running when the run ends never reported. Leaving
+        it as "pending" asserts a result is still coming — the screen has no
+        basis for that once the run is over, so it says only what it knows.
+        """
+        self.run_done = True
+        for t in self._trials:
+            if t.state in _UNSETTLED:
+                t.state = STATE_UNREPORTED
+        # Count the unreported rows rather than the ones this call flipped: on a
+        # second invocation (hydrated terminal, then a terminal bus event) the
+        # flip count is zero and the banner would claim every trial reported.
+        n_unreported = sum(1 for t in self._trials if t.state == STATE_UNREPORTED)
+        text = f"run {phase} — {len(self._trials) - n_unreported}/{len(self._trials)} reported"
+        if n_unreported:
+            text += f", {n_unreported} never reported"
+        if error:
+            text += f"  [{error}]"
+        self._terminal_text = text
+        if rerender and self.is_mounted:
+            self._rerender()
+
     # ── Rendering ─────────────────────────────────────────────────────────
 
     def _row_text(self, trial: _TrialRow, idx: int) -> str:
         cursor = "▸" if idx == self.cursor_idx else " "
-        _icons = {"pending": " ", "running": "↺", "defended": "✓", "error": "✗"}
+        _icons = {
+            "pending": " ", "running": "↺", "defended": "✓", "error": "✗",
+            STATE_UNREPORTED: "!",
+        }
         state_icon = _icons.get(trial.state, "?")
         elapsed = f"  {trial.elapsed_sec:.1f}s" if trial.elapsed_sec is not None else ""
         reason = f"  {escape(f'[{trial.failure_reason}]')}" if trial.failure_reason else ""
@@ -115,6 +207,7 @@ class RunnerTrialsScreen(Screen[None]):
 
     def _rerender(self) -> None:
         root = self.query_one("#trials-root", Vertical)
+        self.query_one("#trials-terminal", Static).update(escape(self._terminal_text))
         prefix = f"trial-row-{self._render_seq}-"
         current = [
             c for c in root.children
@@ -125,9 +218,12 @@ class RunnerTrialsScreen(Screen[None]):
             for i, trial in enumerate(self._trials):
                 cast("Static", current[i]).update(self._row_text(trial, i))
             return
+        # Chrome (legend, terminal banner) is not a stale row — removing it here
+        # would delete the banner on the next full re-render.
         stale = [
             c for c in root.children
-            if not isinstance(c, Breadcrumb) and c.id != "trials-legend"
+            if not isinstance(c, Breadcrumb)
+            and c.id not in ("trials-legend", "trials-terminal")
         ]
         for child in stale:
             child.remove()
@@ -160,8 +256,18 @@ class RunnerTrialsScreen(Screen[None]):
                     t.elapsed_sec = ev.get("elapsed_sec")
                     t.failure_reason = ev.get("failure_reason", "")
                     t.output_preview = ev.get("output_preview", "")
+                    t.raw_response = ev.get("raw_response", "")
+                    t.raw_prompt = ev.get("raw_prompt", "")
+                    t.raw_system = ev.get("raw_system", "")
+                    t.raw_thinking = ev.get("raw_thinking", "")
             if self.is_mounted:
                 self._rerender()
+
+    async def _listen_terminal(self, topic: str, phase: str) -> None:
+        """Give the screen an end state. Without this a finished run looks frozen."""
+        async for ev in self.app.bus.subscribe(topic):  # type: ignore[attr-defined]
+            self._apply_terminal(phase, error=str(ev.get("error", "")))
+            return
 
     # ── Navigation ─────────────────────────────────────────────────────────
 

--- a/src/hermia/tui/screens/runner_trials.py
+++ b/src/hermia/tui/screens/runner_trials.py
@@ -2,18 +2,20 @@
 
 One row per (selected model × test × repeat) combination.
 
-The screen hydrates every row from `app.run_state` on mount and *then*
-subscribes to run.* on `app.bus` for deltas. Hydration is not optional: the bus
-allocates a fresh empty queue per subscriber with no replay, so before
+On mount the screen registers its bus queues, hydrates every row from
+`app.run_state`, and only then starts consuming. Hydration is not optional: the
+bus allocates a fresh empty queue per subscriber with no replay, so before
 hermia-mo4a every trial that finished while the user was on another screen
-rendered as "pending" forever. It also tracks the run's terminal phase — a
-finished run with no end state read as frozen.
+rendered as "pending" forever. Registering before hydrating matters just as
+much — see on_mount. It also tracks the run's terminal phase; a finished run
+with no end state read as frozen.
 """
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 from rich.markup import escape
 from textual.app import ComposeResult
@@ -24,10 +26,12 @@ from textual.widgets import Footer, Static
 
 from hermia.tui.run_state import (
     PHASE_ABORTED,
+    STATE_ERROR,
     STATE_PENDING,
     STATE_RUNNING,
     STATE_UNREPORTED,
     RunState,
+    opt_float,
 )
 from hermia.tui.state import FleetConfig, Host
 from hermia.tui.widgets.breadcrumb import Breadcrumb
@@ -72,6 +76,7 @@ class RunnerTrialsScreen(Screen[None]):
         self._listener_tasks: list[asyncio.Task[None]] = []
         self.run_done: bool = False
         self._terminal_text: str = ""
+        self._terminal_error: str = ""
 
     @property
     def app_config(self) -> FleetConfig:
@@ -124,15 +129,26 @@ class RunnerTrialsScreen(Screen[None]):
                         repeat_idx=rep,
                         host_name=self._host.name,
                     ))
-        # Hydrate BEFORE subscribing. Anything published before this moment is
-        # unreachable from the bus, so run_state is the only source for it.
+        # Register the queues BEFORE hydrating. bus.subscribe() is synchronous
+        # and registers immediately, but the coroutine that calls it does not
+        # run until the loop next schedules it — so subscribing inside the
+        # listener tasks leaves a window after the hydrate snapshot in which a
+        # published event is missed by the snapshot AND by the not-yet-created
+        # queue. That is the exact defect this screen is being fixed for.
+        # Subscribing first can only duplicate an event, and every apply here
+        # is idempotent.
+        bus = self.app.bus  # type: ignore[attr-defined]
+        started = bus.subscribe("run.trial_started")
+        finished = bus.subscribe("run.trial_finished")
+        completed = bus.subscribe("run.completed")
+        aborted = bus.subscribe("run.aborted")
         self._hydrate()
         self._rerender()
         self._listener_tasks = [
-            asyncio.create_task(self._listen_started()),
-            asyncio.create_task(self._listen_finished()),
-            asyncio.create_task(self._listen_terminal("run.completed", "completed")),
-            asyncio.create_task(self._listen_terminal("run.aborted", "aborted")),
+            asyncio.create_task(self._listen_started(started)),
+            asyncio.create_task(self._listen_finished(finished)),
+            asyncio.create_task(self._listen_terminal(completed, "completed")),
+            asyncio.create_task(self._listen_terminal(aborted, "aborted")),
         ]
 
     def on_unmount(self) -> None:
@@ -173,6 +189,10 @@ class RunnerTrialsScreen(Screen[None]):
         basis for that once the run is over, so it says only what it knows.
         """
         self.run_done = True
+        # Never replace a known reason with an empty one: the hydrated phase
+        # carries RunState.error, while the matching bus event may not.
+        if error:
+            self._terminal_error = error
         for t in self._trials:
             if t.state in _UNSETTLED:
                 t.state = STATE_UNREPORTED
@@ -183,8 +203,8 @@ class RunnerTrialsScreen(Screen[None]):
         text = f"run {phase} — {len(self._trials) - n_unreported}/{len(self._trials)} reported"
         if n_unreported:
             text += f", {n_unreported} never reported"
-        if error:
-            text += f"  [{error}]"
+        if self._terminal_error:
+            text += f"  [{self._terminal_error}]"
         self._terminal_text = text
         if rerender and self.is_mounted:
             self._rerender()
@@ -234,38 +254,44 @@ class RunnerTrialsScreen(Screen[None]):
 
     # ── Bus listeners ──────────────────────────────────────────────────────
 
-    async def _listen_started(self) -> None:
-        async for ev in self.app.bus.subscribe("run.trial_started"):  # type: ignore[attr-defined]
+    async def _listen_started(self, events: AsyncIterator[dict[str, Any]]) -> None:
+        async for ev in events:
             if ev.get("host_name") != self._host.name:
                 continue
             for t in self._trials:
                 if (t.model_name == ev.get("model_name") and t.test_id == ev.get("test_id")
                         and t.repeat_idx == ev.get("repeat_idx")):
-                    t.state = "running"
+                    t.state = STATE_RUNNING
             if self.is_mounted:
                 self._rerender()
 
-    async def _listen_finished(self) -> None:
-        async for ev in self.app.bus.subscribe("run.trial_finished"):  # type: ignore[attr-defined]
+    async def _listen_finished(self, events: AsyncIterator[dict[str, Any]]) -> None:
+        async for ev in events:
             if ev.get("host_name") != self._host.name:
                 continue
             for t in self._trials:
                 if (t.model_name == ev.get("model_name") and t.test_id == ev.get("test_id")
                         and t.repeat_idx == ev.get("repeat_idx")):
-                    t.state = ev.get("verdict", "error")
-                    t.elapsed_sec = ev.get("elapsed_sec")
-                    t.failure_reason = ev.get("failure_reason", "")
-                    t.output_preview = ev.get("output_preview", "")
-                    t.raw_response = ev.get("raw_response", "")
-                    t.raw_prompt = ev.get("raw_prompt", "")
-                    t.raw_system = ev.get("raw_system", "")
-                    t.raw_thinking = ev.get("raw_thinking", "")
+                    # Same coercions RunState.apply uses. When these two paths
+                    # disagree, the same event renders differently live than it
+                    # does after a remount — an empty verdict became the "?"
+                    # icon here but "error" there.
+                    t.state = str(ev.get("verdict") or STATE_ERROR)
+                    t.elapsed_sec = opt_float(ev.get("elapsed_sec"))
+                    t.failure_reason = str(ev.get("failure_reason", ""))
+                    t.output_preview = str(ev.get("output_preview", ""))
+                    t.raw_response = str(ev.get("raw_response", ""))
+                    t.raw_prompt = str(ev.get("raw_prompt", ""))
+                    t.raw_system = str(ev.get("raw_system", ""))
+                    t.raw_thinking = str(ev.get("raw_thinking", ""))
             if self.is_mounted:
                 self._rerender()
 
-    async def _listen_terminal(self, topic: str, phase: str) -> None:
+    async def _listen_terminal(
+        self, events: AsyncIterator[dict[str, Any]], phase: str
+    ) -> None:
         """Give the screen an end state. Without this a finished run looks frozen."""
-        async for ev in self.app.bus.subscribe(topic):  # type: ignore[attr-defined]
+        async for ev in events:
             self._apply_terminal(phase, error=str(ev.get("error", "")))
             return
 

--- a/tests/unit/tui/screens/test_runner_trials_hydration.py
+++ b/tests/unit/tui/screens/test_runner_trials_hydration.py
@@ -616,6 +616,35 @@ def test_hydrated_abort_reason_survives_the_matching_bus_event() -> None:
     asyncio.run(_run())
 
 
+def test_detail_screen_leaves_no_bus_subscriptions_behind() -> None:
+    """Opening a settled trial must not leak its queues.
+
+    SessionBus.subscribe() registers a queue synchronously, but the
+    registration is only undone by the finally in SessionBus._consume — which
+    needs the generator started and then closed. A subscription with no
+    consuming task therefore leaks for the life of the app, and publish() keeps
+    filling it with full raw_response payloads.
+    """
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            bus = pilot.app.bus
+            for i in range(5):
+                row = _TrialRow(
+                    model_name="m", test_id=f"t{i}", repeat_idx=1,
+                    state="defended", raw_response="answer",
+                )
+                pilot.app.push_screen(RunnerDetailScreen(trial=row))
+                await pilot.pause()
+                pilot.app.pop_screen()
+                await pilot.pause()
+            await pilot.pause()
+
+            leaked = {t: len(q) for t, q in bus._subscribers.items() if q}
+            assert leaked == {}, f"leaked bus subscriptions: {leaked}"
+
+    asyncio.run(_run())
+
+
 # ── End-to-end: the mid-run drill that produced the original report ──────────
 
 

--- a/tests/unit/tui/screens/test_runner_trials_hydration.py
+++ b/tests/unit/tui/screens/test_runner_trials_hydration.py
@@ -207,6 +207,92 @@ def test_screen_still_receives_live_events_after_hydrating() -> None:
     asyncio.run(_run())
 
 
+def test_bus_queues_are_registered_before_the_hydrate_snapshot() -> None:
+    """The ordering invariant that closes the last event-loss window.
+
+    bus.subscribe() is synchronous and registers the queue immediately, but the
+    coroutine that calls it is not scheduled until the loop next runs. If the
+    screen subscribes inside its listener tasks, an event published after the
+    hydrate snapshot but before those tasks first run is missed by BOTH — the
+    same "pending forever" defect hydration was added to fix. Registering first
+    can only duplicate an event, and every apply is idempotent.
+    """
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            order: list[str] = []
+            real_subscribe = pilot.app.bus.subscribe
+            real_trial = pilot.app.run_state.trial
+
+            def spy_subscribe(topic: str, **kw: object) -> object:
+                order.append(f"subscribe:{topic}")
+                return real_subscribe(topic, **kw)  # type: ignore[arg-type]
+
+            def spy_trial(*a: object, **kw: object) -> object:
+                order.append("hydrate")
+                return real_trial(*a, **kw)  # type: ignore[arg-type]
+
+            pilot.app.bus.subscribe = spy_subscribe  # type: ignore[method-assign]
+            pilot.app.run_state.trial = spy_trial  # type: ignore[method-assign]
+
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            assert "hydrate" in order, "screen never hydrated"
+            first_hydrate = order.index("hydrate")
+            registered = [o for o in order[:first_hydrate] if o.startswith("subscribe:")]
+            assert "subscribe:run.trial_finished" in registered
+            assert "subscribe:run.trial_started" in registered
+            assert "subscribe:run.completed" in registered
+            assert "subscribe:run.aborted" in registered
+
+    asyncio.run(_run())
+
+
+def test_empty_verdict_renders_the_same_live_as_hydrated() -> None:
+    # RunState folds `verdict or "error"`; the live listener used
+    # dict.get(k, "error"), which returns "" when the key is present but empty
+    # — rendering the "?" icon live and "✗" after a remount.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            await pilot.app.bus.publish("run.trial_finished", _ev("t1", verdict=""))
+            await pilot.pause()
+
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "error"
+            assert "?" not in _row_texts(screen)[0]
+
+    asyncio.run(_run())
+
+
+def test_non_float_elapsed_sec_does_not_crash_the_render() -> None:
+    # RunState coerced elapsed_sec; the live listener assigned it raw, so a
+    # string reached an f-string ":.1f" and raised TypeError mid-render.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            await pilot.app.bus.publish(
+                "run.trial_finished", _ev("t1", verdict="defended", elapsed_sec="1.5")
+            )
+            await pilot.pause()
+
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+            assert "1.5s" in _row_texts(screen)[0]
+
+    asyncio.run(_run())
+
+
 # ── Terminal state (hermia-mo4a, part 2) ─────────────────────────────────────
 
 
@@ -456,6 +542,76 @@ def test_detail_hydrates_a_stale_row_from_run_state() -> None:
             screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
             assert screen.output_text == "the real answer"
             assert screen.is_awaiting_result is False
+
+    asyncio.run(_run())
+
+
+def test_detail_stops_claiming_in_progress_when_the_run_ends() -> None:
+    """L3 must not contradict L2.
+
+    The detail screen subscribed only to run.trial_finished. A run that ends
+    without ever reporting this trial (abort, host failure) left L3 asserting
+    "Trial in progress…" indefinitely while L2 showed the same trial as
+    unreported.
+    """
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            pilot.app.run_state.apply("run.started", {})
+            row = _TrialRow(
+                model_name="qwen3:32b", test_id="t1", repeat_idx=1,
+                host_name="node-a", state="running",
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.is_awaiting_result is True
+
+            await pilot.app.bus.publish("run.aborted", {"n_completed": 0})
+            await pilot.pause()
+
+            assert screen.is_awaiting_result is False
+            assert "in progress" not in screen.summary_text
+            assert "unreported" in screen.summary_text
+
+    asyncio.run(_run())
+
+
+def test_detail_mounted_after_a_terminal_run_is_not_in_progress() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.aborted", {"error": "aborted by user"})
+            row = _TrialRow(
+                model_name="qwen3:32b", test_id="t1", repeat_idx=1,
+                host_name="node-a", state="pending",
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.is_awaiting_result is False
+            assert "in progress" not in screen.summary_text
+
+    asyncio.run(_run())
+
+
+def test_hydrated_abort_reason_survives_the_matching_bus_event() -> None:
+    # The bus's run.aborted payload need not carry "error"; recomputing the
+    # banner from it must not erase the reason hydration already knew.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.aborted", {"error": "no such test id"})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert "no such test id" in screen.terminal_text
+
+            await pilot.app.bus.publish("run.aborted", {"n_completed": 0})
+            await pilot.pause()
+
+            assert "no such test id" in screen.terminal_text
 
     asyncio.run(_run())
 

--- a/tests/unit/tui/screens/test_runner_trials_hydration.py
+++ b/tests/unit/tui/screens/test_runner_trials_hydration.py
@@ -1,0 +1,517 @@
+"""Tests for L2 hydration/terminal state (hermia-mo4a) and L3 full response (hermia-2ke3).
+
+The bugs both reproduce only under a specific ordering: events must land
+*before* the screen mounts. A harness that pushes the screen and then publishes
+does not exercise either defect — RunnerTrialsScreen subscribes in on_mount, so
+it sees everything published after that point and looks correct.
+"""
+import asyncio
+
+from textual.widgets import Static
+
+from hermia.tui.app import HermiaApp
+from hermia.tui.runner_backend import TuiRunner
+from hermia.tui.screens.runner_detail import RunnerDetailScreen
+from hermia.tui.screens.runner_trials import RunnerTrialsScreen, _TrialRow
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+
+def _host_with_models() -> Host:
+    return Host(
+        name="node-a",
+        url="http://e:11434",
+        engine="ollama",
+        models=[
+            ModelChoice(name="qwen3:32b", selected=True),
+            ModelChoice(name="qwen2.5:7b", selected=False),
+        ],
+    )
+
+
+def _config_with_host(host: Host) -> FleetConfig:
+    return FleetConfig(name="smoke", hosts=[host], tests=["t1", "t2"], repeat=1)
+
+
+def _ev(test_id: str = "t1", host: str = "node-a", **extra: object) -> dict:
+    ev: dict = {
+        "host_name": host,
+        "model_name": "qwen3:32b",
+        "test_id": test_id,
+        "repeat_idx": 1,
+    }
+    ev.update(extra)
+    return ev
+
+
+def _row_texts(screen: RunnerTrialsScreen) -> list[str]:
+    """Rendered text of the L2 trial rows, in display order.
+
+    Reads `.content` — on Textual 8.2.8 `Static.renderable` is None and a probe
+    that reads it silently reports zero rows.
+    """
+    root = screen.query_one("#trials-root")
+    return [
+        str(c.content) for c in root.children
+        if isinstance(c, Static) and str(getattr(c, "id", "")).startswith("trial-row-")
+    ]
+
+
+# ── Hydration: state that predates the screen (hermia-mo4a, part 1) ──────────
+
+
+def test_trial_finished_before_mount_shows_its_verdict() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.trial_started", _ev("t1"))
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended", elapsed_sec=0.4)
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+
+    asyncio.run(_run())
+
+
+def test_hydrated_verdict_reaches_the_rendered_row() -> None:
+    # Guards a fix that hydrates the model but never re-renders the widgets.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended", elapsed_sec=1.5)
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            rows = _row_texts(screen)
+            assert len(rows) == 2
+            assert "✓" in rows[0]
+            assert "1.5s" in rows[0]
+
+    asyncio.run(_run())
+
+
+def test_trial_started_before_mount_shows_running() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.trial_started", _ev("t1"))
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "running"
+
+    asyncio.run(_run())
+
+
+def test_trial_with_no_prior_events_stays_pending() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "pending"
+
+    asyncio.run(_run())
+
+
+def test_hydration_ignores_another_hosts_results() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished",
+                _ev("t1", host="other-host", verdict="defended"),
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "pending"
+
+    asyncio.run(_run())
+
+
+def test_hydration_picks_this_host_when_both_reported() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended")
+            )
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", host="other-host", verdict="error")
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+
+    asyncio.run(_run())
+
+
+def test_hydration_is_partial_not_all_or_nothing() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended")
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "pending"
+
+    asyncio.run(_run())
+
+
+def test_screen_still_receives_live_events_after_hydrating() -> None:
+    # A fix that hydrates but drops the subscription would pass every test above.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended")
+            )
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            await pilot.app.bus.publish(
+                "run.trial_finished", _ev("t2", verdict="defended", elapsed_sec=0.2)
+            )
+            await pilot.pause()
+
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "defended"
+
+    asyncio.run(_run())
+
+
+# ── Terminal state (hermia-mo4a, part 2) ─────────────────────────────────────
+
+
+def test_run_not_done_while_running() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.run_done is False
+            assert screen.terminal_text == ""
+
+    asyncio.run(_run())
+
+
+def test_run_completed_on_the_bus_marks_the_screen_done() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            await pilot.app.bus.publish("run.completed", {"n_completed": 2})
+            await pilot.pause()
+
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.run_done is True
+            assert "completed" in screen.terminal_text
+
+    asyncio.run(_run())
+
+
+def test_run_aborted_on_the_bus_marks_the_screen_done() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+
+            await pilot.app.bus.publish("run.aborted", {"n_completed": 1})
+            await pilot.pause()
+
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.run_done is True
+            assert "aborted" in screen.terminal_text
+
+    asyncio.run(_run())
+
+
+def test_run_already_terminal_before_mount_needs_no_bus_event() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.completed", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.run_done is True
+            assert "completed" in screen.terminal_text
+
+    asyncio.run(_run())
+
+
+def test_terminal_run_stops_claiming_unreported_trials_are_pending() -> None:
+    # "pending" asserts a result is still coming. After the run ends that is a
+    # confident non-answer — the screen must say only what it knows.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.trial_started", _ev("t1"))
+            pilot.app.run_state.apply("run.completed", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "unreported"
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "unreported"
+
+    asyncio.run(_run())
+
+
+def test_terminal_run_preserves_reported_verdicts() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended")
+            )
+            pilot.app.run_state.apply("run.completed", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "unreported"
+
+    asyncio.run(_run())
+
+
+def test_terminal_bus_event_also_flips_pending_rows() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "pending"
+
+            await pilot.app.bus.publish("run.aborted", {"n_completed": 0})
+            await pilot.pause()
+
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "unreported"
+
+    asyncio.run(_run())
+
+
+def test_terminal_banner_count_survives_a_second_terminal_signal() -> None:
+    # Hydrating a terminal run and THEN receiving the terminal bus event must
+    # not make the banner claim every trial reported. Counting the rows flipped
+    # by this call (zero the second time) instead of the rows currently
+    # unreported produces exactly that false "17/17".
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply(
+                "run.trial_finished", _ev("t1", verdict="defended")
+            )
+            pilot.app.run_state.apply("run.completed", {})
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+            assert "1/2 reported" in screen.terminal_text
+
+            await pilot.app.bus.publish("run.completed", {"n_completed": 1})
+            await pilot.pause()
+
+            assert "1/2 reported" in screen.terminal_text
+            assert "1 never reported" in screen.terminal_text
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "unreported"
+
+    asyncio.run(_run())
+
+
+# ── Full response in the detail view (hermia-2ke3) ───────────────────────────
+
+
+def test_detail_shows_the_entire_raw_response() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            row = _TrialRow(
+                model_name="m", test_id="t1", repeat_idx=1,
+                state="defended", raw_response="y" * 4000,
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert len(screen.output_text) == 4000
+            assert screen.output_text == "y" * 4000
+
+    asyncio.run(_run())
+
+
+def test_detail_prefers_raw_response_over_preview() -> None:
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            row = _TrialRow(
+                model_name="m", test_id="t1", repeat_idx=1, state="defended",
+                raw_response="the full response", output_preview="the trunc",
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.output_text == "the full response"
+
+    asyncio.run(_run())
+
+
+def test_detail_falls_back_to_preview_when_no_raw_response() -> None:
+    # Error and timeout rows never carry a raw_response.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            row = _TrialRow(
+                model_name="m", test_id="t1", repeat_idx=1, state="error",
+                raw_response="", output_preview="TIMEOUT: no response in 90s",
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.output_text == "TIMEOUT: no response in 90s"
+
+    asyncio.run(_run())
+
+
+def test_detail_response_with_brackets_survives_rendering() -> None:
+    # Model output is routinely JSON. Rich markup parsing silently DELETES
+    # "[bold]" from a rendered line, so asserting on the property alone is not
+    # enough — this reads the composited line back.
+    raw = '{"tools": ["a", "b"], "note": "[bold] not markup"}'
+
+    async def _run() -> None:
+        async with HermiaApp().run_test(size=(120, 30)) as pilot:
+            row = _TrialRow(
+                model_name="m", test_id="t1", repeat_idx=1,
+                state="defended", raw_response=raw,
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.output_text == raw
+            rendered = screen.query_one("#detail-output", Static).render_line(0).text
+            assert "[bold]" in rendered
+
+    asyncio.run(_run())
+
+
+def test_detail_hydrates_a_stale_row_from_run_state() -> None:
+    # L3 can be reached carrying a row that predates the result (drill in, then
+    # the trial lands). Without hydration it renders "in progress" forever.
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            pilot.app.run_state.apply("run.started", {})
+            pilot.app.run_state.apply("run.trial_finished", _ev(
+                "t1", verdict="defended", elapsed_sec=2.0,
+                raw_response="the real answer",
+            ))
+            row = _TrialRow(
+                model_name="qwen3:32b", test_id="t1", repeat_idx=1,
+                host_name="node-a", state="pending",
+            )
+            pilot.app.push_screen(RunnerDetailScreen(trial=row))
+            await pilot.pause()
+            screen: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert screen.output_text == "the real answer"
+            assert screen.is_awaiting_result is False
+
+    asyncio.run(_run())
+
+
+# ── End-to-end: the mid-run drill that produced the original report ──────────
+
+
+def test_drilling_in_after_a_run_finishes_shows_every_verdict() -> None:
+    """The reported failure, end to end: run first, drill in second.
+
+    Uses the real TuiRunner with an injected run_test_fn — no network, no disk.
+    """
+    def _fake_run_test(model_name: str, test: dict, **kwargs: object) -> dict:
+        return {
+            "model": model_name,
+            "test_id": test["id"],
+            "failure_reason": "",
+            "elapsed_sec": 0.01,
+            "output_preview": "trunc",
+            "raw_response": f"full answer for {test['id']}",
+            "signals": {},
+        }
+
+    async def _run() -> None:
+        async with HermiaApp().run_test() as pilot:
+            host = _host_with_models()
+            pilot.app.config = _config_with_host(host)
+            runner = TuiRunner(
+                config=pilot.app.config,
+                bus=pilot.app.bus,
+                results_dir=None,
+                run_test_fn=_fake_run_test,
+                run_state=pilot.app.run_state,
+                _tests_override=[{"id": "t1"}, {"id": "t2"}],
+            )
+            await runner.start()
+            for _ in range(200):
+                if not runner.is_running:
+                    break
+                await pilot.pause()
+            assert runner.is_running is False
+
+            # Only now does the user drill in — every event is already gone.
+            pilot.app.push_screen(RunnerTrialsScreen(host=host))
+            await pilot.pause()
+            screen: RunnerTrialsScreen = pilot.app.screen  # type: ignore[assignment]
+
+            assert screen.trial_state("qwen3:32b", "t1", 1) == "defended"
+            assert screen.trial_state("qwen3:32b", "t2", 1) == "defended"
+            assert screen.run_done is True
+            assert "completed" in screen.terminal_text
+
+            # …and the full response is reachable from the detail view.
+            screen.action_drill()
+            await pilot.pause()
+            detail: RunnerDetailScreen = pilot.app.screen  # type: ignore[assignment]
+            assert detail.output_text == "full answer for t1"
+
+    asyncio.run(_run())

--- a/tests/unit/tui/test_run_state.py
+++ b/tests/unit/tui/test_run_state.py
@@ -1,0 +1,245 @@
+"""Tests for RunState — the durable fold of run.* bus events.
+
+NOTE ON TEST NAMES: keep them under ~35 characters after the `test_` prefix.
+TruffleHog's Lob detector matches a long lowercase identifier following
+`test_` and reports it as a verified API key, which fails the Security
+workflow. Two names in this file did exactly that (hermia-v0h6).
+
+The SessionBus carries deltas only: `subscribe()` allocates a fresh empty
+queue, so a screen mounted mid-run can never reconstruct what it missed from
+the bus. RunState is the store screens hydrate from instead (hermia-mo4a), and
+the carrier for the full model response the L3 detail screen needs
+(hermia-2ke3).
+"""
+from hermia.tui.run_state import RunState, TrialRecord
+
+_KEY = ("host1", "model1", "test1", 1)
+
+
+def _started(host: str = "host1", model: str = "model1",
+             test: str = "test1", rep: int = 1) -> dict:
+    return {
+        "host_name": host, "model_name": model,
+        "test_id": test, "repeat_idx": rep,
+    }
+
+
+def _finished(verdict: str = "defended", **over: object) -> dict:
+    ev: dict = {**_started(), "verdict": verdict}
+    ev.update(over)
+    return ev
+
+
+class TestInitialState:
+    def test_fresh_run_state_is_idle_and_empty(self) -> None:
+        rs = RunState()
+        assert rs.phase == "idle"
+        assert rs.is_terminal is False
+        assert rs.error == ""
+        assert rs.trial(*_KEY) is None
+        assert rs.trials_for_host("host1") == []
+
+    def test_trials_for_unknown_host_is_empty(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started())
+        assert rs.trials_for_host("nobody") == []
+
+
+class TestTrialFold:
+    def test_trial_started_creates_running_record(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started())
+        rec = rs.trial(*_KEY)
+        assert isinstance(rec, TrialRecord)
+        assert rec.state == "running"
+
+    def test_trial_finished_sets_state_from_verdict(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started())
+        rs.apply("run.trial_finished", _finished("defended"))
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "defended"
+
+    def test_trial_finished_without_verdict_defaults_to_error(self) -> None:
+        rs = RunState()
+        ev = _started()
+        rs.apply("run.trial_finished", ev)
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "error"
+
+    def test_trial_finished_without_a_prior_start_still_records(self) -> None:
+        # The host-error path in TuiRunner publishes trial_finished with no
+        # matching trial_started; so does any trial whose start was missed.
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished("error"))
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "error"
+
+    def test_started_then_finished_updates_one_record(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started())
+        rs.apply("run.trial_finished", _finished("defended"))
+        assert len(rs.trials_for_host("host1")) == 1
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "defended"
+
+    def test_repeat_idx_distinguishes_records(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started(rep=1))
+        rs.apply("run.trial_started", _started(rep=2))
+        assert len(rs.trials_for_host("host1")) == 2
+
+    def test_host_name_distinguishes_and_filters_records(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started(host="host1"))
+        rs.apply("run.trial_started", _started(host="host2"))
+        assert len(rs.trials_for_host("host1")) == 1
+        assert len(rs.trials_for_host("host2")) == 1
+        assert rs.trials_for_host("host1")[0].host_name == "host1"
+
+    def test_trials_for_host_preserves_first_seen_order(self) -> None:
+        rs = RunState()
+        for tid in ("test1", "test2", "test3"):
+            rs.apply("run.trial_started", _started(test=tid))
+        assert [t.test_id for t in rs.trials_for_host("host1")] == [
+            "test1", "test2", "test3",
+        ]
+
+    def test_reordered_events_keep_first_seen_order(self) -> None:
+        # A later finish on an earlier-started trial must not reshuffle rows
+        # under the user's cursor.
+        rs = RunState()
+        rs.apply("run.trial_started", _started(test="test1"))
+        rs.apply("run.trial_started", _started(test="test2"))
+        rs.apply("run.trial_finished", {**_started(test="test1"), "verdict": "defended"})
+        assert [t.test_id for t in rs.trials_for_host("host1")] == ["test1", "test2"]
+
+
+class TestPayloadPassthrough:
+    def test_full_raw_response_is_not_truncated(self) -> None:
+        # The entire point of hermia-2ke3: nothing in the fold may truncate.
+        raw = "x" * 5000
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished(raw_response=raw))
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert len(rec.raw_response) == 5000
+        assert rec.raw_response == raw
+
+    def test_all_payload_fields_round_trip(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished(
+            "error",
+            elapsed_sec=1.25,
+            failure_reason="JSON_PARSE_ERROR",
+            output_preview="trunc",
+            raw_response="full response",
+            raw_prompt="the prompt",
+            raw_system="the system prompt",
+            raw_thinking="the reasoning trace",
+        ))
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.elapsed_sec == 1.25
+        assert rec.failure_reason == "JSON_PARSE_ERROR"
+        assert rec.output_preview == "trunc"
+        assert rec.raw_response == "full response"
+        assert rec.raw_prompt == "the prompt"
+        assert rec.raw_system == "the system prompt"
+        assert rec.raw_thinking == "the reasoning trace"
+
+    def test_absent_fields_default_to_empty(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished("defended"))
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.elapsed_sec is None
+        assert rec.failure_reason == ""
+        assert rec.raw_response == ""
+        assert rec.raw_thinking == ""
+
+
+class TestPhase:
+    def test_run_completed_is_terminal(self) -> None:
+        rs = RunState()
+        rs.apply("run.started", {})
+        rs.apply("run.completed", {"n_completed": 3})
+        assert rs.phase == "completed"
+        assert rs.is_terminal is True
+
+    def test_run_aborted_is_terminal_and_captures_error(self) -> None:
+        rs = RunState()
+        rs.apply("run.aborted", {"error": "no such test id"})
+        assert rs.phase == "aborted"
+        assert rs.error == "no such test id"
+        assert rs.is_terminal is True
+
+    def test_run_aborted_without_error_key_leaves_error_empty(self) -> None:
+        rs = RunState()
+        rs.apply("run.aborted", {"n_completed": 2})
+        assert rs.phase == "aborted"
+        assert rs.error == ""
+
+    def test_run_started_is_running_and_not_terminal(self) -> None:
+        rs = RunState()
+        rs.apply("run.started", {"n_trials_total": 4})
+        assert rs.phase == "running"
+        assert rs.is_terminal is False
+
+    def test_terminal_phase_does_not_alter_recorded_verdicts(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished("defended"))
+        rs.apply("run.completed", {})
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "defended"
+
+
+class TestResetSemantics:
+    def test_run_started_clears_a_previous_runs_trials(self) -> None:
+        # Without this, a second run in the same TUI session hydrates screens
+        # from the first run's rows.
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished("defended"))
+        rs.apply("run.completed", {})
+        rs.apply("run.started", {"n_trials_total": 2})
+        assert rs.trial(*_KEY) is None
+        assert rs.trials_for_host("host1") == []
+        assert rs.phase == "running"
+        assert rs.is_terminal is False
+
+    def test_run_started_clears_a_previous_runs_error(self) -> None:
+        rs = RunState()
+        rs.apply("run.aborted", {"error": "boom"})
+        rs.apply("run.started", {})
+        assert rs.error == ""
+
+    def test_reset_clears_all_run_state(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_started", _started())
+        rs.apply("run.aborted", {"error": "boom"})
+        rs.reset()
+        assert rs.phase == "idle"
+        assert rs.error == ""
+        assert rs.trial(*_KEY) is None
+
+
+class TestUnknownTopics:
+    def test_unknown_topic_leaves_state_untouched(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_finished", _finished("defended"))
+        rs.apply("probe.host_finished", {"host_name": "host1", "verdict": "error"})
+        rec = rs.trial(*_KEY)
+        assert rec is not None
+        assert rec.state == "defended"
+        assert rs.phase == "idle"
+        assert len(rs.trials_for_host("host1")) == 1
+
+    def test_trial_chunk_topic_is_ignored(self) -> None:
+        rs = RunState()
+        rs.apply("run.trial_chunk", {**_started(), "chunk": "tok"})
+        assert rs.trial(*_KEY) is None


### PR DESCRIPTION
Fixes the two drill-down surfaces a person needs in order to audit a run. Both were asserting things they did not know.

## hermia-mo4a — the trials screen rendered a completed run as pending

`SessionBus.subscribe()` allocates a fresh empty queue with **no replay**, and `RunnerTrialsScreen` built every row at the dataclass default *before* subscribing. Any trial that finished while the user was on another screen read `pending` forever. The screen also subscribed only to `run.trial_started` / `run.trial_finished` — never the terminal topics — so a finished run had no end state and looked frozen.

**Fix:** new `src/hermia/tui/run_state.py`. `RunState` is a durable fold of the `run.*` stream, one record per `(host, model, test_id, repeat_idx)`, reset on `run.started`. `TuiRunner` folds each event in **before** publishing it, through a single `_emit()` choke point, so the store can never lag the bus. Screens hydrate from it on mount and use the bus for deltas thereafter.

**Rejected alternative — a replay buffer in `SessionBus`:** bounded, it silently drops the oldest events and reproduces the same false `pending`; unbounded, it accumulates every event (now including full responses) and would replay a previous run into a new run's screens.

**Terminal state:** rows still pending/running when the run ends flip to `unreported`. `pending` asserts a result is still coming — an assertion the screen has no basis for once the run is over.

## hermia-2ke3 — the detail view showed 120 characters, not the response

`run.trial_finished` did not carry `raw_response` at all, so this could not be fixed in the detail screen alone. The event contract is widened with `raw_response` / `raw_prompt` / `raw_system` / `raw_thinking`, and the backend's error and timeout paths now carry their full message rather than 120 characters of it (`output_preview` stays truncated — it is the row summary, not the response). The output pane is scrollable.

**Separate bug found while here:** the old code called `Static.update()` with Rich markup **on**, and Rich silently *deletes* bracketed spans. Probed directly: `x [bold] y` renders as `x  y`. Model output is routinely JSON, so real responses were being quietly mangled. The pane is now `markup=False`, with a render-level test that reads the composited line back rather than trusting a property.

## Verification

- **1944 passed**, +45 new tests. The 6 `test_detect_gpu_*` failures are pre-existing macOS platform noise, tracked as `hermia-2ess` — unchanged from the baseline on `dev`.
- **Mutation pass** — each half of the fix was broken on purpose to confirm the tests catch it: dropping hydration fails 10, the terminal listener 1, the `raw_response` preference 5.
- **Live probe** with the real `TuiRunner`: drilling in shows 17/17 verdicts, banner `run completed — 17/17 reported`; the detail view renders 515 characters where 120 was the ceiling, brackets intact.
- `ruff check src/ tests/` and `mypy src/` clean.

Self-review caught a defect in the fix itself: `_apply_terminal` counted the rows *it* flipped, so a second terminal signal would report `17/17 reported` when two never did — the exact failure shape this work removes. Fixed, with a regression test.

## Scope

`src/hermia/tui/**` only. No corpus, no CLI writer, no published number.

Follow-up filed: `hermia-6q4d` — host-level failures publish with an empty model and test id, so they match no row and remain invisible on the trials screen. Pre-existing, not made worse here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial results now persist throughout a run, allowing screens opened later to display recorded progress and verdicts.
  * Added clear status indicators for running, completed, aborted, pending, and unreported trials.
  * Trial details display complete responses, prompts, system instructions, and reasoning when available.
  * Preserved response formatting and enabled scrolling for lengthy outputs.
  * Run completion and abort reasons are shown in the interface.

* **Bug Fixes**
  * Prevented trial results from disappearing when navigating between screens or opening details after a run finishes.
  * Improved handling of partial results, host errors, timeouts, and terminal runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->