### PR TITLE
fix(tui): load headless fleet configs instead of silently returning zero hosts (hermia-79z6)

### DIFF
--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -59,24 +59,73 @@ def save_fleet(config: FleetConfig, *, root: Path = Path(".")) -> Path:
     return path
 
 
+def _headless_host(d: Any) -> Host:
+    """Convert one headless `fleet[]` entry to a TUI Host.
+
+    The reverse of ``fleet._tui_fleet_to_entries``, and it must stay in step
+    with it: headless writes {name, host, transport?, auth.bearer.key_env?,
+    models?}, the TUI wants {name, url, engine, auth_header_env?, models[]}.
+
+    ``test_timeout`` and ``stack`` have no Host field and are dropped — a
+    headless config carrying them still loads rather than failing.
+    """
+    if not isinstance(d, dict):
+        raise TypeError("Fleet entry must be a dictionary")
+    if not d.get("name"):
+        raise KeyError("Fleet entry missing required field: 'name'")
+    if not d.get("host"):
+        raise KeyError("Fleet entry missing required field: 'host'")
+    raw_models = d.get("models")
+    # `models: auto` is a headless directive meaning "discover on the host".
+    # The TUI discovers through its picker, so it selects nothing here — it must
+    # not materialise a model literally named "auto".
+    models: list[str] = [] if (raw_models is None or raw_models == "auto") else list(raw_models)
+    auth = d.get("auth") or {}
+    bearer = (auth.get("bearer") or {}) if isinstance(auth, dict) else {}
+    return Host(
+        name=d["name"],
+        url=d["host"],
+        engine=d.get("transport") or "ollama",
+        auth_header_env=bearer.get("key_env") if isinstance(bearer, dict) else None,
+        models=[ModelChoice(name=n, selected=True) for n in models],
+    )
+
+
 def load_fleet(path: Path) -> FleetConfig:
     """Parse a fleet YAML file into a FleetConfig.
+
+    Accepts BOTH layouts, mirroring ``fleet.load_fleet_config`` which already
+    reads TUI files: the TUI's own `hosts:` key, and the headless runner's
+    `fleet:` key. Before hermia-79z6 only `hosts:` was read and a headless
+    config loaded as zero hosts with no error — 23 of 25 committed configs.
 
     Raises:
         FileNotFoundError: if the path does not exist.
         yaml.YAMLError: if the file is not valid YAML.
-        KeyError: if a required field (name) is missing.
+        KeyError: if a required field (name), or any host key at all, is missing.
     """
     if not path.exists():
         raise FileNotFoundError(f"No fleet found at {path}")
     raw = yaml.safe_load(path.read_text())
     # The isinstance check forces the right error class — `"name" not in raw`
-    # would substring-match if raw were a scalar string. `not raw.get("name")`
-    # also catches `name:` (explicit-null) and `name: ""` (empty string), which
-    # would otherwise construct FleetConfig(name=None) and write
-    # `fleets/None.yaml` downstream.
-    if not isinstance(raw, dict) or not raw.get("name"):
+    # would substring-match if raw were a scalar string.
+    if not isinstance(raw, dict):
         raise KeyError("name")
+    is_headless = "hosts" not in raw and "fleet" in raw
+    if is_headless:
+        # Headless configs have no `name:` — the CLI never needed one. Falling
+        # back to the filename keeps them openable AND avoids the unnamed-fleet
+        # trap: RunnerScreen only sets results_dir when config.name is truthy,
+        # so a nameless fleet runs and silently discards every row.
+        # TUI-saved files are `fleets/<name>.yaml`, so stem == name round-trips.
+        name = str(raw.get("name") or "") or Path(path.stem).name or "unnamed"
+    else:
+        # TUI format keeps the strict contract: `name:` (explicit-null) and
+        # `name: ""` would otherwise construct FleetConfig(name=None) and write
+        # `fleets/None.yaml` downstream.
+        if not raw.get("name"):
+            raise KeyError("name")
+        name = raw["name"]
     # `raw.get("key", [])` would return None if the YAML has an empty key
     # (e.g. `tests:` with no children), causing list(None) / iteration to
     # TypeError. `... or []` short-circuits both missing and explicit-null.
@@ -85,14 +134,42 @@ def load_fleet(path: Path) -> FleetConfig:
     repeat_raw = raw.get("repeat")
     # `tests: <single-string>` would silently `list("foo") == ['f','o','o']`
     # — fail loud instead of producing nonsense test IDs.
-    tests_raw = raw.get("tests") or []
-    if isinstance(tests_raw, str):
-        raise TypeError("tests must be a list of strings, not a single string")
+    # ABSENT and EMPTY are deliberately different. A headless config omits
+    # `tests:` because the CLI always runs the whole corpus, so defaulting an
+    # absent key to [] would load a fleet with hosts but zero trials — the same
+    # silent-empty shape as the missing hosts. An explicit `tests: []` is a TUI
+    # user who deselected everything, and must be left alone.
+    if "tests" in raw:
+        tests_raw = raw.get("tests") or []
+        if isinstance(tests_raw, str):
+            raise TypeError("tests must be a list of strings, not a single string")
+        tests = list(tests_raw)
+    else:
+        from hermia.runner import load_tests_all
+        tests = [t["id"] for t in load_tests_all()]
+
+    # `hosts:` is the TUI's native key and wins when both are present.
+    if "hosts" in raw:
+        host_entries = raw.get("hosts") or []
+        if not isinstance(host_entries, list):
+            raise TypeError("'hosts' must be a list")
+        hosts = [_deserialize_host(h) for h in host_entries]
+    elif "fleet" in raw:
+        fleet_entries = raw.get("fleet") or []
+        if not isinstance(fleet_entries, list):
+            raise TypeError("'fleet' must be a list")
+        hosts = [_headless_host(h) for h in fleet_entries]
+    else:
+        raise KeyError(
+            "fleet config has no 'hosts' (TUI) or 'fleet' (headless) key — "
+            "refusing to load it as an empty fleet"
+        )
+
     return FleetConfig(
-        name=raw["name"],
-        tests=list(tests_raw),
+        name=name,
+        tests=tests,
         repeat=int(repeat_raw) if repeat_raw is not None else 1,
-        hosts=[_deserialize_host(h) for h in (raw.get("hosts") or [])],
+        hosts=hosts,
     )
 
 

--- a/tests/unit/tui/test_fleet_io_headless_format.py
+++ b/tests/unit/tui/test_fleet_io_headless_format.py
@@ -1,0 +1,292 @@
+"""The TUI must load headless (CLI) fleet YAML, not silently return zero hosts.
+
+hermia-79z6. `load_fleet` read only the TUI's own `hosts:` key, while every
+headless config uses `fleet:`. Because the guard was `raw.get("hosts") or []`,
+opening a real fleet in the TUI produced a config with NO hosts and NO error —
+23 of the 25 committed configs were affected.
+
+The conversion already existed in the other direction: `fleet._tui_fleet_to_entries`
+lets the headless runner read TUI files. These tests pin the reverse mapping so
+the two formats are interchangeable both ways.
+"""
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from hermia.runner import load_tests_all
+from hermia.tui.fleet_io import load_fleet
+
+
+def _write(tmp_path: Path, body: str, name: str = "f.yaml") -> Path:
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(body))
+    return p
+
+
+# ── Headless (CLI) format is accepted ────────────────────────────────────────
+
+
+class TestHeadlessFormatLoads:
+    def test_fleet_key_produces_hosts(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: smoke
+            fleet:
+              - name: bh-m3-36gb
+                host: http://192.168.2.2:11434
+                models:
+                  - mistral:7b
+              - name: bh-m1-16gb
+                host: http://192.168.2.4:11434
+                models:
+                  - mistral:7b
+        """)
+        cfg = load_fleet(p)
+        assert [h.name for h in cfg.hosts] == ["bh-m3-36gb", "bh-m1-16gb"]
+
+    def test_host_key_maps_to_url(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://10.0.0.1:11434'}
+        """)
+        assert load_fleet(p).hosts[0].url == "http://10.0.0.1:11434"
+
+    def test_transport_maps_to_engine(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'https://x/v1', transport: openai-compat}
+        """)
+        assert load_fleet(p).hosts[0].engine == "openai-compat"
+
+    def test_missing_transport_defaults_to_ollama(self, tmp_path: Path) -> None:
+        # Mirrors fleet._tui_fleet_to_entries, which defaults engine -> ollama.
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """)
+        assert load_fleet(p).hosts[0].engine == "ollama"
+
+    def test_auth_bearer_key_env_maps_to_auth_header_env(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - name: a
+                host: 'https://x/v1'
+                auth:
+                  bearer:
+                    key_env: MY_TOKEN
+        """)
+        assert load_fleet(p).hosts[0].auth_header_env == "MY_TOKEN"
+
+    def test_models_become_selected_choices(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434', models: [mistral:7b, qwen3:8b]}
+        """)
+        models = load_fleet(p).hosts[0].models
+        assert [m.name for m in models] == ["mistral:7b", "qwen3:8b"]
+        assert all(m.selected for m in models), "loaded models must be runnable"
+
+    def test_models_auto_yields_no_preselection(self, tmp_path: Path) -> None:
+        # 'auto' is a headless directive meaning "discover on the host". The TUI
+        # has a picker for that; it must not crash or invent a model named auto.
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434', models: auto}
+        """)
+        assert load_fleet(p).hosts[0].models == []
+
+    def test_absent_models_yields_empty_list(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """)
+        assert load_fleet(p).hosts[0].models == []
+
+    def test_test_timeout_is_ignored_not_fatal(self, tmp_path: Path) -> None:
+        # test_timeout has no Host field; it must not break the load.
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434', test_timeout: 300}
+        """)
+        assert load_fleet(p).hosts[0].name == "a"
+
+
+# ── tests: key semantics ─────────────────────────────────────────────────────
+
+
+class TestTestsKeyDefaulting:
+    def test_absent_tests_key_defaults_to_the_full_corpus(self, tmp_path: Path) -> None:
+        # Headless configs omit `tests:` because the CLI always runs the whole
+        # corpus. Loading one into the TUI with zero tests would be a second
+        # silent-empty path: hosts present, but no trials.
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a, host: 'http://h:11434', models: [m:7b]}
+        """)
+        cfg = load_fleet(p)
+        assert len(cfg.tests) == len(load_tests_all())
+        assert cfg.tests, "a headless config must not load as zero trials"
+
+    def test_present_tests_key_is_honoured_exactly(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            tests: [tool-calling-basic]
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """)
+        assert load_fleet(p).tests == ["tool-calling-basic"]
+
+    def test_explicit_empty_tests_stays_empty(self, tmp_path: Path) -> None:
+        # A TUI-saved fleet always writes the key. `tests: []` means the user
+        # deselected everything — do NOT silently run all 30 instead.
+        p = _write(tmp_path, """
+            name: s
+            tests: []
+            hosts:
+              - {name: a, url: 'http://h:11434', engine: ollama}
+        """)
+        assert load_fleet(p).tests == []
+
+
+# ── The silent-empty failure is now loud ─────────────────────────────────────
+
+
+class TestNameDerivation:
+    def test_headless_config_without_a_name_uses_the_filename(self, tmp_path: Path) -> None:
+        # Headless configs have no `name:` — the CLI never needed one. Without a
+        # fallback the TUI refuses to open 8 of the committed configs; worse, an
+        # empty name makes RunnerScreen skip results_dir entirely, so the run
+        # would discard every row silently.
+        p = _write(tmp_path, """
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """, name="fleet-2026-08-05-mobile-lab-smoke.yaml")
+        assert load_fleet(p).name == "fleet-2026-08-05-mobile-lab-smoke"
+
+    def test_headless_name_when_present_wins_over_the_filename(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: declared-name
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """, name="ignored.yaml")
+        assert load_fleet(p).name == "declared-name"
+
+    def test_derived_name_is_never_empty(self, tmp_path: Path) -> None:
+        # A falsy name reaching FleetConfig is the bug this guards: save_fleet
+        # would write fleets/None.yaml and the runner would drop the rows.
+        p = _write(tmp_path, """
+            fleet:
+              - {name: a, host: 'http://h:11434'}
+        """, name="x.yaml")
+        assert load_fleet(p).name
+
+
+class TestNoSilentEmpty:
+    def test_neither_hosts_nor_fleet_key_raises(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            repeat: 1
+        """)
+        with pytest.raises(KeyError) as exc:
+            load_fleet(p)
+        assert "hosts" in str(exc.value) or "fleet" in str(exc.value)
+
+    def test_explicit_empty_hosts_list_is_still_allowed(self, tmp_path: Path) -> None:
+        # A part-built fleet saved from the TUI is legitimate — only a config
+        # with NO host key at all is malformed.
+        p = _write(tmp_path, """
+            name: s
+            tests: []
+            hosts: []
+        """)
+        assert load_fleet(p).hosts == []
+
+    def test_fleet_entry_missing_host_raises(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {name: a}
+        """)
+        with pytest.raises(KeyError):
+            load_fleet(p)
+
+    def test_fleet_entry_missing_name_raises(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet:
+              - {host: 'http://h:11434'}
+        """)
+        with pytest.raises(KeyError):
+            load_fleet(p)
+
+    def test_fleet_must_be_a_list(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            fleet: nonsense
+        """)
+        with pytest.raises((TypeError, ValueError)):
+            load_fleet(p)
+
+
+# ── TUI format is unchanged ──────────────────────────────────────────────────
+
+
+class TestTuiFormatRegression:
+    def test_hosts_key_still_loads(self, tmp_path: Path) -> None:
+        p = _write(tmp_path, """
+            name: s
+            tests: [tool-calling-basic]
+            repeat: 2
+            hosts:
+              - name: a
+                url: 'http://h:11434'
+                engine: ollama
+                auth_header_env: TOK
+                hardware: metal
+                models: [mistral:7b]
+        """)
+        cfg = load_fleet(p)
+        h = cfg.hosts[0]
+        assert (h.name, h.url, h.engine) == ("a", "http://h:11434", "ollama")
+        assert h.auth_header_env == "TOK"
+        assert h.hardware == "metal"
+        assert [m.name for m in h.models] == ["mistral:7b"]
+        assert cfg.repeat == 2
+
+    def test_hosts_key_wins_when_both_present(self, tmp_path: Path) -> None:
+        # Matches the headless loader, which prefers `fleet:` when both exist by
+        # only converting TUI format if "fleet" is absent. Here the TUI's own
+        # key is the native one, so it takes precedence — but the behaviour must
+        # be defined rather than accidental.
+        p = _write(tmp_path, """
+            name: s
+            hosts:
+              - {name: from-hosts, url: 'http://h:11434', engine: ollama}
+            fleet:
+              - {name: from-fleet, host: 'http://h:11434'}
+        """)
+        assert [h.name for h in load_fleet(p).hosts] == ["from-hosts"]
+
+
+# ── The actual reported failure, on the real committed configs ───────────────
+
+
+class TestRealConfigs:
+    def test_the_reported_config_loads_three_hosts(self) -> None:
+        # fleets/ is gitignored, so skip when the real files are absent (CI).
+        p = Path("fleets/fleet-2026-08-05-mobile-lab-smoke.yaml")
+        if not p.exists():
+            pytest.skip("local fleets/ not present")
+        cfg = load_fleet(p)
+        assert len(cfg.hosts) == 3, "this is the config that loaded as zero hosts"
+        assert all(h.url.startswith("http://") for h in cfg.hosts)
+        assert cfg.tests, "must not load as zero trials"


### PR DESCRIPTION
Opening a real fleet config in the TUI produced a config with **no hosts and no error**. 23 of the 25 committed configs were affected, including both mobile-lab configs.

Found while doing real-lab verification for #159 — the TUI could not load the very config that fleet was defined in.

## Root cause

`load_fleet` read only the TUI's own `hosts:` key, via `raw.get("hosts") or []`. Every headless (CLI) config uses `fleet:`.

The conversion already existed in the other direction — `fleet._tui_fleet_to_entries` lets the headless runner read TUI files, and `load_fleet_config` documents that it "accepts both formats". Only the TUI half was missing, so the two formats interoperated one way and failed silently the other.

## Three stacked silent-empty paths, not one

Fixing the hosts key exposed two more of the same shape underneath:

| # | Path | Effect |
|---|------|--------|
| 1 | `fleet:` ignored | 23 of 25 configs loaded as **zero hosts** |
| 2 | absent `tests:` → `[]` | even with hosts fixed, a headless config loads **zero trials** — the CLI omits the key because it always runs all 30 |
| 3 | no top-level `name:` | blocked 8 more configs outright; an empty name also trips the existing trap in `screens/config.py`, where `results_dir` is only set when `config.name` is truthy — so the run happens and **silently discards every row** |

## The fix

- `fleet:` entries convert to `Host`s, mirroring `_tui_fleet_to_entries` exactly in reverse: `host`→`url`, `transport`→`engine` (default `ollama`), `auth.bearer.key_env`→`auth_header_env`, `models`→selected `ModelChoice`s.
- `models: auto` is a headless *discovery directive* — it now selects nothing rather than materialising a model literally named `auto`.
- `test_timeout` and `stack` have no `Host` field and are dropped rather than being fatal.
- An **absent** `tests:` key defaults to the full corpus, matching CLI semantics. An **explicit** `tests: []` means the user deselected everything and is left alone.
- `name` falls back to the filename stem **for headless files only**. The TUI-format contract is unchanged: `name:` null or `""` still raises, and all three existing tests for it pass untouched.
- A config with neither key now **raises** instead of loading as an empty fleet.

## Verification

- **23 new tests**; all **27 existing** `fleet_io` tests pass **unchanged** — no goalposts moved.
- **Mutation pass, 5/5 caught**: dropping `fleet:` support fails 16; absent-tests→empty fails 2; dropping the name fallback fails 2; restoring the silent empty fails 1; `models: auto` materialising fake models fails 1.
- **Census over the real configs: 25/25 now load with hosts, tests and a name — previously 2.**
- Full suite **1974 passed**. The 6 `test_detect_gpu_*` failures are pre-existing macOS platform noise, tracked as `hermia-2ess`, unchanged from the baseline on `dev`.
- `ruff check src/ tests/` and `mypy src/` clean.

## Not verified

An end-to-end run of a previously-broken config against live models. The loader produced the right 3 hosts / 3 engines / 30 tests, but the lab machines were asleep and every trial hit the 90s timeout. The loader itself is covered by tests and the config census; the live run is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading both TUI and headless fleet configuration formats.
  - Run progress and trial results now persist during navigation and can be restored when screens open.
  - Trial views display complete raw responses, verdicts, timing, errors, and unreported trials.
  - Completed and aborted runs show clear terminal status indicators.

- **Bug Fixes**
  - Prevented lost results when screens mount after trial events.
  - Improved handling of timeouts, malformed responses, and incomplete runs.
  - Preserved output containing markup-like characters without altering its display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->