### PR TITLE
fix(tui): write run-scoped results at the top level so tooling can find them (hermia-u1v7)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,14 @@ jobs:
           fetch-depth: 0
       - name: TruffleHog — entropy + credential scan
         uses: trufflesecurity/trufflehog@0fa069c12f0c7baf431041cd1e564a9c5058846c  # main 2026-05-16
+        with:
+          # Lob detector (hermia-v0h6): Lob issues test_<random> API keys, colliding
+          # with pytest's test_<description> naming convention. Confirmed 3x false
+          # positive (most recently hermia-u1v7 PR #162), 0 true positives ever —
+          # hermia has no mail/postcard/check feature and none is planned. A real,
+          # correctly-formatted Lob key deliberately planted for testing (hermia-scyz)
+          # was NOT caught by this detector, so excluding it loses no real coverage.
+          extra_args: --exclude-detectors=Lob
 
   trivy:
     runs-on: ubuntu-latest

--- a/docs/kwaai-quickstart.md
+++ b/docs/kwaai-quickstart.md
@@ -25,13 +25,24 @@ If `hermia` isn't found afterward, run `pipx ensurepath` and reopen your shell.
 pAI-OS runs its inference backend as Ollama on port `11434`, which is **Hermia's
 native default target** — no config file needed.
 
+Run Hermia with no arguments. It opens a terminal UI:
+
 ```bash
-# Point Hermia at your pAI-OS Ollama backend (this is the default host).
-hermia --host http://localhost:11434
+hermia
 ```
 
-Hermia auto-discovers the models installed on that Ollama instance and runs the
-corpus against each. Results land in `results/eval_*.{jsonl,csv}`.
+From the launch screen, choose **Quick local run**. That pre-fills the host as
+`http://localhost:11434` (Ollama) and selects the full test corpus, so the only
+thing left to choose is which models to evaluate:
+
+1. **Quick local run** on the launch screen.
+2. On the config screen, open the host's model list — Hermia probes
+   `GET /api/tags` and shows what pAI-OS actually has installed.
+3. Select one or more models, then start the run.
+4. Watch verdicts land per trial; drill into any row for the full response.
+
+Each run writes its own file: **`results/eval_<run_id>.jsonl`** (and `.csv`) —
+the same directory and naming the fleet path uses, so every Hermia tool finds it.
 
 ---
 
@@ -84,6 +95,10 @@ hermia-submit --dry-run     # inspect the anonymized payload — no network I/O
 hermia-submit               # submit (prompts for confirmation; --yes to skip)
 ```
 
+With no `--results`, `hermia-submit` uses the most recent results file — which
+is the run you just finished, on either path. Pass `--results <file>` to submit
+a specific one.
+
 `hermia-submit` anonymizes the payload (no usernames, no raw hostnames) before
 sending it to the live endpoint (`https://hermia.scottbly.com`). On success it
 prints a public URL where your submission renders.
@@ -95,6 +110,8 @@ prints a public URL where your submission renders.
 | Symptom | Fix |
 |---------|-----|
 | `hermia: command not found` | `pipx ensurepath`, reopen shell |
+| `unrecognized arguments: --host` | There is no `--host` flag. Run bare `hermia` and pick **Quick local run** (Path A). |
+| `--repeat/--verbose can only be used with --fleet` | Those flags are fleet-mode only; set repeats inside the TUI or use `--fleet` |
 | openai-compat host "requires an explicit 'models:' list" | add `models: auto` (or an explicit list) to the entry |
 | `/v1/models` returns nothing | confirm `kwaainet shard api` is up on `:11435` and a model is loaded |
 | Discovery failed, host skipped | the endpoint was unreachable or returned a malformed `/v1/models` — re-check step 2 |

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -374,8 +374,12 @@ class TuiRunner:
         result["backend_stack"] = resolve_stack(
             {"stack": host.stack}, result.get("orchestration_version")
         )["backend_stack"]
-        jsonl_path = results_dir / "results.jsonl"
-        csv_path = results_dir / "results.csv"
+        # Run-scoped, and named the way the CLI names its files, so hermia-push,
+        # hermia-submit and hermia --audit all find TUI runs — every one of them
+        # scans the top level of results/ for eval_*.jsonl (hermia-u1v7). The
+        # old shared results.jsonl also accumulated across runs indefinitely.
+        jsonl_path = results_dir / f"eval_{self._run_id}.jsonl"
+        csv_path = results_dir / f"eval_{self._run_id}.csv"
         append_result(result, jsonl_path, csv_path)
 
     def _count_trials(self, tests: list[dict[str, Any]]) -> int:

--- a/src/hermia/tui/screens/config.py
+++ b/src/hermia/tui/screens/config.py
@@ -6,6 +6,8 @@ child drills; Task 9 wires save / unsaved-changes indicator.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
@@ -14,6 +16,30 @@ from textual.widgets import Footer, Static
 
 from hermia.tui.state import FleetConfig
 from hermia.tui.widgets.breadcrumb import Breadcrumb
+
+RESULTS_DIR = Path("results")
+
+
+def results_dir_for(config: FleetConfig) -> Path:
+    """Where a TUI run writes its rows.
+
+    Always the top-level `results/`, the same directory the CLI writes to.
+    Runs are separated by filename (`eval_<run_id>.jsonl`), not by directory
+    (hermia-u1v7). Two defects lived in the per-fleet subdirectory this
+    replaces:
+
+    * nothing could find the rows — hermia-push, hermia-submit and
+      hermia --audit all scan the top level of `results/`, so a TUI run was
+      invisible to every one of them; and
+    * an unnamed fleet produced no results directory at all, so the run
+      executed normally and every row was discarded without a word.
+
+    `config` is accepted and deliberately ignored — the destination no longer
+    depends on it. That is the point: the fleet name never reaches the
+    filesystem, so a hostile name out of YAML cannot steer where results are
+    written and no longer needs sanitising against `../` traversal.
+    """
+    return RESULTS_DIR
 
 
 class FleetConfigScreen(Screen[None]):
@@ -160,22 +186,12 @@ class FleetConfigScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_run(self) -> None:
-        from pathlib import Path
-
         from hermia.tui.runner_backend import TuiRunner
         from hermia.tui.screens.runner import RunnerScreen
-        results_dir: Path | None = None
-        if self.app_config.name:
-            # Strip any directory components from the fleet name before using
-            # it as a path segment (guards against '../' traversal in YAML).
-            safe_name = Path(self.app_config.name).name or "unnamed"
-            results_dir = Path("results") / safe_name
-            # mkdir is deferred to _write_result so no empty dir is created
-            # if the run is aborted before writing any results.
         runner = TuiRunner(
             config=self.app_config,
             bus=self.app.bus,  # type: ignore[attr-defined]
-            results_dir=results_dir,
+            results_dir=results_dir_for(self.app_config),
             run_state=self.app.run_state,  # type: ignore[attr-defined]
         )
         self.app.push_screen(RunnerScreen(runner=runner))

--- a/tests/unit/tui/screens/test_config_results_dir.py
+++ b/tests/unit/tui/screens/test_config_results_dir.py
@@ -1,0 +1,39 @@
+"""Where the TUI sends its results (hermia-u1v7).
+
+Two defects lived in one branch in FleetConfigScreen.action_run:
+
+  * results went to a per-fleet subdirectory, which no consumer scans; and
+  * an UNNAMED fleet got results_dir=None, so the run executed normally and
+    every row was discarded in silence.
+
+Both are decided by `results_dir_for`, which is a pure function so it can be
+asserted directly rather than by driving the screen.
+"""
+from pathlib import Path
+
+from hermia.tui.screens.config import results_dir_for
+from hermia.tui.state import FleetConfig
+
+
+class TestResultsDirFor:
+    def test_named_fleet_writes_to_the_top_level_results_dir(self) -> None:
+        assert results_dir_for(FleetConfig(name="quick-local")) == Path("results")
+
+    def test_unnamed_fleet_still_gets_a_results_dir(self) -> None:
+        """Previously None — the run happened and every row was silently dropped."""
+        assert results_dir_for(FleetConfig(name="")) == Path("results")
+
+    def test_no_per_fleet_subdirectory(self) -> None:
+        """A subdir is invisible to hermia-push / hermia-submit / hermia --audit."""
+        got = results_dir_for(FleetConfig(name="my-fleet"))
+        assert got == Path("results")
+        assert "my-fleet" not in got.parts
+
+    def test_traversal_in_a_fleet_name_cannot_escape_results(self) -> None:
+        """The old code sanitised the name because it became a path segment.
+
+        The name is no longer used in the path at all, so a hostile name from
+        YAML cannot influence where results are written. Pin that.
+        """
+        for hostile in ("../../etc", "/absolute/evil", "..", "a/b/c"):
+            assert results_dir_for(FleetConfig(name=hostile)) == Path("results")

--- a/tests/unit/tui/test_runner_backend_run_identity.py
+++ b/tests/unit/tui/test_runner_backend_run_identity.py
@@ -1,7 +1,7 @@
 """Run identity on TUI-written result rows (hermia-0hqm).
 
 Before this, TUI rows carried no run_id / run_timestamp / run_index, so rows
-appended to the shared results.jsonl could not be attributed to the run that
+appended to a shared results file could not be attributed to the run that
 produced them. Error and timeout rows were built as 7-key dicts with no `host`,
 so one file held two row shapes and export.push silently dropped the error rows
 (_REQUIRED_FIELDS = {run_id, host, model, test_id}).
@@ -108,8 +108,10 @@ def _run_to_completion(runner: TuiRunner) -> None:
 
 
 def _rows(results_dir: Path) -> list[dict]:
-    path = results_dir / "results.jsonl"
-    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    # Run-scoped filename since hermia-u1v7; exactly one per run here.
+    paths = list(results_dir.glob("eval_*.jsonl"))
+    assert len(paths) == 1, f"expected one run file, got {[p.name for p in paths]}"
+    return [json.loads(line) for line in paths[0].read_text().splitlines() if line.strip()]
 
 
 class TestMakeRunId:
@@ -307,7 +309,9 @@ class TestErrorRowShape:
         )
         _run_to_completion(runner)
 
-        with (tmp_path / "results.csv").open(newline="", encoding="utf-8") as f:
+        csv_paths = list(tmp_path.glob("eval_*.csv"))
+        assert len(csv_paths) == 1
+        with csv_paths[0].open(newline="", encoding="utf-8") as f:
             csv_rows = list(csv.DictReader(f))
 
         assert len(csv_rows) == 2

--- a/tests/unit/tui/test_runner_backend_run_scoped_files.py
+++ b/tests/unit/tui/test_runner_backend_run_scoped_files.py
@@ -1,0 +1,150 @@
+"""TUI results are written run-scoped and top-level, so tooling can find them
+(hermia-u1v7).
+
+The TUI wrote `results/<fleet-name>/results.jsonl`. Every consumer scans the TOP
+LEVEL of `results/`:
+
+    export.py    glob("eval_*.jsonl")   -> hermia-push  ("No results found", visible)
+    submit.py    glob("*.jsonl")        -> hermia-submit (SILENTLY submits an older file)
+    audit.py     glob("eval_*.jsonl")   -> hermia --audit
+
+So none of them ever saw a TUI run. The submit case is the dangerous one: it does
+not fail, it publishes the wrong file and returns a success URL.
+"""
+import asyncio
+import csv
+import json
+from pathlib import Path
+
+from hermia.export import collect_results
+from hermia.tui.bus import SessionBus
+from hermia.tui.runner_backend import SUCCESS_ROW_ORDER, TuiRunner
+from hermia.tui.state import FleetConfig, Host, ModelChoice
+
+HOST_URL = "http://host0:11434"
+
+
+def _config(name: str = "test-fleet", repeat: int = 1) -> FleetConfig:
+    host = Host(
+        name="host-0",
+        url=HOST_URL,
+        engine="ollama",
+        models=[ModelChoice(name="m0", selected=True)],
+    )
+    return FleetConfig(name=name, hosts=[host], tests=["t1"], repeat=repeat)
+
+
+def _ok_run_test(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+    row = dict.fromkeys(SUCCESS_ROW_ORDER)
+    row.update({
+        "model": model_name, "test_id": test["id"], "host": host,
+        "failure_reason": "", "elapsed_sec": 0.01, "output_preview": "ok",
+        "raw_response": "ok", "signals": {}, "schema_compliant": True,
+        "orchestration_version": None,
+    })
+    return row
+
+
+def _boom_run_test(model_name, test, *, host, engine, auth_env):  # noqa: ANN001
+    raise RuntimeError("boom")
+
+
+def _run(results_dir: Path, *, repeat: int = 1, fn=_ok_run_test) -> TuiRunner:
+    runner = TuiRunner(
+        config=_config(repeat=repeat),
+        bus=SessionBus(),
+        results_dir=results_dir,
+        run_test_fn=fn,
+        _tests_override=[{"id": "t1"}],
+    )
+
+    async def _go() -> None:
+        await runner.start()
+        assert runner._task is not None
+        await asyncio.wait_for(runner._task, timeout=10.0)
+
+    asyncio.run(_go())
+    return runner
+
+
+def _rows(path: Path) -> list[dict]:
+    return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+class TestRunScopedFilenames:
+    def test_jsonl_is_named_for_the_run_id(self, tmp_path: Path) -> None:
+        runner = _run(tmp_path)
+        files = list(tmp_path.glob("eval_*.jsonl"))
+        assert len(files) == 1
+        assert files[0].name == f"eval_{runner._run_id}.jsonl"
+        # the row's own run_id must match the filename it landed in
+        assert _rows(files[0])[0]["run_id"] == runner._run_id
+
+    def test_legacy_results_jsonl_is_no_longer_written(self, tmp_path: Path) -> None:
+        _run(tmp_path)
+        assert not (tmp_path / "results.jsonl").exists()
+        assert not (tmp_path / "results.csv").exists()
+
+    def test_csv_is_named_for_the_run_id_and_readable(self, tmp_path: Path) -> None:
+        runner = _run(tmp_path)
+        files = list(tmp_path.glob("eval_*.csv"))
+        assert len(files) == 1
+        assert files[0].name == f"eval_{runner._run_id}.csv"
+        with files[0].open(newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 1
+        assert rows[0]["model"] == "m0"
+        assert rows[0]["test_id"] == "t1"
+        assert rows[0]["run_id"] == runner._run_id
+
+    def test_two_runs_write_two_separate_files(self, tmp_path: Path) -> None:
+        """The point of the change — runs no longer accumulate into one file."""
+        a = _run(tmp_path)
+        b = _run(tmp_path)
+        files = sorted(p.name for p in tmp_path.glob("eval_*.jsonl"))
+        assert len(files) == 2
+        assert a._run_id != b._run_id
+        assert files == sorted([f"eval_{a._run_id}.jsonl", f"eval_{b._run_id}.jsonl"])
+
+    def test_repeats_of_one_run_stay_in_one_file(self, tmp_path: Path) -> None:
+        """Run-scoped, not trial-scoped: all repeats of a run share its file."""
+        _run(tmp_path, repeat=3)
+        files = list(tmp_path.glob("eval_*.jsonl"))
+        assert len(files) == 1
+        rows = _rows(files[0])
+        assert len(rows) == 3
+        assert {r["run_index"] for r in rows} == {1, 2, 3}
+        assert len({r["run_id"] for r in rows}) == 1
+
+    def test_error_rows_land_in_the_same_run_scoped_file(self, tmp_path: Path) -> None:
+        runner = _run(tmp_path, fn=_boom_run_test)
+        files = list(tmp_path.glob("eval_*.jsonl"))
+        assert len(files) == 1
+        assert files[0].name == f"eval_{runner._run_id}.jsonl"
+        assert _rows(files[0])[0]["failure_reason"].startswith("ERROR:")
+
+
+class TestDiscoverableByTooling:
+    """Each assertion here is one of the three consumers that could not see TUI runs."""
+
+    def test_hermia_push_finds_the_rows(self, tmp_path: Path) -> None:
+        _run(tmp_path)
+        # export.collect_results is exactly what hermia-push calls.
+        assert len(collect_results(tmp_path)) == 1
+
+    def test_hermia_submit_glob_finds_the_file(self, tmp_path: Path) -> None:
+        # submit._find_latest_results does RESULTS_DIR.glob("*.jsonl") — top level only.
+        _run(tmp_path)
+        assert list(tmp_path.glob("*.jsonl"))
+
+    def test_hermia_audit_glob_finds_the_file(self, tmp_path: Path) -> None:
+        # audit.load_rows does source.glob("eval_*.jsonl").
+        _run(tmp_path)
+        assert list(tmp_path.glob("eval_*.jsonl"))
+
+    def test_submit_picks_the_newest_run_not_an_older_one(self, tmp_path: Path) -> None:
+        """The failure that published wrong data: newest-by-mtime must be this run."""
+        _run(tmp_path)
+        newest_first = _run(tmp_path)
+        latest = max(tmp_path.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+        assert latest.name == f"eval_{newest_first._run_id}.jsonl"


### PR DESCRIPTION
The TUI wrote `results/<fleet-name>/results.jsonl`. All three consumers scan the top level of `results/`, so none of them ever saw a TUI run:

| File | Glob | Consumer | Failure mode |
|---|---|---|---|
| export.py:130 | `eval_*.jsonl` | hermia-push | "No results found" — visible |
| submit.py:311 | `*.jsonl` | hermia-submit | **Silently submits an older file** |
| audit.py:109 | `eval_*.jsonl` | hermia --audit | no rows |

The submit case is the dangerous one. It does not fail — it falls back to the most recent top-level file, which is some earlier CLI fleet run, publishes THAT to the public endpoint, and returns a success URL. Fails green, and it publishes.

## Fix

The TUI now writes `results/eval_<run_id>.{jsonl,csv}` — the same directory and the same naming the CLI already uses. That fixes all three consumers with no change to any of them, which is also why this stays inside the TUI module boundary. Landing it needed the collision-safe `run_id` from #161: run-scoped filenames are only safe once two runs in the same second cannot share an id.

Second defect fixed in the same branch: an **unnamed fleet** previously produced `results_dir=None`, so the run executed normally and every row was discarded without a word. `results_dir_for()` now returns `results/` regardless of the name. The fleet name no longer reaches the filesystem at all, so it also no longer needs sanitising against `../` traversal out of YAML — a test pins that.

Also drops the per-run accumulation problem: the old shared `results.jsonl` grew across every run with no way to separate them (the quick-local file holds 300+ rows from an unknown number of runs since 2026-06-21).

## Docs

`kwaai-quickstart` Path A rewritten around the TUI. It still documented `hermia --host http://localhost:11434`, a flag deleted on 2026-06-21 in 85361b3, plus two other claims that stopped being true with it. Verified by extracting the real flag set from all five entry-point parsers and validating every documented invocation across 47 doc files — zero stale flags remain.

## Verification

Verified live, not just in tests: an unnamed fleet across two reachable hosts (local M1 + work M3 on VLAN 43), 4/4 real inferences with real responses, all in one run-scoped file; `collect_results()` returns 4 rows all surviving `_REQUIRED_FIELDS`; newest-`*.jsonl` resolves to that run; and `hermia --audit` renders a real spill table from TUI output for the first time.

Suite 2028 passed / 6 failed (pre-existing macOS `detect_gpu` noise, hermia-2ess, identical to baseline). ruff + mypy clean.

## Deliberately NOT migrated

Pre-existing `results/<fleet>/results.jsonl` files stay where they are and remain invisible to tooling (quick-local 2.1 MB, blackhat-mobile-lab 29 KB). They predate run-scoping, so merging them into the new layout would fabricate run boundaries. Left deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Evaluation results are saved as run-specific `eval_<run_id>` files, making separate runs easier to identify and compare.
  - Results are stored in the top-level `results` directory for consistent access across configurations.
  - Submission and audit tools can discover available runs and select the newest results automatically.

- **Documentation**
  - Updated the quickstart guide for the streamlined local-run workflow.
  - Documented explicit results-file selection and clarified unsupported options and fleet-mode requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->