### PR TITLE
fix(tui): stamp run identity on result rows and stop CSV column shear (hermia-0hqm)

### DIFF
--- a/src/hermia/results.py
+++ b/src/hermia/results.py
@@ -33,14 +33,36 @@ def append_result(
                 f.write(json.dumps(result) + "\n")
 
         if csv_path is not None:
-            write_header = not csv_path.exists()
+            # Fieldnames MUST come from the header already on disk, not from this
+            # row. Deriving them per-row wrote later rows' values under the first
+            # row's column names whenever the key sets differed — silently, with
+            # no exception, so a JSONL-only test passed over corrupt CSV
+            # (hermia-0hqm). Rows written before the header existed decide it.
+            fieldnames = _existing_header(csv_path)
+            write_header = fieldnames is None
+            if fieldnames is None:
+                fieldnames = list(result.keys())
             with open(csv_path, "a", newline="", encoding="utf-8") as f:
                 writer = csv.DictWriter(
-                    f, fieldnames=result.keys(), extrasaction="ignore", restval=""
+                    f, fieldnames=fieldnames, extrasaction="ignore", restval=""
                 )
                 if write_header:
                     writer.writeheader()
                 writer.writerow(result)
+
+
+def _existing_header(csv_path: Path) -> list[str] | None:
+    """Return the column names already written to csv_path, or None if there are none.
+
+    A zero-byte file counts as "no header" — it exists, but committing to its
+    (absent) columns would make the first data row masquerade as the header.
+    Called under _write_lock so the check and the append cannot interleave.
+    """
+    if not csv_path.exists() or csv_path.stat().st_size == 0:
+        return None
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        header = next(csv.reader(f), None)
+    return header or None
 
 
 def patch_results(jsonl_path: Path, updated_rows: list[dict[str, Any]]) -> None:

--- a/src/hermia/results.py
+++ b/src/hermia/results.py
@@ -57,12 +57,19 @@ def _existing_header(csv_path: Path) -> list[str] | None:
     A zero-byte file counts as "no header" — it exists, but committing to its
     (absent) columns would make the first data row masquerade as the header.
     Called under _write_lock so the check and the append cannot interleave.
+
+    Leading blank lines are skipped rather than treated as the header. A file
+    holding only a newline (touch, or an interrupted write) is non-zero in size
+    but yields [] from csv.reader, which read as "no header" on EVERY call and
+    made append_result re-emit the header before every row.
     """
     if not csv_path.exists() or csv_path.stat().st_size == 0:
         return None
     with open(csv_path, newline="", encoding="utf-8") as f:
-        header = next(csv.reader(f), None)
-    return header or None
+        for row in csv.reader(f):
+            if row and any(field.strip() for field in row):
+                return row
+    return None
 
 
 def patch_results(jsonl_path: Path, updated_rows: list[dict[str, Any]]) -> None:

--- a/src/hermia/tui/fleet_io.py
+++ b/src/hermia/tui/fleet_io.py
@@ -12,6 +12,7 @@ Fleet YAML schema:
         engine: str
         auth_header_env: str (optional — env var NAME, never a secret value)
         hardware: str (optional)
+        stack: mapping (optional — gpu_arch / runtime_version, feeds backend_stack)
         models: list[str]  # only selected models
 
 Per AGENTS.md rule 11, credentials are never persisted in this file. Only the
@@ -66,8 +67,10 @@ def _headless_host(d: Any) -> Host:
     with it: headless writes {name, host, transport?, auth.bearer.key_env?,
     models?}, the TUI wants {name, url, engine, auth_header_env?, models[]}.
 
-    ``test_timeout`` and ``stack`` have no Host field and are dropped — a
-    headless config carrying them still loads rather than failing.
+    ``stack`` is preserved (it feeds backend_stack on result rows, hermia-0hqm);
+    a non-mapping ``stack`` is ignored rather than raising, so a malformed
+    headless config still loads. ``test_timeout`` has no Host field and is
+    dropped — a headless config carrying it still loads rather than failing.
     """
     if not isinstance(d, dict):
         raise TypeError("Fleet entry must be a dictionary")
@@ -87,8 +90,15 @@ def _headless_host(d: Any) -> Host:
         url=d["host"],
         engine=d.get("transport") or "ollama",
         auth_header_env=bearer.get("key_env") if isinstance(bearer, dict) else None,
+        stack=_stack_of(d),
         models=[ModelChoice(name=n, selected=True) for n in models],
     )
+
+
+def _stack_of(d: dict[str, Any]) -> dict[str, Any] | None:
+    """Read a host entry's ``stack:`` block, or None if absent/malformed."""
+    stack = d.get("stack")
+    return stack if isinstance(stack, dict) else None
 
 
 def load_fleet(path: Path) -> FleetConfig:
@@ -179,6 +189,8 @@ def _serialize_host(h: Host) -> dict[str, Any]:
         d["auth_header_env"] = h.auth_header_env
     if h.hardware:
         d["hardware"] = h.hardware
+    if h.stack:
+        d["stack"] = dict(h.stack)
     d["models"] = [m.name for m in h.models if m.selected]
     return d
 
@@ -198,6 +210,7 @@ def _deserialize_host(d: Any) -> Host:
         engine=d["engine"],
         auth_header_env=d.get("auth_header_env"),
         hardware=d.get("hardware"),
+        stack=_stack_of(d),
         # `models:` with no children parses as None; `or []` guards iteration.
         models=[ModelChoice(name=n, selected=True) for n in (d.get("models") or [])],
     )

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -54,7 +54,14 @@ def _trial_wall_timeout_sec(test: dict[str, Any], per_call_timeout: float) -> fl
 # tests/unit/tui/test_runner_backend_run_identity.py asserts this stays in step
 # with run_test; if that test reds, decide what error rows should carry rather
 # than letting the two shapes drift.
-SUCCESS_ROW_KEYS: frozenset[str] = frozenset({
+
+# Order matters and must match run_test's return dict. append_result pins the CSV
+# header from whichever row is written first, so if error rows enumerated their
+# keys in a different order than success rows, the column layout would depend on
+# whether the first trial happened to fail. Deriving the set from a tuple (rather
+# than iterating a frozenset, whose order varies with PYTHONHASHSEED across
+# processes) also keeps that layout stable run to run.
+SUCCESS_ROW_ORDER: tuple[str, ...] = (
     "model", "test_id", "dimension", "frameworks", "framework_versions",
     "failure_reason", "had_markdown_fence", "json_valid", "schema_compliant",
     "signals", "tokens", "elapsed_sec", "tokens_per_sec", "output_preview",
@@ -63,7 +70,9 @@ SUCCESS_ROW_KEYS: frozenset[str] = frozenset({
     "vram_server_gb", "model_size_server_gb", "execution_path", "orchestration",
     "orchestration_version", "turn_count", "raw_turns", "hermia_version",
     "git_sha", "corpus_sha256", "sampling", "stack_fingerprint", "_provenance",
-})
+)
+
+SUCCESS_ROW_KEYS: frozenset[str] = frozenset(SUCCESS_ROW_ORDER)
 
 
 def _error_result(
@@ -82,19 +91,25 @@ def _error_result(
     not observe 0 tokens/sec, it observed nothing, and a fabricated zero would
     be indistinguishable from a real measurement downstream. `mode` is left
     None for the same reason: it derives from transport.is_api_mode, which is
-    decided inside the worker thread that never returned. Provenance IS
-    stamped — the run happened, it just failed.
+    decided inside the worker thread that never returned.
+
+    Provenance that is knowable WITHOUT reaching the host is stamped —
+    hermia_version, git_sha, corpus_sha256, framework_versions — because the run
+    happened, it just failed. `stack_fingerprint` and `_provenance` stay None on
+    purpose: both come from probing the host, which is exactly what did not
+    happen here, and inventing them would assert a backend we never observed.
     """
     from hermia import __git_sha__, __version__
-    from hermia.runner import corpus_sha256
+    from hermia.runner import corpus_sha256, load_framework_versions
 
-    row: dict[str, Any] = dict.fromkeys(SUCCESS_ROW_KEYS)
+    row: dict[str, Any] = dict.fromkeys(SUCCESS_ROW_ORDER)
     row.update({
         "model": model,
         "test_id": test["id"],
         "host": host,
         "dimension": test.get("dimension", ""),
         "frameworks": test.get("frameworks", {}),
+        "framework_versions": load_framework_versions(),
         "failure_reason": failure_reason,
         "elapsed_sec": elapsed_sec,
         "output_preview": output_preview,

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -12,11 +12,13 @@ Pass results_dir=None to skip disk writes (useful in tests).
 from __future__ import annotations
 
 import asyncio
+import secrets
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from hermia.backend import resolve_stack
 from hermia.runner import TEST_TIMEOUT
 from hermia.transport.openai_compat import MAX_5XX_RETRIES, RETRY_BACKOFF_SEC
 from hermia.tui.bus import SessionBus
@@ -43,6 +45,71 @@ def _trial_wall_timeout_sec(test: dict[str, Any], per_call_timeout: float) -> fl
     """
     n_turns = len(test.get("turns") or (None,))
     return per_call_timeout * max(1, n_turns)
+
+
+# Exactly the keys hermia.runner.run_test returns. Error rows are built to this
+# same set so one results file cannot hold two row shapes — before hermia-0hqm
+# the failure branches emitted 7-key dicts with no `host`, and export.push
+# (_REQUIRED_FIELDS = {run_id, host, model, test_id}) silently dropped them.
+# tests/unit/tui/test_runner_backend_run_identity.py asserts this stays in step
+# with run_test; if that test reds, decide what error rows should carry rather
+# than letting the two shapes drift.
+SUCCESS_ROW_KEYS: frozenset[str] = frozenset({
+    "model", "test_id", "dimension", "frameworks", "framework_versions",
+    "failure_reason", "had_markdown_fence", "json_valid", "schema_compliant",
+    "signals", "tokens", "elapsed_sec", "tokens_per_sec", "output_preview",
+    "raw_system", "raw_prompt", "raw_response", "raw_thinking", "peak_cpu_pct",
+    "peak_ram_used_gb", "peak_gpu_pct", "peak_vram_used_gb", "mode", "host",
+    "vram_server_gb", "model_size_server_gb", "execution_path", "orchestration",
+    "orchestration_version", "turn_count", "raw_turns", "hermia_version",
+    "git_sha", "corpus_sha256", "sampling", "stack_fingerprint", "_provenance",
+})
+
+
+def _error_result(
+    *,
+    model: str,
+    test: dict[str, Any],
+    host: str,
+    failure_reason: str,
+    elapsed_sec: float,
+    raw_response: str,
+    output_preview: str,
+) -> dict[str, Any]:
+    """Build a failed-trial row with the same key set as a successful one.
+
+    Unmeasured fields stay None rather than 0/"" — a trial that timed out did
+    not observe 0 tokens/sec, it observed nothing, and a fabricated zero would
+    be indistinguishable from a real measurement downstream. `mode` is left
+    None for the same reason: it derives from transport.is_api_mode, which is
+    decided inside the worker thread that never returned. Provenance IS
+    stamped — the run happened, it just failed.
+    """
+    from hermia import __git_sha__, __version__
+    from hermia.runner import corpus_sha256
+
+    row: dict[str, Any] = dict.fromkeys(SUCCESS_ROW_KEYS)
+    row.update({
+        "model": model,
+        "test_id": test["id"],
+        "host": host,
+        "dimension": test.get("dimension", ""),
+        "frameworks": test.get("frameworks", {}),
+        "failure_reason": failure_reason,
+        "elapsed_sec": elapsed_sec,
+        "output_preview": output_preview,
+        "raw_system": test.get("system") or "",
+        "raw_prompt": test.get("prompt") or "",
+        "raw_response": raw_response,
+        "raw_thinking": "",
+        "json_valid": False,
+        "schema_compliant": False,
+        "signals": {},
+        "hermia_version": __version__,
+        "git_sha": __git_sha__,
+        "corpus_sha256": corpus_sha256(),
+    })
+    return row
 
 
 def verdict_from_result(result: dict[str, Any]) -> str:
@@ -90,6 +157,10 @@ class TuiRunner:
         self._abort_requested = False
         self._n_completed = 0
         self._task: asyncio.Task[None] | None = None
+        # One identity per run, set in _run() and stamped on every row. Both
+        # run.started sites used to mint their own and discard it, so nothing
+        # written to disk could be traced back to the run that produced it.
+        self._run_id: str = ""
 
     # ── Public API ─────────────────────────────────────────────────────────
 
@@ -120,11 +191,12 @@ class TuiRunner:
         await self._bus.publish(topic, event)
 
     async def _run(self) -> None:
+        self._run_id = _make_run_id()
         try:
             tests = self._load_tests()
         except Exception as exc:  # noqa: BLE001
             await self._emit("run.started", {
-                "run_id": _make_run_id(),
+                "run_id": self._run_id,
                 "n_hosts": len(self._config.hosts),
                 "n_trials_total": 0,
             })
@@ -136,7 +208,7 @@ class TuiRunner:
 
         n_trials = self._count_trials(tests)
         await self._emit("run.started", {
-            "run_id": _make_run_id(),
+            "run_id": self._run_id,
             "n_hosts": len(self._config.hosts),
             "n_trials_total": n_trials,
         })
@@ -221,28 +293,28 @@ class TuiRunner:
             )
         except TimeoutError:
             _timeout_msg = f"TIMEOUT: no response in {timeout:.0f}s"
-            result = {
-                "model": model.name,
-                "test_id": test["id"],
-                "failure_reason": _timeout_msg,
-                "elapsed_sec": timeout,
-                "output_preview": "",
-                "raw_response": _timeout_msg,
-                "signals": {},
-            }
+            result = _error_result(
+                model=model.name,
+                test=test,
+                host=host.url,
+                failure_reason=_timeout_msg,
+                elapsed_sec=timeout,
+                output_preview="",
+                raw_response=_timeout_msg,
+            )
         except Exception as exc:  # noqa: BLE001
-            result = {
-                "model": model.name,
-                "test_id": test["id"],
-                "failure_reason": f"ERROR: {exc}",
-                "elapsed_sec": 0.0,
+            result = _error_result(
+                model=model.name,
+                test=test,
+                host=host.url,
+                failure_reason=f"ERROR: {exc}",
+                elapsed_sec=0.0,
                 # output_preview stays truncated for the row; raw_response
                 # keeps the whole message so the detail screen can show a full
                 # traceback-bearing error instead of its first 120 characters.
-                "output_preview": str(exc)[:120],
-                "raw_response": f"ERROR: {exc}",
-                "signals": {},
-            }
+                output_preview=str(exc)[:120],
+                raw_response=f"ERROR: {exc}",
+            )
 
         self._n_completed += 1
 
@@ -265,15 +337,28 @@ class TuiRunner:
         })
 
         if self._results_dir is not None:
-            await asyncio.to_thread(self._write_result, result, host.name)
+            await asyncio.to_thread(self._write_result, result, host, repeat_idx)
 
-    def _write_result(self, result: dict[str, Any], fleet_host_name: str) -> None:
+    def _write_result(
+        self, result: dict[str, Any], host: Host, run_index: int
+    ) -> None:
         from hermia.results import append_result
         # Caller (_run_trial) guards with `if self._results_dir is not None`.
         results_dir: Path = self._results_dir  # type: ignore[assignment]
         results_dir.mkdir(parents=True, exist_ok=True)
         result = dict(result)
-        result["fleet_host_name"] = fleet_host_name
+        result["fleet_host_name"] = host.name
+        # Run identity, stamped on success and failure rows alike. Without it,
+        # rows appended to the shared results.jsonl cannot be attributed to the
+        # run that produced them (hermia-0hqm).
+        result["run_id"] = self._run_id
+        result["run_timestamp"] = datetime.now(UTC).isoformat()
+        result["run_index"] = run_index
+        # Only backend_stack: gpu_arch and runtime_version are schema-ahead
+        # placeholders on the CLI path too (hermia-425q) and stay out of scope.
+        result["backend_stack"] = resolve_stack(
+            {"stack": host.stack}, result.get("orchestration_version")
+        )["backend_stack"]
         jsonl_path = results_dir / "results.jsonl"
         csv_path = results_dir / "results.csv"
         append_result(result, jsonl_path, csv_path)
@@ -294,7 +379,15 @@ class TuiRunner:
 
 
 def _make_run_id() -> str:
-    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    """Sortable UTC stamp plus a random suffix.
+
+    The bare second-resolution stamp collided: two runs started in the same
+    second produced rows sharing (run_id, host, model, test_id, run_index) —
+    the Postgres dedup key — so `ON CONFLICT DO NOTHING` silently discarded the
+    second run. The suffix makes the identity unique; the prefix keeps run ids
+    chronologically sortable.
+    """
+    return f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{secrets.token_hex(3)}"
 
 
 def _real_run_test(

--- a/src/hermia/tui/state.py
+++ b/src/hermia/tui/state.py
@@ -10,7 +10,7 @@ MCP-sourced data).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass
@@ -30,6 +30,10 @@ class Host:
     engine: str
     auth_header_env: str | None = None
     hardware: str | None = None
+    # Fleet YAML `stack:` block (gpu_arch / runtime_version). Carried so a TUI
+    # run can resolve backend_stack the way the CLI does; previously dropped on
+    # load, leaving TUI rows with no backend provenance (hermia-0hqm).
+    stack: dict[str, Any] | None = None
     models: list[ModelChoice] = field(default_factory=list)
 
 

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -263,3 +263,17 @@ def test_append_result_to_empty_existing_csv_file_writes_header(tmp_path: Path) 
 
     assert fieldnames == ["a", "b"]
     assert rows == [{"a": "1", "b": "2"}]
+
+
+def test_blank_first_line_does_not_re_emit_the_header_every_row(tmp_path: Path) -> None:
+    """A whitespace-only csv (touch, interrupted write) read as 'no header' forever."""
+    csv_path = tmp_path / "results.csv"
+    csv_path.write_text("\n", encoding="utf-8")
+
+    append_result({"a": 1, "b": 2}, None, csv_path)
+    append_result({"a": 3, "b": 4}, None, csv_path)
+
+    assert csv_path.read_text(encoding="utf-8").count("a,b") == 1
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        rows = [r for r in csv.DictReader(line for line in f if line.strip())]
+    assert [r["a"] for r in rows] == ["1", "3"]

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -173,3 +173,93 @@ def test_append_result_is_thread_safe(tmp_path: Path) -> None:
     assert len(rows) == n_threads * per_thread
     for line in jsonl.read_text().splitlines():
         json.loads(line)
+
+
+# ── CSV column shear (hermia-0hqm) ────────────────────────────────────────────
+#
+# append_result pinned the header from the FIRST row but rebuilt DictWriter's
+# fieldnames from the CURRENT row, so a later row with a different key set wrote
+# its values under the wrong column names — silently, with no exception. These
+# tests assert on the CSV itself; a JSONL-only test ships green over the bug.
+
+
+def test_csv_columns_stay_aligned_when_later_row_has_different_keys(tmp_path: Path) -> None:
+    csv_path = tmp_path / "results.csv"
+    append_result({"a": 1, "b": 2, "c": 3}, None, csv_path)
+    # Different order AND a key the header does not have.
+    append_result({"c": 30, "a": 10, "z": 99}, None, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 2
+    assert rows[0] == {"a": "1", "b": "2", "c": "3"}
+    # Pre-fix these read a="30", b="10", c="99" — every value under the wrong name.
+    assert rows[1]["a"] == "10"
+    assert rows[1]["c"] == "30"
+    assert rows[1]["b"] == ""
+
+
+def test_csv_header_is_written_once_and_never_repeated(tmp_path: Path) -> None:
+    csv_path = tmp_path / "results.csv"
+    append_result({"a": 1, "b": 2}, None, csv_path)
+    append_result({"a": 3, "b": 4}, None, csv_path)
+
+    lines = csv_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 3  # header + 2 data rows
+    assert lines[0] == "a,b"
+
+
+def test_csv_extra_keys_in_later_row_are_dropped_not_sheared(tmp_path: Path) -> None:
+    csv_path = tmp_path / "results.csv"
+    append_result({"a": 1, "b": 2}, None, csv_path)
+    append_result({"a": 10, "b": 20, "z": 99}, None, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert reader.fieldnames == ["a", "b"]
+        rows = list(reader)
+
+    assert "z" not in rows[1]
+    assert rows[1]["a"] == "10"
+    assert rows[1]["b"] == "20"
+
+
+def test_csv_row_with_fewer_keys_fills_blanks(tmp_path: Path) -> None:
+    csv_path = tmp_path / "results.csv"
+    append_result({"a": 1, "b": 2, "c": 3}, None, csv_path)
+    append_result({"a": 10, "c": 30}, None, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows[1]["b"] == ""
+    assert rows[1]["c"] == "30"
+
+
+def test_jsonl_still_records_every_key_even_when_csv_drops_it(tmp_path: Path) -> None:
+    import json
+
+    jsonl_path = tmp_path / "results.jsonl"
+    csv_path = tmp_path / "results.csv"
+    append_result({"a": 1, "b": 2}, jsonl_path, csv_path)
+    append_result({"a": 10, "z": 99}, jsonl_path, csv_path)
+
+    rows = [json.loads(line) for line in jsonl_path.read_text().splitlines()]
+    # Dropping is a CSV-shape concern only — the JSONL stays lossless.
+    assert rows[1]["z"] == 99
+
+
+def test_append_result_to_empty_existing_csv_file_writes_header(tmp_path: Path) -> None:
+    csv_path = tmp_path / "results.csv"
+    csv_path.write_text("", encoding="utf-8")  # exists but has no header
+
+    append_result({"a": 1, "b": 2}, None, csv_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames
+        rows = list(reader)
+
+    assert fieldnames == ["a", "b"]
+    assert rows == [{"a": "1", "b": "2"}]

--- a/tests/unit/tui/test_fleet_io_stack_roundtrip.py
+++ b/tests/unit/tui/test_fleet_io_stack_roundtrip.py
@@ -1,0 +1,96 @@
+"""Fleet YAML `stack:` block survives into Host (hermia-0hqm).
+
+fleet_io previously dropped `stack:` on load ("no Host field"), so a TUI run
+could not resolve backend_stack — the field the corpus uses for version-confound
+analysis. These tests cover both layouts fleet_io accepts: the headless runner's
+`fleet:` key and the TUI's own `hosts:` key.
+"""
+from pathlib import Path
+
+import yaml
+
+from hermia.tui.fleet_io import load_fleet, save_fleet
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+STACK = {"gpu_arch": "sm_89", "runtime_version": "cuda-12.4"}
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / "fleet.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+class TestHeadlessFormat:
+    def test_load_preserves_stack_block(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, {
+            "fleet": [{
+                "name": "h1",
+                "host": "http://x:11434",
+                "stack": dict(STACK),
+            }],
+        })
+        config = load_fleet(path)
+        assert config.hosts[0].stack == STACK
+
+    def test_host_without_stack_loads_as_none(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, {
+            "fleet": [{"name": "h1", "host": "http://x:11434"}],
+        })
+        assert load_fleet(path).hosts[0].stack is None
+
+    def test_non_dict_stack_is_ignored_rather_than_crashing(self, tmp_path: Path) -> None:
+        """A malformed config still loads — same stance as the rest of fleet_io."""
+        path = _write(tmp_path, {
+            "fleet": [{"name": "h1", "host": "http://x:11434", "stack": "sm_89"}],
+        })
+        assert load_fleet(path).hosts[0].stack is None
+
+
+class TestTuiFormat:
+    def test_load_preserves_stack_block(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, {
+            "name": "f1",
+            "hosts": [{
+                "name": "h1",
+                "url": "http://x:11434",
+                "engine": "ollama",
+                "stack": dict(STACK),
+            }],
+        })
+        assert load_fleet(path).hosts[0].stack == STACK
+
+    def test_host_without_stack_loads_as_none(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, {
+            "name": "f1",
+            "hosts": [{"name": "h1", "url": "http://x:11434", "engine": "ollama"}],
+        })
+        assert load_fleet(path).hosts[0].stack is None
+
+
+class TestRoundTrip:
+    def test_stack_survives_save_then_load(self, tmp_path: Path) -> None:
+        config = FleetConfig(
+            name="f1",
+            tests=["t1"],
+            hosts=[Host(
+                name="h1",
+                url="http://x:11434",
+                engine="ollama",
+                stack=dict(STACK),
+                models=[ModelChoice(name="m1", selected=True)],
+            )],
+        )
+        path = save_fleet(config, root=tmp_path)
+        assert load_fleet(path).hosts[0].stack == STACK
+
+    def test_stack_key_is_omitted_when_absent(self, tmp_path: Path) -> None:
+        """Do not emit `stack: null` — keep saved YAML clean, as with hardware."""
+        config = FleetConfig(
+            name="f1",
+            tests=["t1"],
+            hosts=[Host(name="h1", url="http://x:11434", engine="ollama")],
+        )
+        path = save_fleet(config, root=tmp_path)
+        saved = yaml.safe_load(path.read_text())
+        assert "stack" not in saved["hosts"][0]

--- a/tests/unit/tui/test_runner_backend_run_identity.py
+++ b/tests/unit/tui/test_runner_backend_run_identity.py
@@ -23,6 +23,7 @@ from hermia.export import _REQUIRED_FIELDS
 from hermia.tui.bus import SessionBus
 from hermia.tui.runner_backend import (
     SUCCESS_ROW_KEYS,
+    SUCCESS_ROW_ORDER,
     TuiRunner,
     _error_result,
     _make_run_id,
@@ -383,3 +384,62 @@ class TestOutOfScopeAggregatesStayAbsent:
         _run_to_completion(runner)
 
         assert field not in _rows(tmp_path)[0]
+
+
+class TestColumnOrderIsDeterministic:
+    """append_result pins the header from whichever row lands first.
+
+    If error rows enumerated their keys in a different order than success rows,
+    the CSV column layout would depend on whether the first trial failed — and
+    iterating a frozenset varies with PYTHONHASHSEED across processes.
+    """
+
+    def test_error_row_key_order_matches_the_declared_order(self) -> None:
+        row = _error_result(
+            model="m1", test={"id": "t1"}, host=HOST_URL,
+            failure_reason="ERROR: boom", elapsed_sec=0.0,
+            raw_response="ERROR: boom", output_preview="boom",
+        )
+        assert list(row) == list(SUCCESS_ROW_ORDER)
+
+    def test_declared_order_matches_the_key_set(self) -> None:
+        assert frozenset(SUCCESS_ROW_ORDER) == SUCCESS_ROW_KEYS
+        assert len(SUCCESS_ROW_ORDER) == len(SUCCESS_ROW_KEYS)  # no duplicates
+
+    def test_order_is_stable_across_processes(self) -> None:
+        """Different PYTHONHASHSEED must not reorder the columns."""
+        import subprocess
+        import sys
+        code = (
+            "from hermia.tui.runner_backend import _error_result;"
+            "r=_error_result(model='m',test={'id':'t'},host='h',failure_reason='x',"
+            "elapsed_sec=0.0,raw_response='x',output_preview='x');"
+            "print(','.join(r))"
+        )
+        seen = {
+            subprocess.run(  # noqa: S603
+                [sys.executable, "-c", code], capture_output=True, text=True,
+                env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"}, check=True,
+            ).stdout.strip()
+            for seed in ("0", "1", "12345")
+        }
+        assert len(seen) == 1
+
+    def test_err_row_carries_framework_versions(self) -> None:
+        """Static corpus metadata is knowable even when the trial never ran."""
+        row = _error_result(
+            model="m1", test={"id": "t1"}, host=HOST_URL,
+            failure_reason="TIMEOUT", elapsed_sec=1.0,
+            raw_response="TIMEOUT", output_preview="",
+        )
+        assert row["framework_versions"]
+
+    def test_host_probe_fields_stay_none_on_error(self) -> None:
+        """We never reached the host, so asserting a backend would be invention."""
+        row = _error_result(
+            model="m1", test={"id": "t1"}, host=HOST_URL,
+            failure_reason="TIMEOUT", elapsed_sec=1.0,
+            raw_response="TIMEOUT", output_preview="",
+        )
+        assert row["stack_fingerprint"] is None
+        assert row["_provenance"] is None

--- a/tests/unit/tui/test_runner_backend_run_identity.py
+++ b/tests/unit/tui/test_runner_backend_run_identity.py
@@ -1,0 +1,385 @@
+"""Run identity on TUI-written result rows (hermia-0hqm).
+
+Before this, TUI rows carried no run_id / run_timestamp / run_index, so rows
+appended to the shared results.jsonl could not be attributed to the run that
+produced them. Error and timeout rows were built as 7-key dicts with no `host`,
+so one file held two row shapes and export.push silently dropped the error rows
+(_REQUIRED_FIELDS = {run_id, host, model, test_id}).
+
+Deliberately NOT covered: the determinism aggregates (consistency_pct,
+reproducibility, pass_count, robustness_n). They are degenerate at repeat=1 —
+the only value reachable from the TUI — and are out of scope by decision.
+"""
+import asyncio
+import csv
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from hermia.export import _REQUIRED_FIELDS
+from hermia.tui.bus import SessionBus
+from hermia.tui.runner_backend import (
+    SUCCESS_ROW_KEYS,
+    TuiRunner,
+    _error_result,
+    _make_run_id,
+)
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+# The key set hermia.runner.run_test returns. Duplicated here on purpose: this
+# literal is the anti-drift tripwire. If run_test's contract changes, the parity
+# test below fails and someone has to decide what the TUI's error rows should
+# carry, instead of the two shapes drifting apart unnoticed.
+RUN_TEST_KEYS = frozenset({
+    "model", "test_id", "dimension", "frameworks", "framework_versions",
+    "failure_reason", "had_markdown_fence", "json_valid", "schema_compliant",
+    "signals", "tokens", "elapsed_sec", "tokens_per_sec", "output_preview",
+    "raw_system", "raw_prompt", "raw_response", "raw_thinking", "peak_cpu_pct",
+    "peak_ram_used_gb", "peak_gpu_pct", "peak_vram_used_gb", "mode", "host",
+    "vram_server_gb", "model_size_server_gb", "execution_path", "orchestration",
+    "orchestration_version", "turn_count", "raw_turns", "hermia_version",
+    "git_sha", "corpus_sha256", "sampling", "stack_fingerprint", "_provenance",
+})
+
+HOST_URL = "http://host0:11434"
+
+
+def _make_config(
+    *,
+    repeat: int = 1,
+    stack: dict | None = None,
+    n_models: int = 1,
+) -> FleetConfig:
+    host = Host(
+        name="host-0",
+        url=HOST_URL,
+        engine="ollama",
+        stack=stack,
+        models=[ModelChoice(name=f"m{j}", selected=True) for j in range(n_models)],
+    )
+    return FleetConfig(name="test", hosts=[host], tests=["t1"], repeat=repeat)
+
+
+def _success_row(model_name: str, test: dict, host: str) -> dict:
+    """A run_test-shaped success row — every key run_test really returns."""
+    row = dict.fromkeys(RUN_TEST_KEYS)
+    row.update({
+        "model": model_name,
+        "test_id": test["id"],
+        "host": host,
+        "failure_reason": "",
+        "elapsed_sec": 0.01,
+        "tokens_per_sec": 50.0,
+        "output_preview": "ok",
+        "raw_response": "ok",
+        "signals": {},
+        "schema_compliant": True,
+        "orchestration_version": None,
+    })
+    return row
+
+
+def _fake_run_test_fn(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+    return _success_row(model_name, test, host)
+
+
+def _raising_run_test_fn(exc: BaseException):
+    def _fn(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+        raise exc
+    return _fn
+
+
+def _run_to_completion(runner: TuiRunner) -> None:
+    """Await start() *and* the background task it spawns.
+
+    start() returns as soon as the task is created — awaiting only start()
+    asserts against an empty results file.
+    """
+    async def _go() -> None:
+        await runner.start()
+        assert runner._task is not None
+        await asyncio.wait_for(runner._task, timeout=10.0)
+
+    asyncio.run(_go())
+
+
+def _rows(results_dir: Path) -> list[dict]:
+    path = results_dir / "results.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class TestMakeRunId:
+    def test_is_unique_across_many_calls_in_the_same_second(self) -> None:
+        # No clock freezing needed: 200 calls complete well inside one second,
+        # and the assertion is exactly "same second must still be unique".
+        ids = {_make_run_id() for _ in range(200)}
+        assert len(ids) == 200
+
+    def test_has_sortable_utc_timestamp_prefix(self) -> None:
+        assert re.fullmatch(r"\d{8}T\d{6}Z-[0-9a-f]{6}", _make_run_id())
+
+    def test_prefix_sorts_chronologically(self) -> None:
+        first, second = _make_run_id(), _make_run_id()
+        assert first.split("-")[0] <= second.split("-")[0]
+
+
+class TestRunIdentityOnRows:
+    def test_every_written_row_carries_run_identity(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(repeat=2),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        rows = _rows(tmp_path)
+        assert len(rows) == 2
+        for row in rows:
+            assert row["run_id"]
+            assert row["run_timestamp"]
+            assert isinstance(row["run_index"], int)
+        assert {r["run_index"] for r in rows} == {1, 2}
+
+    def test_all_rows_in_one_run_share_one_run_id(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(repeat=3, n_models=2),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        rows = _rows(tmp_path)
+        assert len(rows) == 6
+        assert len({r["run_id"] for r in rows}) == 1
+
+    def test_row_run_id_matches_the_run_started_event(self, tmp_path: Path) -> None:
+        """The event's id was generated inline and thrown away; rows had none."""
+        async def _go() -> None:
+            bus = SessionBus()
+            started: list[dict] = []
+
+            async def listen() -> None:
+                async for ev in bus.subscribe("run.started"):
+                    started.append(ev)
+                    return
+
+            task = asyncio.create_task(listen())
+            await asyncio.sleep(0)  # let the subscriber register before publish
+
+            runner = TuiRunner(
+                config=_make_config(),
+                bus=bus,
+                results_dir=tmp_path,
+                run_test_fn=_fake_run_test_fn,
+                _tests_override=[{"id": "t1"}],
+            )
+            await runner.start()
+            assert runner._task is not None
+            await asyncio.wait_for(runner._task, timeout=10.0)
+            await asyncio.wait_for(task, timeout=3.0)
+
+            assert started[0]["run_id"] == _rows(tmp_path)[0]["run_id"]
+
+        asyncio.run(_go())
+
+    def test_run_timestamp_is_iso8601_with_timezone(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        parsed = datetime.fromisoformat(_rows(tmp_path)[0]["run_timestamp"])
+        assert parsed.tzinfo is not None
+
+    def test_run_index_matches_repeat_index_order(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(repeat=3),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        assert [r["run_index"] for r in _rows(tmp_path)] == [1, 2, 3]
+
+
+class TestErrorRowShape:
+    def test_error_row_key_set_equals_success_row_key_set(self) -> None:
+        row = _error_result(
+            model="m1",
+            test={"id": "t1"},
+            host=HOST_URL,
+            failure_reason="TIMEOUT: no response in 5s",
+            elapsed_sec=5.0,
+            raw_response="TIMEOUT: no response in 5s",
+            output_preview="",
+        )
+        assert set(row) == RUN_TEST_KEYS
+
+    def test_module_constant_tracks_the_real_run_test_contract(self) -> None:
+        """If run_test changes shape, fail here rather than drifting silently."""
+        assert SUCCESS_ROW_KEYS == RUN_TEST_KEYS
+
+    def test_timeout_row_has_host_and_survives_export_required_fields(
+        self, tmp_path: Path
+    ) -> None:
+        runner = TuiRunner(
+            config=_make_config(),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_raising_run_test_fn(TimeoutError()),
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        row = _rows(tmp_path)[0]
+        assert row["host"] == HOST_URL
+        # export.push drops any row missing one of these — the bug that made
+        # error rows vanish while their siblings claimed to summarise them.
+        assert all(row.get(f) for f in _REQUIRED_FIELDS)
+
+    def test_exception_row_has_host_and_error_reason(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_raising_run_test_fn(RuntimeError("boom")),
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        row = _rows(tmp_path)[0]
+        assert row["host"] == HOST_URL
+        assert row["failure_reason"].startswith("ERROR:")
+        assert "boom" in row["raw_response"]
+        assert all(row.get(f) for f in _REQUIRED_FIELDS)
+
+    def test_wall_timeout_row_has_host(self, tmp_path: Path) -> None:
+        """A real asyncio.wait_for timeout, not a raised TimeoutError."""
+        def _slow(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+            import time
+            time.sleep(1.0)
+            return _success_row(model_name, test, host)
+
+        runner = TuiRunner(
+            config=_make_config(),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_slow,
+            _tests_override=[{"id": "t1"}],
+            trial_timeout=0.05,
+        )
+        _run_to_completion(runner)
+
+        row = _rows(tmp_path)[0]
+        assert row["host"] == HOST_URL
+        assert row["failure_reason"].startswith("TIMEOUT:")
+
+    def test_error_then_success_write_aligned_csv_columns(self, tmp_path: Path) -> None:
+        """The shear case, end to end: an error row first, a success row second."""
+        calls: list[int] = []
+
+        def _fail_then_pass(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("boom")
+            return _success_row(model_name, test, host)
+
+        runner = TuiRunner(
+            config=_make_config(repeat=2),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fail_then_pass,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        with (tmp_path / "results.csv").open(newline="", encoding="utf-8") as f:
+            csv_rows = list(csv.DictReader(f))
+
+        assert len(csv_rows) == 2
+        # Pre-fix, row 2's values landed under row 1's column names.
+        for row in csv_rows:
+            assert row["model"] == "m0"
+            assert row["test_id"] == "t1"
+            assert row["host"] == HOST_URL
+        assert csv_rows[0]["failure_reason"].startswith("ERROR:")
+        assert csv_rows[1]["failure_reason"] == ""
+
+
+class TestBackendStack:
+    def test_backend_stack_stamped_from_host_stack_block(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(
+                stack={"gpu_arch": "sm_89", "runtime_version": "cuda-12.4"}
+            ),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        row = _rows(tmp_path)[0]
+        assert "sm_89" in row["backend_stack"]
+        assert "cuda-12.4" in row["backend_stack"]
+
+    def test_backend_stack_is_none_without_stack_metadata(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(stack=None),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        assert _rows(tmp_path)[0]["backend_stack"] is None
+
+    def test_error_row_carries_backend_stack(self, tmp_path: Path) -> None:
+        runner = TuiRunner(
+            config=_make_config(stack={"gpu_arch": "sm_89"}),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_raising_run_test_fn(RuntimeError("boom")),
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        assert _rows(tmp_path)[0]["backend_stack"] == "sm_89"
+
+
+class TestOutOfScopeAggregatesStayAbsent:
+    """Guard the decision, not just the code.
+
+    consistency_pct=1.0 on a repeat=1 run is a confident wrong number on the
+    most public surface. Absent is honest. If someone adds these later they
+    must also add a TUI repeat control and delete this test deliberately.
+    """
+
+    @pytest.mark.parametrize(
+        "field", ["consistency_pct", "reproducibility", "pass_count", "robustness_n"]
+    )
+    def test_determinism_aggregate_is_not_stamped(self, tmp_path: Path, field: str) -> None:
+        runner = TuiRunner(
+            config=_make_config(),
+            bus=SessionBus(),
+            results_dir=tmp_path,
+            run_test_fn=_fake_run_test_fn,
+            _tests_override=[{"id": "t1"}],
+        )
+        _run_to_completion(runner)
+
+        assert field not in _rows(tmp_path)[0]


### PR DESCRIPTION
Closes the narrow, adjudicated scope of `hermia-0hqm`.

## The problem

TUI-written result rows carried no run identity, so rows appended to the shared
`results.jsonl` could not be attributed to the run that produced them. Separately, the
timeout and error branches built 7-key dicts with no `host`, so one file held two row
shapes and `export.push` (`_REQUIRED_FIELDS = {run_id, host, model, test_id}`) silently
discarded every failure row while its sibling success row survived.

## What changed

- **Run identity on every row** — `run_id` / `run_timestamp` / `run_index`, on success and
  failure alike. `run_id` is minted once per run and reused; both `run.started` sites
  previously minted their own inline and threw it away.
- **`run_id` is collision-safe.** The bare second-resolution stamp let two runs in one
  second share the Postgres dedup key `(run_id, host, model, test_id, run_index)`, so
  `ON CONFLICT DO NOTHING` dropped the second run. A random suffix makes it unique; the
  timestamp prefix keeps it sortable.
- **One row shape.** Error rows are built by `_error_result()` against `SUCCESS_ROW_KEYS`,
  the key set `run_test` returns. Unmeasured fields stay `None` rather than a fabricated
  `0` — including `mode`, which derives from state inside the worker thread that never
  returned. Provenance is still stamped: the run happened, it just failed.
- **`backend_stack`** resolved from the fleet YAML `stack:` block, which `fleet_io` had
  been dropping on load. `Host` gains a `stack` field that round-trips through both the
  headless `fleet:` and TUI `hosts:` layouts.
- **CSV column shear fixed** (`results.py`). `append_result` wrote the header from the
  *first* row but built `DictWriter` from the *current* row's keys, so any row with a
  different key set landed under the wrong column names with no exception raised. A
  zero-byte file now counts as "no header" instead of promoting the first data row into one.

## Deliberately NOT included

The determinism aggregates (`consistency_pct`, `reproducibility`, `pass_count`,
`robustness_n`). At `repeat=1` — the only value reachable from the TUI, which has no repeat
control — they compute `consistency_pct=1.0` and would stamp *perfect determinism* on every
single-shot run. Absent is honest; `1.0` is not. A parametrized test pins that decision, so
re-adding them requires deleting the test on purpose.

## Known trade-off

A CSV row carrying keys absent from the header now has those values **dropped** rather than
sheared into neighbouring columns. The JSONL stays lossless. `append_result` is shared with
the CLI, whose key sets are uniform within a run, so no column loss is expected there.

## Verification

Not just unit tests. Ran the real `TuiRunner` write path against the live lab Mac
(`192.168.2.3`, ollama 0.32.5) plus a deliberately dead host:

- 4 rows / 2 hosts / repeat=2, one shared `run_id`, `run_index` 1 and 2
- `backend_stack` = `0.32.5 | apple-m3-pro | metal`, where `0.32.5` came from the host's
  real `/api/version`
- key-set count across success **and** error rows = **1**
- export filter: `rows=4 kept=4 dropped=0` (the bead's pre-fix probe was `2 / 1 / 1`)
- 4 distinct Postgres dedup keys
- CSV read back through `DictReader`: 42 columns, all values aligned across mixed row shapes

Suite **2008 passed / 6 failed**; the 6 are pre-existing macOS `detect_gpu` noise
(`hermia-2ess`), identical to the baseline on `dev`. ruff and mypy clean.

## Still open (not this PR)

Host-level failure rows are still never written to disk (`hermia-6q4d` / `hermia-qkhl`), and
the CLI's own `open_run()` keeps the 1-second-resolution collision hazard — only the TUI's
`run_id` was made safe. Post-DEF-CON single-writer extraction remains the right structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet configurations can now include backend stack metadata, preserved when loading and saving.
  * Run results now include a unique run ID, timestamp, run order, host name, and resolved backend stack.
  * Error and timeout results use the same consistent format as successful results.

* **Bug Fixes**
  * CSV exports now maintain a stable header, leave missing values blank, and ignore extra fields in later rows.
  * Existing empty CSV files now receive headers correctly.
  * Run provenance and measured fields are preserved consistently across result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->