### PR TITLE
feat(identity): machine identity bound to hardware, not the network (hermia-cfqv)

### DIFF
--- a/docs/superpowers/plans/2026-08-16-machine-identity-core.md
+++ b/docs/superpowers/plans/2026-08-16-machine-identity-core.md
@@ -1,5 +1,28 @@
 # Machine Identity Core (hermia-cfqv) Implementation Plan
 
+> **STATUS 2026-08-16 — PARTLY SUPERSEDED. Read this box before the plan.**
+>
+> Two independent outside-family adversarial reviews (Antigravity, and gpt-oss:120b
+> run locally) rejected the identity model this plan implements, and a proposed
+> weighted-threshold successor, for the same reason:
+>
+> > Any threshold loose enough to tolerate a hardware repair merges two identical
+> > laptops; any threshold tight enough to keep them apart is just an exact match
+> > on the strongest identifier.
+>
+> What shipped instead is an **identifier / capability split**:
+> * IDENTITY comes only from non-transferable identifiers (firmware UUID, hardware
+>   serial, minted on-host token), matched EXACTLY in a fixed preference order.
+> * CAPABILITIES (CPU, memory, GPU, MAC) are recorded and never hashed, so a RAM
+>   upgrade is a visible fact rather than a new machine.
+> * The salt is FLEET-scoped, not per-install — a per-install salt made the same
+>   host derive different ids from different workstations.
+>
+> Tasks 1-7 below remain accurate for structure, file layout, and the
+> never-guess rule. The `HardwareFacts` type and the "platform_uuid REQUIRED,
+> else null" rule are superseded by `MachineIdentifiers` / `MachineCapabilities`
+> and the preference order in `derive.py`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Derive a salted, locally-unique `machine_id` from identifiers bound to the *machine* (not to a detachable network adapter), so a row's identity stops depending on an operator-typed name or a DHCP reservation.

--- a/docs/superpowers/plans/2026-08-16-machine-identity-core.md
+++ b/docs/superpowers/plans/2026-08-16-machine-identity-core.md
@@ -1,0 +1,703 @@
+# Machine Identity Core (hermia-cfqv) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive a salted, locally-unique `machine_id` from identifiers bound to the *machine* (not to a detachable network adapter), so a row's identity stops depending on an operator-typed name or a DHCP reservation.
+
+**Architecture:** A new `src/hermia/identity/` package with four focused modules: a probe layer that measures hardware facts (local probe now, remote probes later behind a Protocol), a derivation layer that HMACs those facts under a per-install salt, a salt store, and a cross-check ledger that warns when a label and a machine stop agreeing. Nothing is wired into result rows in this PR — see Non-Goals.
+
+**Tech Stack:** Python 3.11+, stdlib only (`hmac`, `hashlib`, `secrets`, `json`, `subprocess`, `tomllib`, `platform`), pytest.
+
+---
+
+## Why this exists (read before changing the design)
+
+`hermia-fqod`: 870 rows were attributed to an Apple M1 Mac but ran on an AMD Vega/Vulkan Linux box. Nothing in the schema could catch it, because a row's machine identity is `fleet_host_name` — an operator-typed string in a fleet YAML, verified against nothing. Host identity has now lied in **four** independent ways in this corpus:
+
+1. One machine under several names (`host-f` ×3, `host-b` ×3).
+2. SSH tunnel ports repointed between machines over time.
+3. DHCP reservations bound to **detachable USB/Thunderbolt dongles** — move the dongle, and the IP follows the accessory, not the computer.
+4. A Thunderbolt **dock** MAC, which identifies the dock; whichever laptop is docked inherits the address.
+
+## Non-negotiable design constraints
+
+- **EXCLUDE MAC entirely.** A MAC-derived id migrates with a dongle or dock. Excluding it means a dongle swap produces *no* identity change — correct. (Including it would produce a spurious "new machine", which is a lesser failure than two machines sharing an identity, but still wrong.)
+- **`platform_uuid` is REQUIRED.** CPU brand + RAM bytes alone are *not* an identity: a fleet commonly contains **several laptops of the same model and memory size**. Identical models would collide. If the platform UUID cannot be measured, `machine_id` is `None` — never a partial hash.
+- **Never guess.** Every failure path yields `machine_id=None` plus a machine-readable `basis`. There is no default, no fallback identity, no "unknown-1".
+- **Salt and raw hardware ids never leave the machine.** Not in a row, not in an export, not in a log line.
+
+## Non-Goals for this PR (deliberate — do not "helpfully" add)
+
+- **Do NOT wire `machine_id` into result rows / `runner.py`.** For a fleet run, hermia runs on Scott's laptop while the model runs on a remote host. Stamping the *local* machine onto a *remote* row would manufacture exactly the misleading field this work exists to eliminate. Row wiring lands with the remote-transport decision (deferred by Scott 2026-08-16).
+- **Do NOT add remote probes.** Define the Protocol; implement `LocalProbe` only.
+- **Do NOT modify `src/hermia/submit.py`.** See the salt-storage note below.
+
+## Naming collision — resolve before wiring (not in this PR)
+
+Corpus rows already carry `machine_id` / `machine_id_basis`, added 2026-08-15 as an *additive alias* for the historical corpus (values are human names like `host-b`; table at `results/machine_aliases.json`). This PR's runtime `machine_id` is a **16-hex salted hash** — same name, different semantics. They must not meet in one row. This PR ships no row field, so nothing collides yet; the wiring PR must rename one of them. File a bead when wiring.
+
+## Salt storage — why a separate file
+
+`submit.py:load_or_create_install_id` writes config with
+`config_path.write_text('[hermia]\ninstall_id = "..."\n')` — a **whole-file overwrite**. A salt stored in `~/.hermia/config.toml` would be silently destroyed the first time an install_id is regenerated (absent or malformed file). Rather than inherit that hazard or edit an out-of-scope module, the salt lives in its own file: `~/.hermia/machine_salt`, mode `0600`. Log the clobbering writer as a separate bead.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/hermia/identity/__init__.py` | Public API re-exports only: `HardwareFacts`, `MachineIdentity`, `HardwareProbe`, `LocalProbe`, `derive_machine_id`, `load_or_create_salt`, `check_identity_consistency`. |
+| `src/hermia/identity/types.py` | Frozen dataclasses + the `HardwareProbe` Protocol. No I/O. |
+| `src/hermia/identity/probes.py` | `LocalProbe`: per-OS measurement of platform UUID / CPU brand / RAM bytes. All subprocess use. |
+| `src/hermia/identity/derive.py` | Facts + salt → `MachineIdentity`. Pure; no I/O. |
+| `src/hermia/identity/salt.py` | Load-or-create the per-install salt at `~/.hermia/machine_salt`. |
+| `src/hermia/identity/crosscheck.py` | Label↔id ledger at `~/.hermia/machine_ledger.json`; returns warnings, never raises. |
+| `src/hermia/sink/anonymize.py` *(modify)* | Add `assign_machine_pseudonyms()`. Do **not** add `machine_id` to `SUBMIT_WHITELIST`. |
+| `tests/unit/identity/test_types.py` … `test_crosscheck.py` | One test module per source module. |
+
+---
+
+## Task 1: Types and Protocol
+
+**Files:**
+- Create: `src/hermia/identity/types.py`
+- Test: `tests/unit/identity/test_types.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from hermia.identity.types import HardwareFacts, MachineIdentity
+
+
+def test_hardware_facts_is_frozen():
+    f = HardwareFacts(platform_uuid="U", cpu_brand="C", ram_bytes=1, os_family="darwin")
+    with pytest.raises(Exception):
+        f.platform_uuid = "other"  # type: ignore[misc]
+
+
+def test_hardware_facts_defaults_unmeasured_to_none_not_empty_string():
+    f = HardwareFacts(platform_uuid=None, cpu_brand=None, ram_bytes=None, os_family="linux")
+    assert f.platform_uuid is None
+    assert f.cpu_brand is None
+    assert f.ram_bytes is None
+    assert f.unavailable == ()
+
+
+def test_is_identifiable_requires_platform_uuid():
+    """CPU+RAM alone must NOT count: identical laptop models share both."""
+    assert HardwareFacts("U", "Apple M1 Pro", 17179869184, "darwin").is_identifiable
+    assert not HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin").is_identifiable
+
+
+def test_machine_identity_null_id_still_carries_a_basis():
+    m = MachineIdentity(machine_id=None, basis="unavailable:no-platform-uuid", os_family="linux")
+    assert m.machine_id is None
+    assert m.basis
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_types.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermia.identity'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Types for machine identity. No I/O, no subprocess — pure data."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class HardwareFacts:
+    """Facts measured ON a machine. ``None`` means NOT MEASURED — never guessed."""
+
+    platform_uuid: str | None
+    cpu_brand: str | None
+    ram_bytes: int | None
+    os_family: str
+    unavailable: tuple[str, ...] = field(default=())
+
+    @property
+    def is_identifiable(self) -> bool:
+        """True only when the strong, machine-bound identifier was measured.
+
+        CPU brand and RAM size are entropy, NOT identity: two identical laptops
+        share both. Requiring platform_uuid is what stops two laptops of
+        identical model and memory from hashing to the same machine_id.
+        """
+        return bool(self.platform_uuid)
+
+
+@dataclass(frozen=True)
+class MachineIdentity:
+    """A derived identity. ``machine_id is None`` is a valid, explicit outcome."""
+
+    machine_id: str | None
+    basis: str
+    os_family: str
+
+
+class HardwareProbe(Protocol):
+    """Measures hardware facts for one machine.
+
+    ``LocalProbe`` implements this for the machine hermia runs on. Remote
+    probes (SSH, agent) implement the same Protocol later; nothing else in the
+    package may assume the facts came from localhost.
+    """
+
+    def probe(self) -> HardwareFacts: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_types.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/types.py tests/unit/identity/test_types.py
+git commit -m "feat(identity): hardware fact and identity types (hermia-cfqv)"
+```
+
+---
+
+## Task 2: Salt store
+
+**Files:**
+- Create: `src/hermia/identity/salt.py`
+- Test: `tests/unit/identity/test_salt.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import stat
+from hermia.identity.salt import load_or_create_salt
+
+
+def test_creates_salt_and_is_stable_across_calls(tmp_path):
+    p = tmp_path / "machine_salt"
+    a = load_or_create_salt(p)
+    b = load_or_create_salt(p)
+    assert a == b
+    assert len(a) == 32
+
+
+def test_salt_file_is_owner_only(tmp_path):
+    p = tmp_path / "machine_salt"
+    load_or_create_salt(p)
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+def test_distinct_paths_get_distinct_salts(tmp_path):
+    assert load_or_create_salt(tmp_path / "a") != load_or_create_salt(tmp_path / "b")
+
+
+def test_corrupt_salt_file_is_regenerated_not_crashed(tmp_path):
+    p = tmp_path / "machine_salt"
+    p.write_text("not-hex-at-all!!")
+    s = load_or_create_salt(p)
+    assert len(s) == 32
+
+
+def test_unwritable_location_still_returns_a_usable_salt(tmp_path):
+    """A read-only home must degrade to an ephemeral salt, not crash the CLI."""
+    d = tmp_path / "ro"
+    d.mkdir()
+    d.chmod(0o500)
+    try:
+        s = load_or_create_salt(d / "machine_salt")
+        assert len(s) == 32
+    finally:
+        d.chmod(0o700)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_salt.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermia.identity.salt'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Per-install salt for machine_id derivation.
+
+Stored in its OWN file, not in ``~/.hermia/config.toml``: that file is written
+with a whole-file overwrite by ``submit.load_or_create_install_id``, which would
+silently destroy a salt stored beside install_id.
+
+The salt is what makes machine_id locally unique but globally meaningless. An
+UNSALTED hash of platform-uuid+cpu+ram is trivially confirmable — the candidate
+space is small enough that anyone holding a machine can hash it and confirm a
+match, re-identifying the box and leaking fleet composition.
+"""
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+SALT_BYTES = 32
+DEFAULT_SALT_PATH = Path.home() / ".hermia" / "machine_salt"
+
+
+def load_or_create_salt(salt_path: Path | None = None) -> bytes:
+    """Return the per-install salt, creating and persisting it if absent.
+
+    A missing, unreadable, or malformed file is regenerated. An unwritable
+    location yields an ephemeral salt for this process rather than raising —
+    the CLI keeps working, but machine_id will not be stable across runs.
+    """
+    path = DEFAULT_SALT_PATH if salt_path is None else salt_path
+    try:
+        raw = bytes.fromhex(path.read_text(encoding="utf-8").strip())
+        if len(raw) == SALT_BYTES:
+            return raw
+    except (OSError, ValueError):
+        pass
+
+    salt = secrets.token_bytes(SALT_BYTES)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(salt.hex(), encoding="utf-8")
+        path.chmod(0o600)
+    except OSError:
+        pass  # ephemeral for this process
+    return salt
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_salt.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/salt.py tests/unit/identity/test_salt.py
+git commit -m "feat(identity): per-install salt store in its own file (hermia-cfqv)"
+```
+
+---
+
+## Task 3: Derivation
+
+**Files:**
+- Create: `src/hermia/identity/derive.py`
+- Test: `tests/unit/identity/test_derive.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from hermia.identity.derive import derive_machine_id
+from hermia.identity.types import HardwareFacts
+
+SALT = b"\x01" * 32
+OTHER = b"\x02" * 32
+M1 = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "darwin")
+
+
+def test_id_is_16_hex_chars_and_deterministic():
+    a = derive_machine_id(M1, SALT)
+    b = derive_machine_id(M1, SALT)
+    assert a.machine_id == b.machine_id
+    assert len(a.machine_id) == 16
+    assert all(c in "0123456789abcdef" for c in a.machine_id)
+
+
+def test_different_salt_gives_different_id_for_same_machine():
+    assert derive_machine_id(M1, SALT).machine_id != derive_machine_id(M1, OTHER).machine_id
+
+
+def test_two_identical_models_with_different_uuids_do_not_collide():
+    """Two laptops of identical model and memory must never share an id."""
+    a = HardwareFacts("UUID-A", "Apple M1 Pro", 17179869184, "darwin")
+    b = HardwareFacts("UUID-B", "Apple M1 Pro", 17179869184, "darwin")
+    assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id
+
+
+def test_missing_platform_uuid_yields_null_id_with_reason():
+    f = HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin")
+    got = derive_machine_id(f, SALT)
+    assert got.machine_id is None
+    assert got.basis == "unavailable:no-platform-uuid"
+
+
+def test_id_changes_when_ram_changes():
+    """RAM is entropy in the tuple, so a genuine hardware change is visible."""
+    more = HardwareFacts("UUID-1", "Apple M1 Pro", 34359738368, "darwin")
+    assert derive_machine_id(more, SALT).machine_id != derive_machine_id(M1, SALT).machine_id
+
+
+def test_raw_identifiers_never_appear_in_the_result():
+    got = derive_machine_id(M1, SALT)
+    blob = f"{got.machine_id}{got.basis}{got.os_family}"
+    assert "UUID-1" not in blob
+    assert "Apple M1 Pro" not in blob
+    assert "17179869184" not in blob
+
+
+def test_basis_records_what_was_measured_on_success():
+    assert derive_machine_id(M1, SALT).basis == "measured:platform-uuid+cpu+ram"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_derive.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermia.identity.derive'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Hardware facts + salt -> machine_id. Pure function, no I/O."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from hermia.identity.types import HardwareFacts, MachineIdentity
+
+ID_HEX_CHARS = 16
+
+
+def derive_machine_id(facts: HardwareFacts, salt: bytes) -> MachineIdentity:
+    """Derive a salted, locally-unique machine id.
+
+    Returns ``machine_id=None`` with an explanatory ``basis`` whenever the
+    machine-bound identifier is missing. There is deliberately no partial or
+    fallback identity: a hash of CPU+RAM alone would collide across identical
+    laptops, which is worse than admitting we do not know.
+    """
+    if not facts.is_identifiable:
+        return MachineIdentity(None, "unavailable:no-platform-uuid", facts.os_family)
+
+    canonical = json.dumps(
+        {
+            "platform_uuid": facts.platform_uuid,
+            "cpu_brand": facts.cpu_brand,
+            "ram_bytes": facts.ram_bytes,
+            "os_family": facts.os_family,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hmac.new(salt, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    return MachineIdentity(
+        digest[:ID_HEX_CHARS], "measured:platform-uuid+cpu+ram", facts.os_family
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_derive.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/derive.py tests/unit/identity/test_derive.py
+git commit -m "feat(identity): salted machine_id derivation, uuid required (hermia-cfqv)"
+```
+
+---
+
+## Task 4: Local probe
+
+**Files:**
+- Create: `src/hermia/identity/probes.py`
+- Test: `tests/unit/identity/test_probes.py`
+
+Platform commands (all read-only):
+
+| OS | platform_uuid | cpu_brand | ram_bytes |
+|---|---|---|---|
+| macOS | `ioreg -rd1 -c IOPlatformExpertDevice` → `IOPlatformUUID` | `sysctl -n machdep.cpu.brand_string` | `sysctl -n hw.memsize` |
+| Linux | `/etc/machine-id`, else `/sys/class/dmi/id/product_uuid` | `model name` in `/proc/cpuinfo` | `MemTotal` in `/proc/meminfo` (kB → bytes) |
+| Windows | `reg query HKLM\SOFTWARE\Microsoft\Cryptography /v MachineGuid` | `PROCESSOR_IDENTIFIER` env | `wmic ComputerSystem get TotalPhysicalMemory` |
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+from hermia.identity.probes import LocalProbe
+
+
+def test_macos_probe_parses_ioreg_and_sysctl():
+    ioreg = '  "IOPlatformUUID" = "ABC-123"\n'
+    with patch("hermia.identity.probes._run") as run:
+        run.side_effect = lambda cmd, **kw: {
+            "ioreg": ioreg, "machdep.cpu.brand_string": "Apple M1 Pro", "hw.memsize": "17179869184",
+        }[next(k for k in ("ioreg", "machdep.cpu.brand_string", "hw.memsize") if k in " ".join(cmd))]
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.platform_uuid == "ABC-123"
+    assert f.cpu_brand == "Apple M1 Pro"
+    assert f.ram_bytes == 17179869184
+
+
+def test_probe_failure_yields_none_not_a_guess():
+    with patch("hermia.identity.probes._run", return_value=None):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.platform_uuid is None
+    assert not f.is_identifiable
+    assert "platform_uuid" in f.unavailable
+
+
+def test_unsupported_os_reports_unavailable_rather_than_raising():
+    f = LocalProbe(os_family="plan9").probe()
+    assert f.platform_uuid is None
+    assert f.os_family == "plan9"
+
+
+def test_ram_bytes_is_never_zero_when_unmeasured():
+    """0 would read as a real measurement of a 0-byte machine."""
+    with patch("hermia.identity.probes._run", return_value=""):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.ram_bytes is None
+
+
+def test_linux_meminfo_kb_is_converted_to_bytes():
+    with patch("hermia.identity.probes._read_text") as rt:
+        rt.side_effect = lambda p: {
+            "/etc/machine-id": "deadbeef\n",
+            "/proc/cpuinfo": "model name\t: AMD Ryzen 9\n",
+            "/proc/meminfo": "MemTotal:       32768000 kB\n",
+        }.get(str(p))
+        f = LocalProbe(os_family="linux").probe()
+    assert f.ram_bytes == 32768000 * 1024
+    assert f.cpu_brand == "AMD Ryzen 9"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_probes.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermia.identity.probes'`
+
+- [ ] **Step 3: Write the implementation**
+
+Implement `_run(cmd) -> str | None` (subprocess, short timeout, returns `None` on any failure — never raises), `_read_text(path) -> str | None`, and `LocalProbe` with `probe()` dispatching on `os_family` (defaulting to `platform.system().lower()`). Every extractor returns `None` on absent/unparseable input and appends the field name to `unavailable`. **No `except: pass` that yields a value** — a failed measurement must be `None`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_probes.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/probes.py tests/unit/identity/test_probes.py
+git commit -m "feat(identity): cross-platform local hardware probe (hermia-cfqv)"
+```
+
+---
+
+## Task 5: Cross-check ledger — the high-value part
+
+This is the check that would have caught `hermia-fqod` **at dispatch time** instead of a month later during analysis.
+
+**Files:**
+- Create: `src/hermia/identity/crosscheck.py`
+- Test: `tests/unit/identity/test_crosscheck.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from hermia.identity.crosscheck import check_identity_consistency, record_observation
+
+
+def test_first_observation_produces_no_warning(tmp_path):
+    led = tmp_path / "ledger.json"
+    assert check_identity_consistency("host-a", "aaaa000000000000", led) == []
+
+
+def test_same_label_now_a_different_machine_warns(tmp_path):
+    """A name that silently starts pointing at different hardware."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "aaaa000000000000", led)
+    warns = check_identity_consistency("host-a", "bbbb111111111111", led)
+    assert len(warns) == 1
+    assert warns[0].kind == "label_moved_machine"
+    assert "host-a" in warns[0].message
+
+
+def test_same_machine_under_a_new_label_warns_as_rename(tmp_path):
+    """One box under several names."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-b", "cccc222222222222", led)
+    warns = check_identity_consistency("host-c", "cccc222222222222", led)
+    assert len(warns) == 1
+    assert warns[0].kind == "machine_renamed"
+
+
+def test_unknown_machine_id_never_warns(tmp_path):
+    """A null id means 'not measured'. It must not be treated as a machine."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "dddd333333333333", led)
+    assert check_identity_consistency("host-a", None, led) == []
+
+
+def test_corrupt_ledger_degrades_to_no_warnings_and_does_not_raise(tmp_path):
+    led = tmp_path / "ledger.json"
+    led.write_text("{not json")
+    assert check_identity_consistency("host-a", "eeee444444444444", led) == []
+
+
+def test_stable_pairing_repeated_many_times_stays_silent(tmp_path):
+    led = tmp_path / "ledger.json"
+    for _ in range(5):
+        record_observation("host-d", "ffff555555555555", led)
+        assert check_identity_consistency("host-d", "ffff555555555555", led) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_crosscheck.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hermia.identity.crosscheck'`
+
+- [ ] **Step 3: Write the implementation**
+
+`IdentityWarning` frozen dataclass with `kind: str` and `message: str`. Ledger is JSON at `~/.hermia/machine_ledger.json`: `{"label_to_id": {...}, "id_to_label": {...}}`. `check_identity_consistency(label, machine_id, path)` returns `[]` when `machine_id is None` or the ledger is unreadable/corrupt; otherwise emits `label_moved_machine` and/or `machine_renamed`. `record_observation` writes both directions. **Warnings only — never raise, never block a run.**
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_crosscheck.py -q`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/crosscheck.py tests/unit/identity/test_crosscheck.py
+git commit -m "feat(identity): label/machine cross-check ledger (hermia-cfqv)"
+```
+
+---
+
+## Task 6: Anonymized-export pseudonyms
+
+**Files:**
+- Modify: `src/hermia/sink/anonymize.py`
+- Test: `tests/unit/test_anonymize.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from hermia.sink.anonymize import SUBMIT_WHITELIST, assign_machine_pseudonyms
+
+
+def test_machine_id_is_not_whitelisted():
+    """Default-deny must keep the salted hash out of submissions."""
+    assert "machine_id" not in SUBMIT_WHITELIST
+    assert "machine_id_basis" not in SUBMIT_WHITELIST
+
+
+def test_pseudonyms_are_stable_and_ordered_by_first_appearance():
+    rows = [{"machine_id": "bbbb"}, {"machine_id": "aaaa"}, {"machine_id": "bbbb"}]
+    got = assign_machine_pseudonyms(rows)
+    assert [r["machine_pseudonym"] for r in got] == ["node-a", "node-b", "node-a"]
+
+
+def test_null_machine_id_gets_null_pseudonym_not_a_node_name():
+    got = assign_machine_pseudonyms([{"machine_id": None}])
+    assert got[0]["machine_pseudonym"] is None
+
+
+def test_original_machine_id_is_removed_from_the_output():
+    got = assign_machine_pseudonyms([{"machine_id": "aaaa"}])
+    assert "machine_id" not in got[0]
+
+
+def test_input_rows_are_not_mutated():
+    rows = [{"machine_id": "aaaa"}]
+    assign_machine_pseudonyms(rows)
+    assert rows[0]["machine_id"] == "aaaa"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/test_anonymize.py -q -k pseudonym`
+Expected: FAIL — `ImportError: cannot import name 'assign_machine_pseudonyms'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add `assign_machine_pseudonyms(rows)` returning **new** dicts: replace `machine_id` with `machine_pseudonym` (`node-a`, `node-b`, … `node-z`, `node-aa`, …) assigned in first-appearance order within the dataset. `None` in → `None` out. Neither the salt nor the mapping is ever written to output. Do **not** touch `SUBMIT_WHITELIST`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/test_anonymize.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/sink/anonymize.py tests/unit/test_anonymize.py
+git commit -m "feat(identity): pseudonymise machine_id on anonymized export (hermia-cfqv)"
+```
+
+---
+
+## Task 7: Public API and full-suite green
+
+**Files:**
+- Create: `src/hermia/identity/__init__.py`
+- Test: `tests/unit/identity/test_public_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_public_api_exports():
+    import hermia.identity as ident
+    for name in (
+        "HardwareFacts", "MachineIdentity", "HardwareProbe", "LocalProbe",
+        "derive_machine_id", "load_or_create_salt", "check_identity_consistency",
+    ):
+        assert hasattr(ident, name), name
+
+
+def test_end_to_end_local_identity_is_stable(tmp_path):
+    from hermia.identity import LocalProbe, derive_machine_id, load_or_create_salt
+    salt = load_or_create_salt(tmp_path / "salt")
+    facts = LocalProbe().probe()
+    a = derive_machine_id(facts, salt)
+    b = derive_machine_id(facts, salt)
+    assert a.machine_id == b.machine_id
+    assert a.basis
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/identity/test_public_api.py -q`
+Expected: FAIL — missing exports
+
+- [ ] **Step 3: Write `__init__.py`** re-exporting the seven names with `__all__`.
+
+- [ ] **Step 4: Verify the whole gate**
+
+```bash
+.venv/bin/ruff check src/
+.venv/bin/mypy src/
+.venv/bin/pytest -q -k 'not test_detect_gpu'
+```
+Expected: ruff clean; mypy clean; **2025 + new tests passed, 9 deselected**. The 9 deselected are the known macOS GPU-detection failures (`hermia-2ess`) — pre-existing on `dev`, unrelated to this work.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hermia/identity/__init__.py tests/unit/identity/test_public_api.py
+git commit -m "feat(identity): public API for machine identity core (hermia-cfqv)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Bead points 1–4 → Tasks 1–4 (tuple, HMAC+salt, salt storage, label kept separate as a pure convenience with no code dependency). Point 5 (anonymized export → pseudonyms) → Task 6. Point 6 (runtime cross-check) → Task 5. "EXCLUDE MAC" → enforced by omission from `HardwareFacts` and asserted by `test_raw_identifiers_never_appear_in_the_result` plus the absence of any MAC field. "Explicit null, never a guess" → tested in Tasks 1, 3, 4, 5, 6.
+
+**Gap accepted deliberately:** nothing stamps a row. Stated under Non-Goals with the reason; without the transport decision, any row stamp would be wrong for fleet runs.
+
+**Placeholder scan.** Tasks 4, 5 and 6 give prose implementation notes rather than full code, because each is mechanical given the fully-specified tests above them and the exact platform commands in the Task 4 table. Every test body is complete and runnable.
+
+**Type consistency.** `HardwareFacts(platform_uuid, cpu_brand, ram_bytes, os_family, unavailable)`, `MachineIdentity(machine_id, basis, os_family)`, `derive_machine_id(facts, salt)`, `load_or_create_salt(path)`, `check_identity_consistency(label, machine_id, path)`, `record_observation(label, machine_id, path)`, `assign_machine_pseudonyms(rows)` — consistent across all tasks.

--- a/src/hermia/identity/__init__.py
+++ b/src/hermia/identity/__init__.py
@@ -1,0 +1,33 @@
+"""Machine identity: a salted, locally-unique id bound to a machine (hermia-cfqv).
+
+Identity is derived from identifiers that belong to the COMPUTER — platform
+UUID, CPU brand, physical RAM — and never from a MAC address, because DHCP
+reservations in this fleet are bound to detachable USB/Thunderbolt dongles and a
+Thunderbolt dock. A MAC-derived id would follow the accessory, not the machine.
+
+Nothing here stamps a result row yet. For a fleet run the model executes on a
+remote host while hermia runs locally, so stamping the LOCAL machine onto a
+remote row would manufacture exactly the misleading attribution this package
+exists to prevent. Row wiring lands with the remote-probe transport decision.
+"""
+from hermia.identity.crosscheck import (
+    IdentityWarning,
+    check_identity_consistency,
+    record_observation,
+)
+from hermia.identity.derive import derive_machine_id
+from hermia.identity.probes import LocalProbe
+from hermia.identity.salt import load_or_create_salt
+from hermia.identity.types import HardwareFacts, HardwareProbe, MachineIdentity
+
+__all__ = [
+    "HardwareFacts",
+    "HardwareProbe",
+    "IdentityWarning",
+    "LocalProbe",
+    "MachineIdentity",
+    "check_identity_consistency",
+    "derive_machine_id",
+    "load_or_create_salt",
+    "record_observation",
+]

--- a/src/hermia/identity/__init__.py
+++ b/src/hermia/identity/__init__.py
@@ -1,33 +1,53 @@
-"""Machine identity: a salted, locally-unique id bound to a machine (hermia-cfqv).
+"""Machine identity: an exact, salted id bound to the silicon (hermia-cfqv).
 
-Identity is derived from identifiers that belong to the COMPUTER — platform
-UUID, CPU brand, physical RAM — and never from a MAC address, because DHCP
-reservations in this fleet are bound to detachable USB/Thunderbolt dongles and a
-Thunderbolt dock. A MAC-derived id would follow the accessory, not the machine.
+Identity comes from NON-TRANSFERABLE identifiers — firmware UUID, hardware serial,
+or a minted on-host token — matched exactly. Capabilities (CPU, memory, GPU) are
+recorded beside it and never hashed, so a RAM upgrade is a visible fact rather
+than a new machine.
+
+Never from a MAC or an IP: reservations here are bound to detachable adapters and
+a dock, so a network-derived identity follows the accessory, not the computer.
 
 Nothing here stamps a result row yet. For a fleet run the model executes on a
 remote host while hermia runs locally, so stamping the LOCAL machine onto a
-remote row would manufacture exactly the misleading attribution this package
-exists to prevent. Row wiring lands with the remote-probe transport decision.
+remote row would manufacture exactly the misattribution this package exists to
+prevent. Row wiring lands with the remote-probe transport decision.
 """
 from hermia.identity.crosscheck import (
     IdentityWarning,
     check_identity_consistency,
+    pending_conflicts,
     record_observation,
+    resolve_conflict,
 )
-from hermia.identity.derive import derive_machine_id
+from hermia.identity.derive import derive_machine_id, select_source
 from hermia.identity.probes import LocalProbe
-from hermia.identity.salt import load_or_create_salt
-from hermia.identity.types import HardwareFacts, HardwareProbe, MachineIdentity
+from hermia.identity.salt import SaltInfo, load_or_create_salt, load_salt
+from hermia.identity.types import (
+    HardwareProbe,
+    MachineCapabilities,
+    MachineIdentifiers,
+    MachineIdentity,
+    MachineObservation,
+    is_usable_identifier,
+)
 
 __all__ = [
-    "HardwareFacts",
     "HardwareProbe",
     "IdentityWarning",
     "LocalProbe",
+    "MachineCapabilities",
+    "MachineIdentifiers",
     "MachineIdentity",
+    "MachineObservation",
+    "SaltInfo",
     "check_identity_consistency",
     "derive_machine_id",
+    "is_usable_identifier",
     "load_or_create_salt",
+    "load_salt",
+    "pending_conflicts",
     "record_observation",
+    "resolve_conflict",
+    "select_source",
 ]

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -1,0 +1,154 @@
+"""Label/machine cross-check ledger (hermia-cfqv).
+
+This is the high-value part. A local ledger remembers which ``machine_id`` was
+last seen under which operator label, and warns when the two stop agreeing.
+
+That check alone would have caught hermia-fqod **at dispatch time** rather than
+a month later during analysis: a fleet YAML named one machine while a
+different one answered, and nothing anywhere noticed. It also covers the case where one machine
+accumulated three different names over three months.
+
+Advisory only. Every function here degrades to silence rather than raising, and
+nothing in this module may block or fail a run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_LEDGER_PATH = Path.home() / ".hermia" / "machine_ledger.json"
+
+_Ledger = dict[str, dict[str, str]]
+
+# fleet.py runs hosts in a ThreadPoolExecutor, so per-host checks land here
+# concurrently. Without this the read-modify-write below interleaves and one
+# worker's pairing is lost, leaving that host silently unprotected against the
+# very swap this module detects. In-process only: a second hermia process
+# writing the same ledger is still last-writer-wins (atomic, but not merged).
+_LEDGER_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class IdentityWarning:
+    """kind is ``label_moved_machine`` or ``machine_renamed``."""
+
+    kind: str
+    message: str
+
+
+def _empty() -> _Ledger:
+    return {"label_to_id": {}, "id_to_label": {}}
+
+
+def _load_ledger(ledger_path: Path) -> _Ledger:
+    """Load the ledger, returning an empty one on ANY problem.
+
+    Shape is validated, not assumed: a file containing valid JSON of the wrong
+    shape (``[]``, ``{"foo": 1}``, a nested non-string value) must degrade to
+    empty rather than raising a KeyError/TypeError deep inside a caller. Testing
+    only malformed JSON would miss that entirely.
+    """
+    try:
+        data = json.loads(ledger_path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 - advisory only, never raise
+        return _empty()
+
+    if not isinstance(data, dict):
+        return _empty()
+
+    out = _empty()
+    for section in ("label_to_id", "id_to_label"):
+        raw = data.get(section)
+        if isinstance(raw, dict):
+            out[section] = {
+                k: v for k, v in raw.items() if isinstance(k, str) and isinstance(v, str)
+            }
+    return out
+
+
+def _save_ledger(ledger_path: Path, data: _Ledger) -> None:
+    """Write the ledger atomically: temp file in the same dir, then os.replace.
+
+    A partial write would leave truncated JSON, which _load_ledger treats as
+    empty — silently discarding every previously recorded pairing and disarming
+    the swap detection this module exists for.
+    """
+    try:
+        ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = ledger_path.with_name(f"{ledger_path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, ledger_path)
+    except OSError:
+        pass  # read-only home: skip persistence, never crash the run
+
+
+def record_observation(
+    label: str, machine_id: str | None, ledger_path: Path | None = None
+) -> None:
+    """Persist a (label, machine_id) pairing in both directions.
+
+    A ``machine_id`` of ``None`` means NOT MEASURED and is never recorded —
+    storing it would make "we don't know" look like a machine, and every
+    unidentified host would then collide into one identity.
+    """
+    if machine_id is None:
+        return
+    path = DEFAULT_LEDGER_PATH if ledger_path is None else ledger_path
+    with _LEDGER_LOCK:
+        ledger = _load_ledger(path)
+        ledger["label_to_id"][label] = machine_id
+        ledger["id_to_label"][machine_id] = label
+        _save_ledger(path, ledger)
+
+
+def check_identity_consistency(
+    label: str, machine_id: str | None, ledger_path: Path | None = None
+) -> list[IdentityWarning]:
+    """Return warnings when a label and a machine stop agreeing.
+
+    Side effect, deliberate and worth knowing about: when the pairing is
+    consistent (or new), it is RECORDED. That makes the check self-bootstrapping
+    at dispatch time — the first run of a host teaches the ledger, and a later
+    swap is caught. When a warning fires nothing is recorded, so the alarm
+    persists across runs until an operator resolves it rather than being
+    silently absorbed on the second run.
+    """
+    if machine_id is None:
+        return []
+
+    path = DEFAULT_LEDGER_PATH if ledger_path is None else ledger_path
+    ledger = _load_ledger(path)
+    warnings: list[IdentityWarning] = []
+
+    previous_id = ledger["label_to_id"].get(label)
+    if previous_id is not None and previous_id != machine_id:
+        warnings.append(
+            IdentityWarning(
+                kind="label_moved_machine",
+                message=(
+                    f"Host label '{label}' previously identified machine "
+                    f"'{previous_id}' but now identifies '{machine_id}'. The name "
+                    f"may have been moved to different hardware."
+                ),
+            )
+        )
+
+    previous_label = ledger["id_to_label"].get(machine_id)
+    if previous_label is not None and previous_label != label:
+        warnings.append(
+            IdentityWarning(
+                kind="machine_renamed",
+                message=(
+                    f"Machine '{machine_id}' was previously labelled "
+                    f"'{previous_label}' and is now labelled '{label}'. Rows from "
+                    f"both labels belong to one machine."
+                ),
+            )
+        )
+
+    if not warnings:
+        record_observation(label, machine_id, path)
+    return warnings

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -40,7 +40,9 @@ except ImportError:  # pragma: no cover - platform dependent
 DEFAULT_LEDGER_PATH = Path.home() / ".hermia" / "machine_ledger.json"
 
 _Ledger = dict[str, Any]
-_LEDGER_LOCK = threading.Lock()
+# Reentrant: a caller reaching this module again from inside a logging handler
+# or error path would otherwise self-deadlock rather than merely misbehave.
+_LEDGER_LOCK = threading.RLock()
 
 
 @dataclass(frozen=True)
@@ -118,6 +120,27 @@ def _save(path: Path, data: _Ledger) -> None:
         os.replace(tmp, path)
     except OSError:
         pass  # read-only home: skip persistence, never crash the run
+
+
+def _still_disputed(conflict: dict[str, Any], machine_id: str) -> bool:
+    """Is a recorded conflict still live for the machine now being observed?
+
+    Two different situations get recorded as a conflict, and only one of them
+    should keep blocking:
+
+    * The label HAD a binding and something else answered to it. The dispute is
+      about this label, so it stays open even once the original machine returns
+      — otherwise a box swapped in for one run and swapped back out clears
+      itself and leaves no trace that anything moved.
+    * The label had NO binding and the conflict came from the machine already
+      answering to another name. Once this label settles on a different,
+      unclaimed machine that dispute is moot FOR THIS LABEL. Keeping it open
+      would permanently block a freshly renamed host from ever binding, while
+      warning forever about a machine no longer involved.
+    """
+    if conflict.get("expected") is not None:
+        return True
+    return conflict.get("observed") == machine_id
 
 
 def _bind(ledger: _Ledger, label: str, machine_id: str) -> None:
@@ -245,7 +268,9 @@ def check_identity_consistency(
                 "observed": machine_id,
                 "expected": previous_id,
             }
-        elif isinstance(open_conflict, dict):
+        elif isinstance(open_conflict, dict) and _still_disputed(
+            open_conflict, machine_id
+        ):
             # Pairing looks fine again, but nobody adjudicated the earlier
             # disagreement. Keep reporting it; do NOT rebind.
             warnings.append(

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -57,18 +58,42 @@ def _empty() -> _Ledger:
     return {"label_to_id": {}, "id_to_label": {}, "conflicts": {}}
 
 
+_LOCK_ATTEMPTS = 50
+_LOCK_SLEEP_SEC = 0.02
+
+
 @contextmanager
 def _locked(path: Path) -> Iterator[None]:
-    """Serialise ledger access across threads AND processes."""
+    """Serialise ledger access across threads AND processes — without blocking.
+
+    The lock is acquired NON-blocking and retried briefly. A plain blocking
+    flock would park the run behind whichever process holds the lock, and if
+    that process is wedged the benchmark hangs with no output and no
+    explanation — this module is advisory and must never stall a run.
+
+    If the lock cannot be taken within about a second we proceed anyway.
+    Writes are atomic via os.replace, so the worst case degrades to
+    last-writer-wins on the ledger rather than a hung or corrupted run.
+    """
     with _LEDGER_LOCK:
         handle = None
         if fcntl is not None:
             try:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 handle = open(path.with_name(path.name + ".lock"), "w")  # noqa: SIM115
-                fcntl.flock(handle, fcntl.LOCK_EX)
             except OSError:
                 handle = None
+        if handle is not None:
+            for attempt in range(_LOCK_ATTEMPTS):
+                try:
+                    fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if attempt == _LOCK_ATTEMPTS - 1:
+                        handle.close()
+                        handle = None
+                        break
+                    time.sleep(_LOCK_SLEEP_SEC)
         try:
             yield
         finally:
@@ -87,8 +112,16 @@ def _load(path: Path) -> _Ledger:
     caller. Testing only malformed JSON would miss that entirely.
     """
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty()
+    try:
+        data = json.loads(raw_text)
     except Exception:  # noqa: BLE001 - advisory only, never raise
+        # Every recorded pairing is about to be discarded, and afterwards every
+        # host looks brand new. Keep the unreadable file so an operator can see
+        # what was lost instead of it vanishing without trace.
+        _quarantine(path)
         return _empty()
     if not isinstance(data, dict):
         return _empty()
@@ -105,6 +138,16 @@ def _load(path: Path) -> _Ledger:
             k: v for k, v in raw_conflicts.items() if isinstance(k, str)
         }
     return out
+
+
+def _quarantine(path: Path) -> None:
+    """Preserve an unreadable ledger alongside itself, once."""
+    try:
+        broken = path.with_name(path.name + ".corrupt")
+        if not broken.exists():
+            broken.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    except OSError:
+        pass
 
 
 def _save(path: Path, data: _Ledger) -> None:

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -150,6 +150,21 @@ def _quarantine(path: Path) -> None:
         pass
 
 
+def _history_was_lost(path: Path) -> bool:
+    """True when a quarantined ledger sits beside this one.
+
+    Preserving the corrupt file is not enough on its own. Every recorded pairing
+    AND every open conflict is gone, so a host that was previously warning about
+    a swap now binds cleanly and reports nothing — the alarm is silently
+    disarmed by a single file corruption. The operator has to be told the
+    history went, not merely be able to find it afterwards.
+    """
+    try:
+        return path.with_name(path.name + ".corrupt").exists()
+    except OSError:
+        return False
+
+
 def _save(path: Path, data: _Ledger) -> None:
     """Atomic write: temp file in the same dir, then os.replace.
 
@@ -277,6 +292,20 @@ def check_identity_consistency(
     with _locked(path):
         ledger = _load(path)
         warnings: list[IdentityWarning] = []
+
+        if _history_was_lost(path) and not ledger["label_to_id"]:
+            warnings.append(
+                IdentityWarning(
+                    kind="ledger_history_lost",
+                    message=(
+                        f"The machine ledger was unreadable and has been reset; "
+                        f"the previous contents are kept at {path.name}.corrupt. "
+                        f"Every prior label/machine pairing and any open conflict "
+                        f"are gone, so swaps that were already flagged will not "
+                        f"be flagged again until each host is re-observed."
+                    ),
+                )
+            )
 
         previous_id = ledger["label_to_id"].get(label)
         if previous_id is not None and previous_id != machine_id:

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -1,33 +1,45 @@
 """Label/machine cross-check ledger (hermia-cfqv).
 
-This is the high-value part. A local ledger remembers which ``machine_id`` was
-last seen under which operator label, and warns when the two stop agreeing.
+A local ledger remembers which ``machine_id`` was last seen under which operator
+label, and warns when the two stop agreeing. That check is what catches a fleet
+YAML naming one machine while a different one answers — at dispatch time, rather
+than a month later during analysis.
 
-That check alone would have caught hermia-fqod **at dispatch time** rather than
-a month later during analysis: a fleet YAML named one machine while a
-different one answered, and nothing anywhere noticed. It also covers the case where one machine
-accumulated three different names over three months.
+Two defects from the first version are fixed here.
 
-Advisory only. Every function here degrades to silence rather than raising, and
-nothing in this module may block or fail a run.
+1. IT LOCKED IN THE FIRST THING IT SAW. The old code recorded an observation only
+   when no warning fired. So if the very first run was misconfigured, the WRONG
+   pairing was blessed permanently: afterwards the correct machine raised an
+   alarm on every run while the wrong one stayed silent, and the only escape was
+   hand-editing JSON. Verified in practice, not theorised. Conflicts are now
+   recorded explicitly and cleared through ``resolve_conflict``, so the alarm
+   persists until a human decides — but a human CAN decide.
+
+2. IT RACED ACROSS PROCESSES. A thread lock is not enough when two hermia runs
+   share a home directory. Writes now take an advisory file lock and land
+   atomically.
+
+Advisory only. Nothing here raises, and nothing here blocks a run.
 """
 from __future__ import annotations
 
 import json
 import os
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+
+try:  # POSIX only; elsewhere the thread lock plus atomic replace still apply.
+    import fcntl
+except ImportError:  # pragma: no cover - platform dependent
+    fcntl = None  # type: ignore[assignment]
 
 DEFAULT_LEDGER_PATH = Path.home() / ".hermia" / "machine_ledger.json"
 
-_Ledger = dict[str, dict[str, str]]
-
-# fleet.py runs hosts in a ThreadPoolExecutor, so per-host checks land here
-# concurrently. Without this the read-modify-write below interleaves and one
-# worker's pairing is lost, leaving that host silently unprotected against the
-# very swap this module detects. In-process only: a second hermia process
-# writing the same ledger is still last-writer-wins (atomic, but not merged).
+_Ledger = dict[str, Any]
 _LEDGER_LOCK = threading.Lock()
 
 
@@ -40,25 +52,44 @@ class IdentityWarning:
 
 
 def _empty() -> _Ledger:
-    return {"label_to_id": {}, "id_to_label": {}}
+    return {"label_to_id": {}, "id_to_label": {}, "conflicts": {}}
 
 
-def _load_ledger(ledger_path: Path) -> _Ledger:
+@contextmanager
+def _locked(path: Path) -> Iterator[None]:
+    """Serialise ledger access across threads AND processes."""
+    with _LEDGER_LOCK:
+        handle = None
+        if fcntl is not None:
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                handle = open(path.with_name(path.name + ".lock"), "w")  # noqa: SIM115
+                fcntl.flock(handle, fcntl.LOCK_EX)
+            except OSError:
+                handle = None
+        try:
+            yield
+        finally:
+            if handle is not None:
+                try:
+                    fcntl.flock(handle, fcntl.LOCK_UN)
+                finally:
+                    handle.close()
+
+
+def _load(path: Path) -> _Ledger:
     """Load the ledger, returning an empty one on ANY problem.
 
-    Shape is validated, not assumed: a file containing valid JSON of the wrong
-    shape (``[]``, ``{"foo": 1}``, a nested non-string value) must degrade to
-    empty rather than raising a KeyError/TypeError deep inside a caller. Testing
-    only malformed JSON would miss that entirely.
+    Shape is validated rather than assumed: valid JSON of the wrong shape (``[]``,
+    ``{"foo": 1}``) must degrade to empty instead of raising a KeyError inside a
+    caller. Testing only malformed JSON would miss that entirely.
     """
     try:
-        data = json.loads(ledger_path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:  # noqa: BLE001 - advisory only, never raise
         return _empty()
-
     if not isinstance(data, dict):
         return _empty()
-
     out = _empty()
     for section in ("label_to_id", "id_to_label"):
         raw = data.get(section)
@@ -66,23 +97,33 @@ def _load_ledger(ledger_path: Path) -> _Ledger:
             out[section] = {
                 k: v for k, v in raw.items() if isinstance(k, str) and isinstance(v, str)
             }
+    raw_conflicts = data.get("conflicts")
+    if isinstance(raw_conflicts, dict):
+        out["conflicts"] = {
+            k: v for k, v in raw_conflicts.items() if isinstance(k, str)
+        }
     return out
 
 
-def _save_ledger(ledger_path: Path, data: _Ledger) -> None:
-    """Write the ledger atomically: temp file in the same dir, then os.replace.
+def _save(path: Path, data: _Ledger) -> None:
+    """Atomic write: temp file in the same dir, then os.replace.
 
-    A partial write would leave truncated JSON, which _load_ledger treats as
-    empty — silently discarding every previously recorded pairing and disarming
-    the swap detection this module exists for.
+    A partial write would leave truncated JSON, which ``_load`` treats as empty —
+    silently discarding every recorded pairing and disarming the whole check.
     """
     try:
-        ledger_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = ledger_path.with_name(f"{ledger_path.name}.{os.getpid()}.tmp")
-        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        os.replace(tmp, ledger_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, path)
     except OSError:
         pass  # read-only home: skip persistence, never crash the run
+
+
+def _bind(ledger: _Ledger, label: str, machine_id: str) -> None:
+    ledger["label_to_id"][label] = machine_id
+    ledger["id_to_label"][machine_id] = label
+    ledger["conflicts"].pop(label, None)
 
 
 def record_observation(
@@ -90,18 +131,36 @@ def record_observation(
 ) -> None:
     """Persist a (label, machine_id) pairing in both directions.
 
-    A ``machine_id`` of ``None`` means NOT MEASURED and is never recorded —
-    storing it would make "we don't know" look like a machine, and every
-    unidentified host would then collide into one identity.
+    ``machine_id`` of ``None`` means NOT MEASURED and is never recorded: storing
+    it would make "we don't know" look like a machine, and every unidentified
+    host would collide into one identity.
     """
     if machine_id is None:
         return
     path = DEFAULT_LEDGER_PATH if ledger_path is None else ledger_path
-    with _LEDGER_LOCK:
-        ledger = _load_ledger(path)
-        ledger["label_to_id"][label] = machine_id
-        ledger["id_to_label"][machine_id] = label
-        _save_ledger(path, ledger)
+    with _locked(path):
+        ledger = _load(path)
+        _bind(ledger, label, machine_id)
+        _save(path, ledger)
+
+
+def resolve_conflict(
+    label: str, machine_id: str, ledger_path: Path | None = None
+) -> None:
+    """Operator decision: ``label`` legitimately identifies ``machine_id`` now.
+
+    This is the escape hatch whose absence made the old ledger unfixable without
+    editing JSON by hand. It rebinds the label, clears the conflict, and lets
+    subsequent runs go quiet.
+    """
+    record_observation(label, machine_id, ledger_path)
+
+
+def pending_conflicts(ledger_path: Path | None = None) -> dict[str, Any]:
+    """Conflicts awaiting an operator decision, keyed by label."""
+    path = DEFAULT_LEDGER_PATH if ledger_path is None else ledger_path
+    conflicts = _load(path)["conflicts"]
+    return dict(conflicts)
 
 
 def check_identity_consistency(
@@ -109,46 +168,52 @@ def check_identity_consistency(
 ) -> list[IdentityWarning]:
     """Return warnings when a label and a machine stop agreeing.
 
-    Side effect, deliberate and worth knowing about: when the pairing is
-    consistent (or new), it is RECORDED. That makes the check self-bootstrapping
-    at dispatch time — the first run of a host teaches the ledger, and a later
-    swap is caught. When a warning fires nothing is recorded, so the alarm
-    persists across runs until an operator resolves it rather than being
-    silently absorbed on the second run.
+    A NEW, consistent pairing is recorded automatically, so the check is
+    self-bootstrapping. A CONFLICTING pairing is recorded as a conflict and keeps
+    warning on every run until ``resolve_conflict`` is called — never silently
+    absorbed on the second run, and never permanently stuck either.
     """
     if machine_id is None:
         return []
 
     path = DEFAULT_LEDGER_PATH if ledger_path is None else ledger_path
-    ledger = _load_ledger(path)
-    warnings: list[IdentityWarning] = []
+    with _locked(path):
+        ledger = _load(path)
+        warnings: list[IdentityWarning] = []
 
-    previous_id = ledger["label_to_id"].get(label)
-    if previous_id is not None and previous_id != machine_id:
-        warnings.append(
-            IdentityWarning(
-                kind="label_moved_machine",
-                message=(
-                    f"Host label '{label}' previously identified machine "
-                    f"'{previous_id}' but now identifies '{machine_id}'. The name "
-                    f"may have been moved to different hardware."
-                ),
+        previous_id = ledger["label_to_id"].get(label)
+        if previous_id is not None and previous_id != machine_id:
+            warnings.append(
+                IdentityWarning(
+                    kind="label_moved_machine",
+                    message=(
+                        f"Host label '{label}' previously identified machine "
+                        f"'{previous_id}' but now identifies '{machine_id}'. If "
+                        f"intended, resolve it explicitly; otherwise the label "
+                        f"may be pointed at the wrong hardware."
+                    ),
+                )
             )
-        )
 
-    previous_label = ledger["id_to_label"].get(machine_id)
-    if previous_label is not None and previous_label != label:
-        warnings.append(
-            IdentityWarning(
-                kind="machine_renamed",
-                message=(
-                    f"Machine '{machine_id}' was previously labelled "
-                    f"'{previous_label}' and is now labelled '{label}'. Rows from "
-                    f"both labels belong to one machine."
-                ),
+        previous_label = ledger["id_to_label"].get(machine_id)
+        if previous_label is not None and previous_label != label:
+            warnings.append(
+                IdentityWarning(
+                    kind="machine_renamed",
+                    message=(
+                        f"Machine '{machine_id}' was previously labelled "
+                        f"'{previous_label}' and is now labelled '{label}'. Rows "
+                        f"under both labels belong to one machine."
+                    ),
+                )
             )
-        )
 
-    if not warnings:
-        record_observation(label, machine_id, path)
+        if warnings:
+            ledger["conflicts"][label] = {
+                "observed": machine_id,
+                "expected": previous_id,
+            }
+        else:
+            _bind(ledger, label, machine_id)
+        _save(path, ledger)
     return warnings

--- a/src/hermia/identity/crosscheck.py
+++ b/src/hermia/identity/crosscheck.py
@@ -121,6 +121,31 @@ def _save(path: Path, data: _Ledger) -> None:
 
 
 def _bind(ledger: _Ledger, label: str, machine_id: str) -> None:
+    """Bind label<->machine, REMOVING whatever each side displaced.
+
+    The two indexes must stay mutually consistent. Writing only the new pair
+    leaves the old inverse entry behind, so the ledger simultaneously claims
+    `label -> new_id` and `old_id -> label`. A later sighting of old_id under a
+    different name then fires `machine_renamed` citing a binding that no longer
+    exists — a warning about nothing, which is how operators learn to ignore
+    warnings.
+    """
+    displaced_id = ledger["label_to_id"].get(label)
+    if (
+        displaced_id is not None
+        and displaced_id != machine_id
+        and ledger["id_to_label"].get(displaced_id) == label
+    ):
+        del ledger["id_to_label"][displaced_id]
+
+    displaced_label = ledger["id_to_label"].get(machine_id)
+    if (
+        displaced_label is not None
+        and displaced_label != label
+        and ledger["label_to_id"].get(displaced_label) == machine_id
+    ):
+        del ledger["label_to_id"][displaced_label]
+
     ledger["label_to_id"][label] = machine_id
     ledger["id_to_label"][machine_id] = label
     ledger["conflicts"].pop(label, None)
@@ -172,6 +197,12 @@ def check_identity_consistency(
     self-bootstrapping. A CONFLICTING pairing is recorded as a conflict and keeps
     warning on every run until ``resolve_conflict`` is called — never silently
     absorbed on the second run, and never permanently stuck either.
+
+    An OPEN conflict keeps warning even once the original pairing reappears. A
+    box swapped in for one run and swapped back out would otherwise clear itself
+    on the next run, leaving no trace that anything moved — which is precisely
+    the silent absorption this exists to prevent. Only ``resolve_conflict``
+    closes it.
     """
     if machine_id is None:
         return []
@@ -208,11 +239,27 @@ def check_identity_consistency(
                 )
             )
 
+        open_conflict = ledger["conflicts"].get(label)
         if warnings:
             ledger["conflicts"][label] = {
                 "observed": machine_id,
                 "expected": previous_id,
             }
+        elif isinstance(open_conflict, dict):
+            # Pairing looks fine again, but nobody adjudicated the earlier
+            # disagreement. Keep reporting it; do NOT rebind.
+            warnings.append(
+                IdentityWarning(
+                    kind="unresolved_conflict",
+                    message=(
+                        f"Host label '{label}' currently identifies "
+                        f"'{machine_id}', but an earlier disagreement on this "
+                        f"label (observed '{open_conflict.get('observed')}') "
+                        f"was never resolved. Resolve it explicitly to clear "
+                        f"this warning."
+                    ),
+                )
+            )
         else:
             _bind(ledger, label, machine_id)
         _save(path, ledger)

--- a/src/hermia/identity/derive.py
+++ b/src/hermia/identity/derive.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import json
 
+from hermia.identity.salt import SALT_BYTES, SaltInfo
 from hermia.identity.types import MachineIdentifiers, MachineIdentity
 
 ID_HEX_CHARS = 16
@@ -38,7 +39,7 @@ def select_source(identifiers: MachineIdentifiers) -> tuple[str, tuple[str, ...]
 
 
 def derive_machine_id(
-    identifiers: MachineIdentifiers, salt: bytes
+    identifiers: MachineIdentifiers, salt: bytes | SaltInfo
 ) -> MachineIdentity:
     """Derive an exact, salted machine id from non-transferable identifiers.
 
@@ -49,10 +50,28 @@ def derive_machine_id(
     known" is the safer failure — a null is visible, a wrong id is not.
 
     Only the derived digest is returned: never the salt, never a raw identifier.
+
+    Raises ``ValueError`` on a salt that is not exactly ``SALT_BYTES`` long. A
+    short or empty salt is a caller bug, not a measurement gap: HMAC accepts it
+    happily and returns a confident-looking id whose small keyspace makes the
+    underlying hardware identifier confirmable by brute force — defeating the
+    only thing the salt is there to do. It must fail loudly rather than return
+    a null that reads like "this machine could not be identified".
     """
+    scope = "unspecified"
+    if isinstance(salt, SaltInfo):
+        scope, salt = salt.scope, salt.salt
+    if not isinstance(salt, bytes) or len(salt) != SALT_BYTES:
+        raise ValueError(
+            f"salt must be exactly {SALT_BYTES} bytes; got "
+            f"{len(salt) if isinstance(salt, bytes) else type(salt).__name__}"
+        )
+
     selected = select_source(identifiers)
     if selected is None:
-        return MachineIdentity(None, "none", "unavailable:no-usable-identifier")
+        return MachineIdentity(
+            None, "none", "unavailable:no-usable-identifier", scope
+        )
 
     source, fields = selected
     usable = identifiers.usable
@@ -62,4 +81,6 @@ def derive_machine_id(
         separators=(",", ":"),
     )
     digest = hmac.new(salt, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
-    return MachineIdentity(digest[:ID_HEX_CHARS], source, f"measured:{source}")
+    return MachineIdentity(
+        digest[:ID_HEX_CHARS], source, f"measured:{source}", scope
+    )

--- a/src/hermia/identity/derive.py
+++ b/src/hermia/identity/derive.py
@@ -81,6 +81,13 @@ def derive_machine_id(
         separators=(",", ":"),
     )
     digest = hmac.new(salt, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    # Name the weakness IN the basis: the basis is what gets written down and
+    # read later, long after the object with its properties is gone.
+    suffix = (
+        " (transferable: a disk clone reproduces this id)"
+        if source in MachineIdentity.TRANSFERABLE_SOURCES
+        else ""
+    )
     return MachineIdentity(
-        digest[:ID_HEX_CHARS], source, f"measured:{source}", scope
+        digest[:ID_HEX_CHARS], source, f"measured:{source}{suffix}", scope
     )

--- a/src/hermia/identity/derive.py
+++ b/src/hermia/identity/derive.py
@@ -1,42 +1,65 @@
-"""Hardware facts + salt -> machine_id (hermia-cfqv). Pure function, no I/O."""
+"""Identifiers + salt -> machine_id (hermia-cfqv). Pure function, no I/O.
+
+Exact match on a strict preference order. No weighting, no threshold, no fuzzy
+comparison — see types.py for why that approach was removed rather than tuned.
+
+Capabilities are NEVER an input here. That is what makes a RAM upgrade a recorded
+fact instead of a new machine.
+"""
 from __future__ import annotations
 
 import hashlib
 import hmac
 import json
 
-from hermia.identity.types import HardwareFacts, MachineIdentity
+from hermia.identity.types import MachineIdentifiers, MachineIdentity
 
 ID_HEX_CHARS = 16
 
+# Strongest first. Both firmware values together beat either alone: vendors have
+# shipped batches with duplicate SMBIOS UUIDs, and a serial alone is weaker still.
+# The minted token ranks last because it lives on disk, so a cloned image carries
+# it to another machine.
+PREFERENCE: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("firmware-uuid+serial", ("firmware_uuid", "hardware_serial")),
+    ("firmware-uuid", ("firmware_uuid",)),
+    ("hardware-serial", ("hardware_serial",)),
+    ("persisted-token", ("persisted_token",)),
+)
 
-def derive_machine_id(facts: HardwareFacts, salt: bytes) -> MachineIdentity:
-    """Derive a salted, locally-unique machine id.
 
-    Returns ``machine_id=None`` with an explanatory ``basis`` whenever the
-    machine-bound identifier is missing. There is deliberately no partial or
-    fallback identity: a hash of CPU + RAM alone would collide across identical
-    laptops (identical laptop models are common in a fleet), and two
-    machines sharing an identity is precisely the defect this prevents.
-    Admitting "not known" is the safer failure.
+def select_source(identifiers: MachineIdentifiers) -> tuple[str, tuple[str, ...]] | None:
+    """Return the strongest available (source_name, fields), or None."""
+    usable = identifiers.usable
+    for source, fields in PREFERENCE:
+        if all(f in usable for f in fields):
+            return source, fields
+    return None
 
-    Only the derived digest is returned — never the salt, never a raw hardware
-    identifier.
+
+def derive_machine_id(
+    identifiers: MachineIdentifiers, salt: bytes
+) -> MachineIdentity:
+    """Derive an exact, salted machine id from non-transferable identifiers.
+
+    Returns ``machine_id=None`` with an explanatory ``basis`` when no usable
+    identifier exists. There is deliberately no partial identity: a value built
+    from CPU and memory would collide across identical laptops, and two machines
+    sharing an identity is exactly the defect this prevents. Admitting "not
+    known" is the safer failure — a null is visible, a wrong id is not.
+
+    Only the derived digest is returned: never the salt, never a raw identifier.
     """
-    if not facts.is_identifiable:
-        return MachineIdentity(None, "unavailable:no-platform-uuid", facts.os_family)
+    selected = select_source(identifiers)
+    if selected is None:
+        return MachineIdentity(None, "none", "unavailable:no-usable-identifier")
 
+    source, fields = selected
+    usable = identifiers.usable
     canonical = json.dumps(
-        {
-            "platform_uuid": facts.platform_uuid,
-            "cpu_brand": facts.cpu_brand,
-            "ram_bytes": facts.ram_bytes,
-            "os_family": facts.os_family,
-        },
+        {"source": source, **{f: usable[f] for f in fields}},
         sort_keys=True,
         separators=(",", ":"),
     )
     digest = hmac.new(salt, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
-    return MachineIdentity(
-        digest[:ID_HEX_CHARS], "measured:platform-uuid+cpu+ram", facts.os_family
-    )
+    return MachineIdentity(digest[:ID_HEX_CHARS], source, f"measured:{source}")

--- a/src/hermia/identity/derive.py
+++ b/src/hermia/identity/derive.py
@@ -1,0 +1,42 @@
+"""Hardware facts + salt -> machine_id (hermia-cfqv). Pure function, no I/O."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from hermia.identity.types import HardwareFacts, MachineIdentity
+
+ID_HEX_CHARS = 16
+
+
+def derive_machine_id(facts: HardwareFacts, salt: bytes) -> MachineIdentity:
+    """Derive a salted, locally-unique machine id.
+
+    Returns ``machine_id=None`` with an explanatory ``basis`` whenever the
+    machine-bound identifier is missing. There is deliberately no partial or
+    fallback identity: a hash of CPU + RAM alone would collide across identical
+    laptops (identical laptop models are common in a fleet), and two
+    machines sharing an identity is precisely the defect this prevents.
+    Admitting "not known" is the safer failure.
+
+    Only the derived digest is returned — never the salt, never a raw hardware
+    identifier.
+    """
+    if not facts.is_identifiable:
+        return MachineIdentity(None, "unavailable:no-platform-uuid", facts.os_family)
+
+    canonical = json.dumps(
+        {
+            "platform_uuid": facts.platform_uuid,
+            "cpu_brand": facts.cpu_brand,
+            "ram_bytes": facts.ram_bytes,
+            "os_family": facts.os_family,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hmac.new(salt, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    return MachineIdentity(
+        digest[:ID_HEX_CHARS], "measured:platform-uuid+cpu+ram", facts.os_family
+    )

--- a/src/hermia/identity/probes.py
+++ b/src/hermia/identity/probes.py
@@ -111,6 +111,23 @@ def _reg_value(output: str | None, name: str) -> str | None:
     return None
 
 
+def _cim(class_name: str, prop: str) -> str | None:
+    """Read one CIM property via PowerShell.
+
+    Preferred over `wmic`, which is removed by default from Windows 11 24H2 and
+    slated for full removal. When wmic vanishes the firmware UUID and board
+    serial vanish with it, and identity silently drops to the cloneable
+    MachineGuid — a downgrade with no outward sign, which is the exact class of
+    failure this package exists to stop.
+    """
+    return _clean(
+        _run([
+            "powershell", "-NoProfile", "-NonInteractive", "-Command",
+            f"(Get-CimInstance -ClassName {class_name}).{prop}",
+        ])
+    )
+
+
 def _wmic_value(output: str | None) -> str | None:
     """First non-header, non-blank line of `wmic ... get X` output."""
     if not output:
@@ -243,13 +260,15 @@ class LocalProbe:
         )
 
     def _windows(self) -> tuple[MachineIdentifiers, MachineCapabilities]:
-        model = _wmic_value(_run(["wmic", "csproduct", "get", "Name"]))
+        model = _cim("Win32_ComputerSystemProduct", "Name") or _wmic_value(
+            _run(["wmic", "csproduct", "get", "Name"])
+        )
         return (
             MachineIdentifiers(
-                firmware_uuid=_wmic_value(_run(["wmic", "csproduct", "get", "UUID"])),
-                hardware_serial=_wmic_value(
-                    _run(["wmic", "baseboard", "get", "SerialNumber"])
-                ),
+                firmware_uuid=_cim("Win32_ComputerSystemProduct", "UUID")
+                or _wmic_value(_run(["wmic", "csproduct", "get", "UUID"])),
+                hardware_serial=_cim("Win32_BaseBoard", "SerialNumber")
+                or _wmic_value(_run(["wmic", "baseboard", "get", "SerialNumber"])),
                 persisted_token=_reg_value(
                     _run(
                         [
@@ -267,7 +286,8 @@ class LocalProbe:
                 cpu_brand=_clean(os.environ.get("PROCESSOR_IDENTIFIER")),
                 logical_cores=_to_int(os.environ.get("NUMBER_OF_PROCESSORS")),
                 ram_bytes=_to_int(
-                    _wmic_value(
+                    _cim("Win32_ComputerSystem", "TotalPhysicalMemory")
+                    or _wmic_value(
                         _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
                     )
                 ),

--- a/src/hermia/identity/probes.py
+++ b/src/hermia/identity/probes.py
@@ -1,0 +1,204 @@
+"""Cross-platform local hardware probe (hermia-cfqv).
+
+Measures the machine hermia is running ON. Remote probes (SSH, agent) implement
+the same ``HardwareProbe`` Protocol later and are deliberately absent here.
+
+Every measurement that fails yields ``None`` and records the field name in
+``unavailable``. There is no default, no zero, no empty string standing in for a
+real value: a ``ram_bytes`` of 0 would read as a genuine measurement of a
+0-byte machine, and a guessed identity is worse than an admitted gap.
+
+No MAC address or other network identifier is collected anywhere in this module.
+DHCP reservations are commonly bound to detachable USB/Thunderbolt adapters
+or a dock, so a MAC-derived identity follows the accessory rather
+than the computer — the exact defect this package exists to end.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hermia.identity.types import HardwareFacts
+
+_TIMEOUT_SEC = 5
+
+
+def _run(cmd: list[str], **kwargs: Any) -> str | None:
+    """Run a read-only command; return stripped stdout, or None on any failure."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_TIMEOUT_SEC,
+            check=False,
+            **kwargs,
+        )
+    except Exception:  # noqa: BLE001 - probing must never raise
+        return None
+    if result.returncode != 0:
+        return None
+    out: str = result.stdout
+    return out.strip()
+
+
+def _read_text(path: str | Path) -> str | None:
+    """Read a file; return stripped contents, or None on any failure."""
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except Exception:  # noqa: BLE001 - probing must never raise
+        return None
+
+
+def _clean(value: str | None) -> str | None:
+    """Normalise a measured string: blank or missing means NOT MEASURED."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _to_int(value: str | None) -> int | None:
+    """Parse a positive integer; anything else means NOT MEASURED."""
+    if value is None:
+        return None
+    try:
+        parsed = int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _macos_uuid(ioreg_output: str | None) -> str | None:
+    if not ioreg_output:
+        return None
+    for line in ioreg_output.splitlines():
+        if '"IOPlatformUUID"' not in line:
+            continue
+        _, _, rhs = line.partition("=")
+        return _clean(rhs.strip().strip('"'))
+    return None
+
+
+def _linux_cpu_brand(cpuinfo: str | None) -> str | None:
+    if not cpuinfo:
+        return None
+    for line in cpuinfo.splitlines():
+        if line.startswith("model name"):
+            return _clean(line.split(":", 1)[1] if ":" in line else None)
+    return None
+
+
+def _linux_ram_bytes(meminfo: str | None) -> int | None:
+    if not meminfo:
+        return None
+    for line in meminfo.splitlines():
+        if line.startswith("MemTotal:"):
+            parts = line.split()
+            kb = _to_int(parts[1]) if len(parts) > 1 else None
+            return kb * 1024 if kb is not None else None
+    return None
+
+
+def _windows_uuid(reg_output: str | None) -> str | None:
+    """Extract MachineGuid from `reg query` output.
+
+    The value token must be the FOURTH-onward field: `reg query` prints
+    ``<name> <type> <value>``, so an EMPTY value leaves only two tokens and a
+    naive ``parts[-1]`` returns the literal type name ``REG_SZ``. That would be
+    accepted downstream as a measured hardware id, giving every affected
+    Windows box the same uuid component — a fabricated identity, which is far
+    worse than admitting the value is missing.
+    """
+    if not reg_output:
+        return None
+    for line in reg_output.splitlines():
+        if "MachineGuid" not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            return None
+        value = _clean(parts[-1])
+        if value is None or value.upper().startswith("REG_"):
+            return None
+        return value
+    return None
+
+
+def _windows_ram_bytes(wmic_output: str | None) -> int | None:
+    if not wmic_output:
+        return None
+    for line in wmic_output.splitlines():
+        candidate = line.strip()
+        if candidate.isdigit():
+            return _to_int(candidate)
+    return None
+
+
+class LocalProbe:
+    """Measures the machine this process is running on."""
+
+    def __init__(self, os_family: str | None = None) -> None:
+        # platform.system().lower() -> "darwin" | "linux" | "windows".
+        # NOT os.name, which returns "posix" on both macOS and Linux and would
+        # therefore match no branch at all, silently probing nothing everywhere.
+        self.os_family = os_family or platform.system().lower()
+
+    def probe(self) -> HardwareFacts:
+        platform_uuid: str | None = None
+        cpu_brand: str | None = None
+        ram_bytes: int | None = None
+
+        if self.os_family == "darwin":
+            platform_uuid = _macos_uuid(
+                _run(["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"])
+            )
+            cpu_brand = _clean(_run(["sysctl", "-n", "machdep.cpu.brand_string"]))
+            ram_bytes = _to_int(_run(["sysctl", "-n", "hw.memsize"]))
+
+        elif self.os_family == "linux":
+            platform_uuid = _clean(_read_text("/etc/machine-id")) or _clean(
+                _read_text("/sys/class/dmi/id/product_uuid")
+            )
+            cpu_brand = _linux_cpu_brand(_read_text("/proc/cpuinfo"))
+            ram_bytes = _linux_ram_bytes(_read_text("/proc/meminfo"))
+
+        elif self.os_family == "windows":
+            platform_uuid = _windows_uuid(
+                _run(
+                    [
+                        "reg",
+                        "query",
+                        r"HKLM\SOFTWARE\Microsoft\Cryptography",  # pragma: allowlist secret
+                        "/v",
+                        "MachineGuid",
+                    ]
+                )
+            )
+            cpu_brand = _clean(os.environ.get("PROCESSOR_IDENTIFIER"))
+            ram_bytes = _windows_ram_bytes(
+                _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
+            )
+
+        # Any other os_family: everything stays None. Not an error, just unknown.
+
+        unavailable = tuple(
+            name
+            for name, value in (
+                ("platform_uuid", platform_uuid),
+                ("cpu_brand", cpu_brand),
+                ("ram_bytes", ram_bytes),
+            )
+            if value is None
+        )
+        return HardwareFacts(
+            platform_uuid=platform_uuid,
+            cpu_brand=cpu_brand,
+            ram_bytes=ram_bytes,
+            os_family=self.os_family,
+            unavailable=unavailable,
+        )

--- a/src/hermia/identity/probes.py
+++ b/src/hermia/identity/probes.py
@@ -1,29 +1,38 @@
 """Cross-platform local hardware probe (hermia-cfqv).
 
-Measures the machine hermia is running ON. Remote probes (SSH, agent) implement
-the same ``HardwareProbe`` Protocol later and are deliberately absent here.
+Measures the machine hermia is running ON, returning identifiers and capabilities
+as two separate things (see types.py for why that split is the whole design).
 
 Every measurement that fails yields ``None`` and records the field name in
-``unavailable``. There is no default, no zero, no empty string standing in for a
-real value: a ``ram_bytes`` of 0 would read as a genuine measurement of a
-0-byte machine, and a guessed identity is worse than an admitted gap.
+``unavailable``. No default, no zero, no empty string standing in for a value: a
+``ram_bytes`` of 0 would read as a genuine measurement of a 0-byte machine.
 
-No MAC address or other network identifier is collected anywhere in this module.
-DHCP reservations are commonly bound to detachable USB/Thunderbolt adapters
-or a dock, so a MAC-derived identity follows the accessory rather
-than the computer — the exact defect this package exists to end.
+Identifier ordering is strongest-first on every platform. An earlier version read
+Linux ``/etc/machine-id`` first and never fell through to the firmware UUID,
+silently preferring the weakest identifier available; and on Windows read only
+``MachineGuid``, never touching the firmware UUID at all. Both are fixed here.
+``/etc/machine-id`` and ``MachineGuid`` are OS-install ids, so they are reported
+as ``persisted_token`` — the weakest tier — because a reinstall resets them and a
+cloned disk image duplicates them.
 """
 from __future__ import annotations
 
 import os
 import platform
+import re
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any
 
-from hermia.identity.types import HardwareFacts
+from hermia.identity.types import (
+    MachineCapabilities,
+    MachineIdentifiers,
+    MachineObservation,
+)
 
 _TIMEOUT_SEC = 5
+_VIRTUAL_HINTS = ("vmware", "virtualbox", "kvm", "qemu", "xen", "hyper-v", "parallels")
 
 
 def _run(cmd: list[str], **kwargs: Any) -> str | None:
@@ -55,15 +64,12 @@ def _read_text(path: str | Path) -> str | None:
 
 
 def _clean(value: str | None) -> str | None:
-    """Normalise a measured string: blank or missing means NOT MEASURED."""
     if value is None:
         return None
-    stripped = value.strip()
-    return stripped or None
+    return value.strip() or None
 
 
 def _to_int(value: str | None) -> int | None:
-    """Parse a positive integer; anything else means NOT MEASURED."""
     if value is None:
         return None
     try:
@@ -73,51 +79,27 @@ def _to_int(value: str | None) -> int | None:
     return parsed if parsed > 0 else None
 
 
-def _macos_uuid(ioreg_output: str | None) -> str | None:
-    if not ioreg_output:
+def _ioreg_field(output: str | None, key: str) -> str | None:
+    if not output:
         return None
-    for line in ioreg_output.splitlines():
-        if '"IOPlatformUUID"' not in line:
-            continue
-        _, _, rhs = line.partition("=")
-        return _clean(rhs.strip().strip('"'))
+    for line in output.splitlines():
+        if f'"{key}"' in line:
+            _, _, rhs = line.partition("=")
+            return _clean(rhs.strip().strip('"'))
     return None
 
 
-def _linux_cpu_brand(cpuinfo: str | None) -> str | None:
-    if not cpuinfo:
-        return None
-    for line in cpuinfo.splitlines():
-        if line.startswith("model name"):
-            return _clean(line.split(":", 1)[1] if ":" in line else None)
-    return None
+def _reg_value(output: str | None, name: str) -> str | None:
+    """Last token of a `reg query` line, rejecting the type token.
 
-
-def _linux_ram_bytes(meminfo: str | None) -> int | None:
-    if not meminfo:
-        return None
-    for line in meminfo.splitlines():
-        if line.startswith("MemTotal:"):
-            parts = line.split()
-            kb = _to_int(parts[1]) if len(parts) > 1 else None
-            return kb * 1024 if kb is not None else None
-    return None
-
-
-def _windows_uuid(reg_output: str | None) -> str | None:
-    """Extract MachineGuid from `reg query` output.
-
-    The value token must be the FOURTH-onward field: `reg query` prints
-    ``<name> <type> <value>``, so an EMPTY value leaves only two tokens and a
-    naive ``parts[-1]`` returns the literal type name ``REG_SZ``. That would be
-    accepted downstream as a measured hardware id, giving every affected
-    Windows box the same uuid component — a fabricated identity, which is far
-    worse than admitting the value is missing.
+    `reg query` prints ``<name> <type> <value>``; an EMPTY value leaves only two
+    tokens, so a naive last-token read returns the literal ``REG_SZ`` and every
+    affected box would share that as an identifier.
     """
-    if not reg_output:
+    if not output:
         return None
-    for line in reg_output.splitlines():
-        if "MachineGuid" not in line:
+    for line in output.splitlines():
+        if name not in line:
             continue
         parts = line.split()
         if len(parts) < 3:
@@ -129,14 +111,63 @@ def _windows_uuid(reg_output: str | None) -> str | None:
     return None
 
 
-def _windows_ram_bytes(wmic_output: str | None) -> int | None:
-    if not wmic_output:
+def _wmic_value(output: str | None) -> str | None:
+    """First non-header, non-blank line of `wmic ... get X` output."""
+    if not output:
         return None
-    for line in wmic_output.splitlines():
-        candidate = line.strip()
-        if candidate.isdigit():
-            return _to_int(candidate)
+    for line in output.splitlines()[1:]:
+        value = _clean(line)
+        if value:
+            return value
     return None
+
+
+def _proc_field(text: str | None, prefix: str) -> str | None:
+    if not text:
+        return None
+    for line in text.splitlines():
+        if line.startswith(prefix) and ":" in line:
+            return _clean(line.split(":", 1)[1])
+    return None
+
+
+def _meminfo_bytes(meminfo: str | None) -> int | None:
+    """MemTotal in bytes.
+
+    NOTE: MemTotal is kernel-visible memory, not installed DIMM capacity — it
+    drifts with kernel updates, crashkernel reservations and driver allocations.
+    That is tolerable ONLY because this is a capability. It must never feed an
+    identity, or a routine kernel update would look like a hardware swap.
+    """
+    if not meminfo:
+        return None
+    for line in meminfo.splitlines():
+        if line.startswith("MemTotal:"):
+            parts = line.split()
+            kb = _to_int(parts[1]) if len(parts) > 1 else None
+            return kb * 1024 if kb is not None else None
+    return None
+
+
+def _primary_mac() -> str | None:
+    """A MAC address, recorded as a CAPABILITY only.
+
+    Never an identifier: reservations here are bound to detachable adapters and a
+    dock, so this value follows the accessory. Recording it lets an operator see
+    that a dock moved; it must never decide which machine answered.
+    """
+    node = uuid.getnode()
+    # Bit 41 set means the value was randomly generated, not read from hardware.
+    if (node >> 40) & 0x1:
+        return None
+    return ":".join(f"{(node >> shift) & 0xFF:02x}" for shift in range(40, -8, -8))
+
+
+def _looks_virtual(*values: str | None) -> bool | None:
+    joined = " ".join(v.lower() for v in values if v)
+    if not joined:
+        return None
+    return any(hint in joined for hint in _VIRTUAL_HINTS)
 
 
 class LocalProbe:
@@ -144,61 +175,149 @@ class LocalProbe:
 
     def __init__(self, os_family: str | None = None) -> None:
         # platform.system().lower() -> "darwin" | "linux" | "windows".
-        # NOT os.name, which returns "posix" on both macOS and Linux and would
-        # therefore match no branch at all, silently probing nothing everywhere.
+        # NOT os.name, which returns "posix" on macOS AND Linux and would match
+        # no branch at all, silently probing nothing on every platform.
         self.os_family = os_family or platform.system().lower()
 
-    def probe(self) -> HardwareFacts:
-        platform_uuid: str | None = None
-        cpu_brand: str | None = None
-        ram_bytes: int | None = None
-
+    def probe(self) -> MachineObservation:
         if self.os_family == "darwin":
-            platform_uuid = _macos_uuid(
-                _run(["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"])
-            )
-            cpu_brand = _clean(_run(["sysctl", "-n", "machdep.cpu.brand_string"]))
-            ram_bytes = _to_int(_run(["sysctl", "-n", "hw.memsize"]))
-
+            ident, caps = self._darwin()
         elif self.os_family == "linux":
-            platform_uuid = _clean(_read_text("/etc/machine-id")) or _clean(
-                _read_text("/sys/class/dmi/id/product_uuid")
-            )
-            cpu_brand = _linux_cpu_brand(_read_text("/proc/cpuinfo"))
-            ram_bytes = _linux_ram_bytes(_read_text("/proc/meminfo"))
-
+            ident, caps = self._linux()
         elif self.os_family == "windows":
-            platform_uuid = _windows_uuid(
-                _run(
-                    [
-                        "reg",
-                        "query",
-                        r"HKLM\SOFTWARE\Microsoft\Cryptography",  # pragma: allowlist secret
-                        "/v",
-                        "MachineGuid",
-                    ]
-                )
+            ident, caps = self._windows()
+        else:
+            ident, caps = MachineIdentifiers(), MachineCapabilities(
+                os_family=self.os_family
             )
-            cpu_brand = _clean(os.environ.get("PROCESSOR_IDENTIFIER"))
-            ram_bytes = _windows_ram_bytes(
-                _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
-            )
-
-        # Any other os_family: everything stays None. Not an error, just unknown.
-
-        unavailable = tuple(
-            name
-            for name, value in (
-                ("platform_uuid", platform_uuid),
-                ("cpu_brand", cpu_brand),
-                ("ram_bytes", ram_bytes),
-            )
-            if value is None
+        return MachineObservation(
+            identifiers=_mark_identifiers(ident), capabilities=_mark_caps(caps)
         )
-        return HardwareFacts(
-            platform_uuid=platform_uuid,
-            cpu_brand=cpu_brand,
-            ram_bytes=ram_bytes,
-            os_family=self.os_family,
-            unavailable=unavailable,
+
+    def _darwin(self) -> tuple[MachineIdentifiers, MachineCapabilities]:
+        ioreg = _run(["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"])
+        model = _clean(_run(["sysctl", "-n", "hw.model"]))
+        return (
+            MachineIdentifiers(
+                firmware_uuid=_ioreg_field(ioreg, "IOPlatformUUID"),
+                hardware_serial=_ioreg_field(ioreg, "IOPlatformSerialNumber"),
+            ),
+            MachineCapabilities(
+                cpu_brand=_clean(_run(["sysctl", "-n", "machdep.cpu.brand_string"])),
+                logical_cores=_to_int(_run(["sysctl", "-n", "hw.logicalcpu"])),
+                ram_bytes=_to_int(_run(["sysctl", "-n", "hw.memsize"])),
+                model_identifier=model,
+                os_family="darwin",
+                os_version=_clean(_run(["sw_vers", "-productVersion"])),
+                nic_mac=_primary_mac(),
+                is_virtual=_looks_virtual(model),
+            ),
         )
+
+    def _linux(self) -> tuple[MachineIdentifiers, MachineCapabilities]:
+        # Firmware root FIRST. These are often mode 0400 (root only); when they
+        # are unreadable the result is None and we fall through to the weak
+        # persisted token, which is recorded AS such rather than promoted.
+        product_name = _clean(_read_text("/sys/class/dmi/id/product_name"))
+        cpuinfo = _read_text("/proc/cpuinfo")
+        cores = len(re.findall(r"^processor\s*:", cpuinfo, re.M)) if cpuinfo else 0
+        return (
+            MachineIdentifiers(
+                firmware_uuid=_clean(_read_text("/sys/class/dmi/id/product_uuid")),
+                hardware_serial=_clean(_read_text("/sys/class/dmi/id/board_serial"))
+                or _clean(_read_text("/sys/class/dmi/id/product_serial")),
+                persisted_token=_clean(_read_text("/etc/machine-id")),
+            ),
+            MachineCapabilities(
+                cpu_brand=_proc_field(cpuinfo, "model name"),
+                logical_cores=cores or None,
+                ram_bytes=_meminfo_bytes(_read_text("/proc/meminfo")),
+                model_identifier=product_name,
+                os_family="linux",
+                os_version=_clean(_run(["uname", "-r"])),
+                nic_mac=_primary_mac(),
+                is_virtual=_looks_virtual(
+                    product_name, _clean(_read_text("/sys/class/dmi/id/sys_vendor"))
+                ),
+            ),
+        )
+
+    def _windows(self) -> tuple[MachineIdentifiers, MachineCapabilities]:
+        model = _wmic_value(_run(["wmic", "csproduct", "get", "Name"]))
+        return (
+            MachineIdentifiers(
+                firmware_uuid=_wmic_value(_run(["wmic", "csproduct", "get", "UUID"])),
+                hardware_serial=_wmic_value(
+                    _run(["wmic", "baseboard", "get", "SerialNumber"])
+                ),
+                persisted_token=_reg_value(
+                    _run(
+                        [
+                            "reg",
+                            "query",
+                            r"HKLM\SOFTWARE\Microsoft\Cryptography",  # pragma: allowlist secret
+                            "/v",
+                            "MachineGuid",
+                        ]
+                    ),
+                    "MachineGuid",
+                ),
+            ),
+            MachineCapabilities(
+                cpu_brand=_clean(os.environ.get("PROCESSOR_IDENTIFIER")),
+                logical_cores=_to_int(os.environ.get("NUMBER_OF_PROCESSORS")),
+                ram_bytes=_to_int(
+                    _wmic_value(
+                        _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
+                    )
+                ),
+                model_identifier=model,
+                os_family="windows",
+                os_version=_clean(platform.version()),
+                nic_mac=_primary_mac(),
+                is_virtual=_looks_virtual(model),
+            ),
+        )
+
+
+def _mark_identifiers(ident: MachineIdentifiers) -> MachineIdentifiers:
+    missing = tuple(
+        name
+        for name, value in (
+            ("firmware_uuid", ident.firmware_uuid),
+            ("hardware_serial", ident.hardware_serial),
+            ("persisted_token", ident.persisted_token),
+        )
+        if value is None
+    )
+    return MachineIdentifiers(
+        firmware_uuid=ident.firmware_uuid,
+        hardware_serial=ident.hardware_serial,
+        persisted_token=ident.persisted_token,
+        unavailable=missing,
+    )
+
+
+def _mark_caps(caps: MachineCapabilities) -> MachineCapabilities:
+    missing = tuple(
+        name
+        for name, value in (
+            ("cpu_brand", caps.cpu_brand),
+            ("logical_cores", caps.logical_cores),
+            ("ram_bytes", caps.ram_bytes),
+            ("model_identifier", caps.model_identifier),
+            ("nic_mac", caps.nic_mac),
+        )
+        if value is None
+    )
+    return MachineCapabilities(
+        cpu_brand=caps.cpu_brand,
+        logical_cores=caps.logical_cores,
+        ram_bytes=caps.ram_bytes,
+        model_identifier=caps.model_identifier,
+        os_family=caps.os_family,
+        os_version=caps.os_version,
+        nic_mac=caps.nic_mac,
+        is_virtual=caps.is_virtual,
+        unavailable=missing,
+    )

--- a/src/hermia/identity/probes.py
+++ b/src/hermia/identity/probes.py
@@ -29,6 +29,7 @@ from hermia.identity.types import (
     MachineCapabilities,
     MachineIdentifiers,
     MachineObservation,
+    is_usable_identifier,
 )
 
 _TIMEOUT_SEC = 5
@@ -69,6 +70,21 @@ def _clean(value: str | None) -> str | None:
     return value.strip() or None
 
 
+def _first_usable(*values: str | None) -> str | None:
+    """First value that is present AND not a vendor placeholder.
+
+    A plain `a or b` fallback is wrong here: DMI board_serial is frequently the
+    non-empty string "None" or "Default string", which is truthy, so it masks a
+    perfectly good product_serial. The placeholder is discarded later, leaving
+    NO serial at all — and the machine's id silently changes depending on which
+    of the two files happened to be readable on a given run.
+    """
+    for value in values:
+        if is_usable_identifier(value):
+            return _clean(value)
+    return None
+
+
 def _to_int(value: str | None) -> int | None:
     if value is None:
         return None
@@ -103,7 +119,9 @@ def _reg_value(output: str | None, name: str) -> str | None:
             continue
         parts = line.split()
         if len(parts) < 3:
-            return None
+            # A path header can also contain the value name. Keep scanning
+            # rather than aborting, or the real line below is never reached.
+            continue
         value = _clean(parts[-1])
         if value is None or value.upper().startswith("REG_"):
             return None
@@ -111,21 +129,43 @@ def _reg_value(output: str | None, name: str) -> str | None:
     return None
 
 
-def _cim(class_name: str, prop: str) -> str | None:
-    """Read one CIM property via PowerShell.
+_CIM_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("uuid", "Win32_ComputerSystemProduct", "UUID"),
+    ("name", "Win32_ComputerSystemProduct", "Name"),
+    ("serial", "Win32_BaseBoard", "SerialNumber"),
+    ("ram", "Win32_ComputerSystem", "TotalPhysicalMemory"),
+)
+_CIM_TIMEOUT_SEC = 45
 
-    Preferred over `wmic`, which is removed by default from Windows 11 24H2 and
-    slated for full removal. When wmic vanishes the firmware UUID and board
-    serial vanish with it, and identity silently drops to the cloneable
-    MachineGuid — a downgrade with no outward sign, which is the exact class of
-    failure this package exists to stop.
+
+def _cim_all() -> dict[str, str | None]:
+    """Read every needed CIM property in ONE PowerShell invocation.
+
+    Preferred over `wmic`, which is removed by default from Windows 11 24H2.
+    When wmic vanishes the firmware UUID and board serial vanish with it and
+    identity silently drops to the cloneable MachineGuid — a downgrade with no
+    outward sign.
+
+    One invocation, not four: PowerShell cold-starts in seconds, so four
+    sequential calls against the default 5s timeout would intermittently drop
+    whichever property happened to be slow. Losing just the UUID silently
+    demotes the machine to a weaker identifier and makes its id flap between
+    runs, which looks exactly like hardware being swapped.
     """
-    return _clean(
-        _run([
-            "powershell", "-NoProfile", "-NonInteractive", "-Command",
-            f"(Get-CimInstance -ClassName {class_name}).{prop}",
-        ])
+    script = "; ".join(
+        f'"{key}=" + [string](Get-CimInstance -ClassName {cls}).{prop}'
+        for key, cls, prop in _CIM_FIELDS
     )
+    out = _run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        timeout=_CIM_TIMEOUT_SEC,
+    )
+    parsed: dict[str, str | None] = {key: None for key, _, _ in _CIM_FIELDS}
+    for line in (out or "").splitlines():
+        key, sep, value = line.partition("=")
+        if sep and key.strip() in parsed:
+            parsed[key.strip()] = _clean(value)
+    return parsed
 
 
 def _wmic_value(output: str | None) -> str | None:
@@ -241,8 +281,10 @@ class LocalProbe:
         return (
             MachineIdentifiers(
                 firmware_uuid=_clean(_read_text("/sys/class/dmi/id/product_uuid")),
-                hardware_serial=_clean(_read_text("/sys/class/dmi/id/board_serial"))
-                or _clean(_read_text("/sys/class/dmi/id/product_serial")),
+                hardware_serial=_first_usable(
+                    _read_text("/sys/class/dmi/id/board_serial"),
+                    _read_text("/sys/class/dmi/id/product_serial"),
+                ),
                 persisted_token=_clean(_read_text("/etc/machine-id")),
             ),
             MachineCapabilities(
@@ -260,15 +302,18 @@ class LocalProbe:
         )
 
     def _windows(self) -> tuple[MachineIdentifiers, MachineCapabilities]:
-        model = _cim("Win32_ComputerSystemProduct", "Name") or _wmic_value(
-            _run(["wmic", "csproduct", "get", "Name"])
-        )
+        cim = _cim_all()
+        model = cim["name"] or _wmic_value(_run(["wmic", "csproduct", "get", "Name"]))
         return (
             MachineIdentifiers(
-                firmware_uuid=_cim("Win32_ComputerSystemProduct", "UUID")
-                or _wmic_value(_run(["wmic", "csproduct", "get", "UUID"])),
-                hardware_serial=_cim("Win32_BaseBoard", "SerialNumber")
-                or _wmic_value(_run(["wmic", "baseboard", "get", "SerialNumber"])),
+                firmware_uuid=_first_usable(
+                    cim["uuid"],
+                    _wmic_value(_run(["wmic", "csproduct", "get", "UUID"])),
+                ),
+                hardware_serial=_first_usable(
+                    cim["serial"],
+                    _wmic_value(_run(["wmic", "baseboard", "get", "SerialNumber"])),
+                ),
                 persisted_token=_reg_value(
                     _run(
                         [
@@ -286,7 +331,7 @@ class LocalProbe:
                 cpu_brand=_clean(os.environ.get("PROCESSOR_IDENTIFIER")),
                 logical_cores=_to_int(os.environ.get("NUMBER_OF_PROCESSORS")),
                 ram_bytes=_to_int(
-                    _cim("Win32_ComputerSystem", "TotalPhysicalMemory")
+                    cim["ram"]
                     or _wmic_value(
                         _run(["wmic", "ComputerSystem", "get", "TotalPhysicalMemory"])
                     )

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -30,6 +30,7 @@ import hashlib
 import os
 import secrets
 import stat
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,20 +74,55 @@ def _read_salt(path: Path) -> bytes | None:
     return raw
 
 
-def _write_salt(path: Path, salt: bytes) -> None:
+def _write_salt(path: Path, salt: bytes) -> bytes:
+    """Create the salt file exclusively; return whichever salt actually won.
+
+    Two processes starting for the first time together would otherwise each mint
+    a salt and the second would overwrite the first, so ids derived either side
+    of that moment would silently disagree.
+
+    Write-then-link, not create-then-write: creating the destination with O_EXCL
+    and filling it afterwards still leaves a window where the losing racer opens
+    a file that exists but is EMPTY, reads nothing usable, and falls back to its
+    own salt — the very divergence this is meant to stop. Building the content
+    in a private temp file and linking it into place makes the destination
+    appear only once it is complete. os.link fails if the target exists, so the
+    first linker wins and everyone else reads the winner's value.
+    """
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Create with 0600 ALREADY SET rather than write-then-chmod: under a
         # normal 022 umask the latter leaves the secret readable by every local
         # process for the window between the two calls.
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         try:
             os.write(fd, salt.hex().encode("ascii"))
         finally:
             os.close(fd)
-        _harden(path)
     except OSError:
-        pass  # read-only home: ephemeral for this process, do not crash
+        return salt  # read-only home: ephemeral for this process, do not crash
+
+    try:
+        os.link(tmp, path)
+        _harden(path)
+        return salt
+    except FileExistsError:
+        existing = _read_salt(path)
+        return existing if existing is not None else salt
+    except OSError:
+        # Filesystem without hard links: fall back to an exclusive create.
+        try:
+            os.replace(tmp, path)
+            _harden(path)
+            return salt
+        except OSError:
+            return salt
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def load_salt(
@@ -101,9 +137,19 @@ def load_salt(
             if len(material) != SALT_BYTES:
                 raise ValueError
         except ValueError:
-            # Not hex — accept a passphrase, stretched to a fixed width so any
-            # operator-chosen string works without a silent length surprise.
-            material = hashlib.sha256(raw.encode("utf-8")).digest()
+            # Not hex — accept a passphrase, stretched with a deliberately slow
+            # KDF. A single SHA-256 is far too cheap here: an operator-chosen
+            # phrase has low entropy, so a plain digest can be brute-forced to
+            # recover the salt, and recovering the salt is what makes derived
+            # ids confirmable against candidate hardware. The context string is
+            # fixed, not random, because every workstation must derive the SAME
+            # material from the same phrase — that is the entire point of a
+            # fleet-scoped salt.
+            material = hashlib.scrypt(
+                raw.encode("utf-8"),
+                salt=b"hermia-fleet-salt-v1",
+                n=2**14, r=8, p=1, dklen=SALT_BYTES,
+            )
         return SaltInfo(material, "fleet:env")
 
     fleet_path = FLEET_SALT_PATH if fleet_salt_path is None else fleet_salt_path
@@ -116,8 +162,7 @@ def load_salt(
     if existing is not None:
         return SaltInfo(existing, "install")
 
-    salt = secrets.token_bytes(SALT_BYTES)
-    _write_salt(install_path, salt)
+    salt = _write_salt(install_path, secrets.token_bytes(SALT_BYTES))
     return SaltInfo(salt, "install")
 
 
@@ -127,7 +172,5 @@ def load_or_create_salt(salt_path: Path | None = None) -> bytes:
         existing = _read_salt(salt_path)
         if existing is not None:
             return existing
-        salt = secrets.token_bytes(SALT_BYTES)
-        _write_salt(salt_path, salt)
-        return salt
+        return _write_salt(salt_path, secrets.token_bytes(SALT_BYTES))
     return load_salt().salt

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -46,7 +46,12 @@ class SaltInfo:
     """A salt plus the scope it identifies machines within."""
 
     salt: bytes
-    scope: str  # "fleet:env" | "fleet:file" | "install"
+    scope: str  # "fleet:env" | "fleet:file" | "install" | "ephemeral"
+
+    @property
+    def is_stable(self) -> bool:
+        """False when the salt could not be persisted, so ids change each run."""
+        return self.scope != "ephemeral"
 
 
 def _harden(path: Path) -> None:
@@ -74,7 +79,7 @@ def _read_salt(path: Path) -> bytes | None:
     return raw
 
 
-def _write_salt(path: Path, salt: bytes) -> bytes:
+def _write_salt(path: Path, salt: bytes) -> tuple[bytes, bool]:
     """Create the salt file exclusively; return whichever salt actually won.
 
     Two processes starting for the first time together would otherwise each mint
@@ -101,7 +106,7 @@ def _write_salt(path: Path, salt: bytes) -> bytes:
         finally:
             os.close(fd)
     except OSError:
-        return salt  # read-only home: ephemeral for this process, do not crash
+        return salt, False  # read-only home: ephemeral, but SAY so
 
     try:
         try:
@@ -120,11 +125,11 @@ def _write_salt(path: Path, salt: bytes) -> bytes:
             finally:
                 os.close(fd)
         _harden(path)
-        return salt
+        return salt, True
     except FileExistsError:
         existing = _read_salt(path)
         if existing is not None:
-            return existing
+            return existing, True
         # The file exists but is EMPTY or malformed — a process killed
         # mid-write, or a truncated restore. Left alone it is never repaired,
         # so every future run mints a throwaway salt and the machine gets a
@@ -134,10 +139,10 @@ def _write_salt(path: Path, salt: bytes) -> bytes:
             os.replace(tmp, path)
             _harden(path)
         except OSError:
-            pass
-        return salt
+            return salt, False
+        return salt, True
     except OSError:
-        return salt
+        return salt, False
     finally:
         try:
             os.unlink(tmp)
@@ -182,8 +187,12 @@ def load_salt(
     if existing is not None:
         return SaltInfo(existing, "install")
 
-    salt = _write_salt(install_path, secrets.token_bytes(SALT_BYTES))
-    return SaltInfo(salt, "install")
+    salt, persisted = _write_salt(install_path, secrets.token_bytes(SALT_BYTES))
+    # A salt that could not be written is regenerated on every invocation, so
+    # every run derives a DIFFERENT machine_id for the same box and the ledger
+    # sees a brand new machine each time. Report that plainly rather than
+    # labelling it "install" and letting the instability look like real churn.
+    return SaltInfo(salt, "install" if persisted else "ephemeral")
 
 
 def load_or_create_salt(salt_path: Path | None = None) -> bytes:
@@ -192,5 +201,5 @@ def load_or_create_salt(salt_path: Path | None = None) -> bytes:
         existing = _read_salt(salt_path)
         if existing is not None:
             return existing
-        return _write_salt(salt_path, secrets.token_bytes(SALT_BYTES))
+        return _write_salt(salt_path, secrets.token_bytes(SALT_BYTES))[0]
     return load_salt().salt

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -1,0 +1,71 @@
+"""Per-install salt for machine_id derivation (hermia-cfqv).
+
+Stored in its OWN file, deliberately NOT in ``~/.hermia/config.toml``: that file
+is written with a whole-file overwrite by ``submit.load_or_create_install_id``,
+so a salt stored beside ``install_id`` would be silently destroyed the first
+time the install id is regenerated.
+
+The salt is what makes ``machine_id`` locally unique but globally meaningless.
+An UNSALTED hash of platform-uuid + cpu + ram is trivially confirmable: the
+candidate space is small enough that anyone holding a machine can hash it and
+confirm a match, re-identifying the box and leaking fleet composition. The
+tradeoff, stated explicitly: cross-install comparison becomes impossible. That
+is acceptable — the requirement is identifying machines WITHIN one fleet's data.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from pathlib import Path
+
+SALT_BYTES = 32
+DEFAULT_SALT_PATH = Path.home() / ".hermia" / "machine_salt"
+
+
+def load_or_create_salt(salt_path: Path | None = None) -> bytes:
+    """Return the per-install salt, creating and persisting it if absent.
+
+    A missing, unreadable, malformed, or wrong-length file is regenerated. An
+    unwritable location yields an ephemeral salt for this process rather than
+    raising — the CLI keeps working, though ``machine_id`` will not then be
+    stable across runs.
+    """
+    path = DEFAULT_SALT_PATH if salt_path is None else salt_path
+    try:
+        raw = bytes.fromhex(path.read_text(encoding="utf-8").strip())
+        if len(raw) == SALT_BYTES:
+            _harden(path)
+            return raw
+    except (OSError, ValueError):
+        pass  # absent, unreadable, or not hex — regenerate below
+
+    salt = secrets.token_bytes(SALT_BYTES)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Create with 0600 ALREADY SET rather than write-then-chmod: under a
+        # normal 022 umask the latter leaves the secret readable by every local
+        # process for the window between the two calls.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, salt.hex().encode("ascii"))
+        finally:
+            os.close(fd)
+        _harden(path)
+    except OSError:
+        pass  # read-only home: ephemeral for this process, do not crash
+    return salt
+
+
+def _harden(path: Path) -> None:
+    """Force owner-only permissions on an existing salt file.
+
+    Applied on READ as well as write: a salt restored from a backup, copied
+    between machines, or written by an older build can already be world
+    readable, and simply consuming it would leave the secret exposed forever.
+    """
+    try:
+        if stat.S_IMODE(path.stat().st_mode) != 0o600:
+            path.chmod(0o600)
+    except OSError:
+        pass

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -104,20 +104,40 @@ def _write_salt(path: Path, salt: bytes) -> bytes:
         return salt  # read-only home: ephemeral for this process, do not crash
 
     try:
-        os.link(tmp, path)
+        try:
+            os.link(tmp, path)
+        except OSError as exc:
+            if isinstance(exc, FileExistsError):
+                raise
+            # Filesystem without hard links (exFAT, some network and container
+            # mounts). Fall back to an EXCLUSIVE create, never os.replace:
+            # replace is an unconditional overwrite, so two first-run processes
+            # would each install their own salt and every id derived either
+            # side of that moment would disagree.
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                os.write(fd, salt.hex().encode("ascii"))
+            finally:
+                os.close(fd)
         _harden(path)
         return salt
     except FileExistsError:
         existing = _read_salt(path)
-        return existing if existing is not None else salt
-    except OSError:
-        # Filesystem without hard links: fall back to an exclusive create.
+        if existing is not None:
+            return existing
+        # The file exists but is EMPTY or malformed — a process killed
+        # mid-write, or a truncated restore. Left alone it is never repaired,
+        # so every future run mints a throwaway salt and the machine gets a
+        # brand new id every single time, silently and forever. Overwriting is
+        # correct here precisely because nothing usable is being destroyed.
         try:
             os.replace(tmp, path)
             _harden(path)
-            return salt
         except OSError:
-            return salt
+            pass
+        return salt
+    except OSError:
+        return salt
     finally:
         try:
             os.unlink(tmp)

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -1,46 +1,79 @@
-"""Per-install salt for machine_id derivation (hermia-cfqv).
+"""Salt for machine_id derivation (hermia-cfqv).
 
-Stored in its OWN file, deliberately NOT in ``~/.hermia/config.toml``: that file
-is written with a whole-file overwrite by ``submit.load_or_create_install_id``,
-so a salt stored beside ``install_id`` would be silently destroyed the first
-time the install id is regenerated.
+FLEET-scoped by preference, per-install only as a fallback.
 
-The salt is what makes ``machine_id`` locally unique but globally meaningless.
-An UNSALTED hash of platform-uuid + cpu + ram is trivially confirmable: the
-candidate space is small enough that anyone holding a machine can hash it and
-confirm a match, re-identifying the box and leaking fleet composition. The
-tradeoff, stated explicitly: cross-install comparison becomes impossible. That
-is acceptable — the requirement is identifying machines WITHIN one fleet's data.
+An earlier version salted per client install. That silently broke the thing the
+identity is for: run an eval from one laptop and then from another, and the same
+fleet host derives two different ids, so one machine appears as two in the
+corpus. The salt has to be a property of the FLEET being measured, not of the
+workstation doing the measuring.
+
+Resolution order:
+  1. ``HERMIA_FLEET_SALT`` environment variable (hex or passphrase)
+  2. ``~/.hermia/fleet_salt``
+  3. ``~/.hermia/machine_salt`` — per-install fallback, scope recorded as such
+
+The scope is returned alongside the salt and must be recorded with any derived
+id: two ids are only comparable when their scopes match. Silently mixing scopes
+would reintroduce exactly the split-identity bug above.
+
+Salting at all is deliberate: an UNSALTED hash of a serial or UUID is trivially
+confirmable, because the candidate space is small enough to enumerate and match,
+re-identifying a machine and leaking fleet composition. Note the limit, stated
+plainly rather than assumed away — an adversary who obtains the salt AND holds a
+candidate machine can still confirm a match. The salt raises the cost of
+re-identification; it does not make it impossible.
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import secrets
 import stat
+from dataclasses import dataclass
 from pathlib import Path
 
 SALT_BYTES = 32
-DEFAULT_SALT_PATH = Path.home() / ".hermia" / "machine_salt"
+CONFIG_DIR = Path.home() / ".hermia"
+FLEET_SALT_PATH = CONFIG_DIR / "fleet_salt"
+INSTALL_SALT_PATH = CONFIG_DIR / "machine_salt"
+FLEET_SALT_ENV = "HERMIA_FLEET_SALT"
 
 
-def load_or_create_salt(salt_path: Path | None = None) -> bytes:
-    """Return the per-install salt, creating and persisting it if absent.
+@dataclass(frozen=True)
+class SaltInfo:
+    """A salt plus the scope it identifies machines within."""
 
-    A missing, unreadable, malformed, or wrong-length file is regenerated. An
-    unwritable location yields an ephemeral salt for this process rather than
-    raising — the CLI keeps working, though ``machine_id`` will not then be
-    stable across runs.
+    salt: bytes
+    scope: str  # "fleet:env" | "fleet:file" | "install"
+
+
+def _harden(path: Path) -> None:
+    """Force owner-only permissions on a salt file.
+
+    Applied on READ as well as write: a salt restored from a backup or copied
+    between machines can already be world readable, and merely consuming it
+    would leave the secret exposed indefinitely.
     """
-    path = DEFAULT_SALT_PATH if salt_path is None else salt_path
+    try:
+        if stat.S_IMODE(path.stat().st_mode) != 0o600:
+            path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _read_salt(path: Path) -> bytes | None:
     try:
         raw = bytes.fromhex(path.read_text(encoding="utf-8").strip())
-        if len(raw) == SALT_BYTES:
-            _harden(path)
-            return raw
     except (OSError, ValueError):
-        pass  # absent, unreadable, or not hex — regenerate below
+        return None
+    if len(raw) != SALT_BYTES:
+        return None
+    _harden(path)
+    return raw
 
-    salt = secrets.token_bytes(SALT_BYTES)
+
+def _write_salt(path: Path, salt: bytes) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         # Create with 0600 ALREADY SET rather than write-then-chmod: under a
@@ -54,18 +87,47 @@ def load_or_create_salt(salt_path: Path | None = None) -> bytes:
         _harden(path)
     except OSError:
         pass  # read-only home: ephemeral for this process, do not crash
-    return salt
 
 
-def _harden(path: Path) -> None:
-    """Force owner-only permissions on an existing salt file.
+def load_salt(
+    fleet_salt_path: Path | None = None, install_salt_path: Path | None = None
+) -> SaltInfo:
+    """Return the salt to derive machine ids with, and the scope it applies to."""
+    env = os.environ.get(FLEET_SALT_ENV)
+    if env and env.strip():
+        raw = env.strip()
+        try:
+            material = bytes.fromhex(raw)
+            if len(material) != SALT_BYTES:
+                raise ValueError
+        except ValueError:
+            # Not hex — accept a passphrase, stretched to a fixed width so any
+            # operator-chosen string works without a silent length surprise.
+            material = hashlib.sha256(raw.encode("utf-8")).digest()
+        return SaltInfo(material, "fleet:env")
 
-    Applied on READ as well as write: a salt restored from a backup, copied
-    between machines, or written by an older build can already be world
-    readable, and simply consuming it would leave the secret exposed forever.
-    """
-    try:
-        if stat.S_IMODE(path.stat().st_mode) != 0o600:
-            path.chmod(0o600)
-    except OSError:
-        pass
+    fleet_path = FLEET_SALT_PATH if fleet_salt_path is None else fleet_salt_path
+    existing = _read_salt(fleet_path)
+    if existing is not None:
+        return SaltInfo(existing, "fleet:file")
+
+    install_path = INSTALL_SALT_PATH if install_salt_path is None else install_salt_path
+    existing = _read_salt(install_path)
+    if existing is not None:
+        return SaltInfo(existing, "install")
+
+    salt = secrets.token_bytes(SALT_BYTES)
+    _write_salt(install_path, salt)
+    return SaltInfo(salt, "install")
+
+
+def load_or_create_salt(salt_path: Path | None = None) -> bytes:
+    """Backwards-compatible accessor returning only the salt bytes."""
+    if salt_path is not None:
+        existing = _read_salt(salt_path)
+        if existing is not None:
+            return existing
+        salt = secrets.token_bytes(SALT_BYTES)
+        _write_salt(salt_path, salt)
+        return salt
+    return load_salt().salt

--- a/src/hermia/identity/salt.py
+++ b/src/hermia/identity/salt.py
@@ -196,7 +196,12 @@ def load_salt(
 
 
 def load_or_create_salt(salt_path: Path | None = None) -> bytes:
-    """Backwards-compatible accessor returning only the salt bytes."""
+    """Bytes-only accessor. PREFER ``load_salt``, which carries the scope.
+
+    An id derived from bare bytes has ``salt_scope="unspecified"`` and is not
+    safely comparable with a scoped one — same shape, different namespace. This
+    exists for tests and for callers that genuinely only need key material.
+    """
     if salt_path is not None:
         existing = _read_salt(salt_path)
         if existing is not None:

--- a/src/hermia/identity/types.py
+++ b/src/hermia/identity/types.py
@@ -33,27 +33,63 @@ from typing import Protocol
 # an unfilled template string.
 KNOWN_BAD_IDENTIFIERS: frozenset[str] = frozenset(
     {
-        "00000000-0000-0000-0000-000000000000",
-        "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "03000200-0400-0500-0006-000700080009",  # mass-duplicated vendor UUID
-        "to be filled by o.e.m.",
-        "to be filled by oem",
-        "system serial number",
-        "default string",
-        "not specified",
+        # mass-duplicated vendor UUID, in canonical (alnum-folded) form
+        "03000200040005000006000700080009",
+        "tobefilledbyoem",
+        "systemserialnumber",
+        "baseboardserialnumber",
+        "chassisserialnumber",
+        "defaultstring",
+        "notspecified",
+        "notapplicable",
         "none",
+        "null",
         "unknown",
-        "0",
+        "oem",
+        "na",
+        "invalid",
+        "serialnumber",
+        "filledbyoem",
     }
 )
 
+# Minimum length for a value to be plausibly unique. Vendors ship short filler
+# like "0", "123", "NA"; a real UUID or serial is comfortably longer.
+_MIN_IDENTIFIER_LEN = 6
+
+
+def canonical_identifier(value: str | None) -> str | None:
+    """Canonical form used for BOTH the placeholder screen and hashing.
+
+    Case and hyphenation are formatting, not identity: Linux reports a firmware
+    UUID lowercase while Windows and macOS report it uppercase, and the same
+    UUID appears hyphenated in one place and bare in another. Hashing the raw
+    string makes one physical motherboard produce different ids depending on
+    which OS asked — a split identity created purely by punctuation.
+    """
+    if value is None:
+        return None
+    folded = "".join(ch for ch in value.strip().lower() if ch.isalnum())
+    return folded or None
+
 
 def is_usable_identifier(value: str | None) -> bool:
-    """True when a value is present and not a known non-unique placeholder."""
-    if value is None:
+    """True when a value is present and not a known non-unique placeholder.
+
+    Screening happens on the CANONICAL form, so "To Be Filled By O.E.M",
+    "to be filled by o.e.m." and "TO_BE_FILLED_BY_OEM" are all caught by one
+    entry. Exact-string matching missed every variant a vendor happened to
+    punctuate differently, and two DIY boxes sharing a filler serial then
+    derived the SAME machine id.
+    """
+    canon = canonical_identifier(value)
+    if canon is None or len(canon) < _MIN_IDENTIFIER_LEN:
         return False
-    cleaned = value.strip()
-    return bool(cleaned) and cleaned.lower() not in KNOWN_BAD_IDENTIFIERS
+    if canon in KNOWN_BAD_IDENTIFIERS:
+        return False
+    if len(set(canon)) == 1:  # "000000...", "ffffff...", "xxxxxx..."
+        return False
+    return not canon.isdigit() or len(set(canon)) > 2
 
 
 @dataclass(frozen=True)
@@ -80,11 +116,12 @@ class MachineIdentifiers:
             "hardware_serial": self.hardware_serial,
             "persisted_token": self.persisted_token,
         }
-        return {
-            k: v.strip()
-            for k, v in candidates.items()
-            if v is not None and is_usable_identifier(v)
-        }
+        out: dict[str, str] = {}
+        for k, v in candidates.items():
+            canon = canonical_identifier(v) if is_usable_identifier(v) else None
+            if canon is not None:
+                out[k] = canon
+        return out
 
     @property
     def is_identifiable(self) -> bool:

--- a/src/hermia/identity/types.py
+++ b/src/hermia/identity/types.py
@@ -1,0 +1,57 @@
+"""Types for machine identity (hermia-cfqv). No I/O, no subprocess — pure data.
+
+A row's machine identity has historically been ``fleet_host_name``: an
+operator-typed string in a fleet YAML, verified against nothing. It has lied in
+four independent ways in this corpus — one machine under several names, tunnel
+ports repointed between machines, DHCP reservations bound to detachable USB
+dongles, and a Thunderbolt dock whose MAC follows whichever laptop is docked.
+
+Note what is deliberately absent here: there is no MAC field. A MAC-derived
+identity migrates with a dongle or a dock rather than with the computer, which
+is the specific failure this module exists to end.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class HardwareFacts:
+    """Facts measured ON a machine. ``None`` means NOT MEASURED — never guessed."""
+
+    platform_uuid: str | None
+    cpu_brand: str | None
+    ram_bytes: int | None
+    os_family: str
+    unavailable: tuple[str, ...] = field(default=())
+
+    @property
+    def is_identifiable(self) -> bool:
+        """True only when the strong, machine-bound identifier was measured.
+
+        CPU brand and RAM size are entropy, NOT identity: two identical laptops
+        share both. Requiring ``platform_uuid`` is what stops two laptops of
+        identical model and memory from hashing to the same ``machine_id``.
+        """
+        return bool(self.platform_uuid)
+
+
+@dataclass(frozen=True)
+class MachineIdentity:
+    """A derived identity. ``machine_id is None`` is a valid, explicit outcome."""
+
+    machine_id: str | None
+    basis: str
+    os_family: str
+
+
+class HardwareProbe(Protocol):
+    """Measures hardware facts for one machine.
+
+    ``LocalProbe`` implements this for the machine hermia runs on. Remote probes
+    (SSH, agent) implement the same Protocol later; nothing else in this package
+    may assume the facts came from localhost.
+    """
+
+    def probe(self) -> HardwareFacts: ...

--- a/src/hermia/identity/types.py
+++ b/src/hermia/identity/types.py
@@ -118,11 +118,18 @@ class MachineIdentity:
     ``source`` names which identifier produced it, so a weak identity can never
     be silently read as a strong one, and a later change of source is visible
     rather than appearing as a brand-new machine.
+
+    ``salt_scope`` records WHICH salt produced the id. Two ids are comparable
+    only when their scopes match — an id derived under a per-install salt says
+    nothing about one derived under a fleet salt. Without this field the scope
+    that ``salt.load_salt`` computes is discarded at the moment of derivation,
+    and incomparable ids look identical in shape.
     """
 
     machine_id: str | None
     source: str
     basis: str
+    salt_scope: str = "unspecified"
 
 
 @dataclass(frozen=True)

--- a/src/hermia/identity/types.py
+++ b/src/hermia/identity/types.py
@@ -25,7 +25,7 @@ computer — the original defect. A MAC is still recorded, but as a capability.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import ClassVar, Protocol
 
 # Firmware placeholder values that are NOT unique and must never be accepted as
 # an identity. Vendors ship these in volume: all-zero/all-FF SMBIOS UUIDs come
@@ -167,6 +167,32 @@ class MachineIdentity:
     source: str
     basis: str
     salt_scope: str = "unspecified"
+
+    #: Sources that a disk clone duplicates. An id derived from one of these is
+    #: NOT unique to a machine, and two cloned VMs derive the same value.
+    TRANSFERABLE_SOURCES: ClassVar[frozenset[str]] = frozenset({"persisted-token"})
+
+    @property
+    def is_transferable(self) -> bool:
+        """True when a disk clone would reproduce this exact id elsewhere.
+
+        The firmware root is bound to the board; the minted token is a file. In a
+        VM — where firmware identifiers are routinely absent — identity falls
+        back to that file, and cloning the image clones the identity. The id is
+        still the best available, but callers must be able to SEE that it is
+        clone-vulnerable rather than reading it as machine-unique.
+        """
+        return self.source in self.TRANSFERABLE_SOURCES
+
+    @property
+    def is_comparable(self) -> bool:
+        """False when the salt scope is unknown, so this id must not be matched.
+
+        Ids are only comparable within one salt scope. A caller that took bare
+        bytes (rather than SaltInfo) has no scope, and an unscoped id looks
+        exactly like a scoped one — so comparing them silently mixes namespaces.
+        """
+        return self.machine_id is not None and self.salt_scope != "unspecified"
 
 
 @dataclass(frozen=True)

--- a/src/hermia/identity/types.py
+++ b/src/hermia/identity/types.py
@@ -1,57 +1,144 @@
 """Types for machine identity (hermia-cfqv). No I/O, no subprocess — pure data.
 
-A row's machine identity has historically been ``fleet_host_name``: an
-operator-typed string in a fleet YAML, verified against nothing. It has lied in
-four independent ways in this corpus — one machine under several names, tunnel
-ports repointed between machines, DHCP reservations bound to detachable USB
-dongles, and a Thunderbolt dock whose MAC follows whichever laptop is docked.
+The central split, and the reason this module exists in this shape:
 
-Note what is deliberately absent here: there is no MAC field. A MAC-derived
-identity migrates with a dongle or a dock rather than with the computer, which
-is the specific failure this module exists to end.
+    IDENTIFIERS answer "which machine is this?" — non-transferable, bound to the
+    silicon. Only these are ever hashed into a machine_id.
+
+    CAPABILITIES answer "what does this machine have?" — CPU, memory, GPU. These
+    are RECORDED and never hashed. Memory is a capability, not an identity: a RAM
+    upgrade must not make one machine look like two, and on Linux the reported
+    total drifts with kernel updates and driver reservations all by itself.
+
+That split is the whole design. An earlier version hashed capabilities into the
+identity and then tried to survive the resulting instability with weighted
+threshold matching. Two independent outside reviews rejected that: any threshold
+loose enough to tolerate a hardware repair will merge two identical laptops, and
+any threshold tight enough to keep them apart is just an exact match on the
+strongest identifier. Threshold matching was removed rather than tuned.
+
+Note what is absent from MachineIdentifiers: anything detachable. No MAC, no IP,
+no hostname. DHCP reservations here are bound to USB/Thunderbolt adapters and a
+dock, so a network-derived identity follows the accessory rather than the
+computer — the original defect. A MAC is still recorded, but as a capability.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Protocol
 
+# Firmware placeholder values that are NOT unique and must never be accepted as
+# an identity. Vendors ship these in volume: all-zero/all-FF SMBIOS UUIDs come
+# from buggy firmware, and DIY builds (this fleet has some) leave the serial as
+# an unfilled template string.
+KNOWN_BAD_IDENTIFIERS: frozenset[str] = frozenset(
+    {
+        "00000000-0000-0000-0000-000000000000",
+        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "03000200-0400-0500-0006-000700080009",  # mass-duplicated vendor UUID
+        "to be filled by o.e.m.",
+        "to be filled by oem",
+        "system serial number",
+        "default string",
+        "not specified",
+        "none",
+        "unknown",
+        "0",
+    }
+)
+
+
+def is_usable_identifier(value: str | None) -> bool:
+    """True when a value is present and not a known non-unique placeholder."""
+    if value is None:
+        return False
+    cleaned = value.strip()
+    return bool(cleaned) and cleaned.lower() not in KNOWN_BAD_IDENTIFIERS
+
 
 @dataclass(frozen=True)
-class HardwareFacts:
-    """Facts measured ON a machine. ``None`` means NOT MEASURED — never guessed."""
+class MachineIdentifiers:
+    """Non-transferable identifiers. ``None`` means NOT MEASURED — never guessed.
 
-    platform_uuid: str | None
-    cpu_brand: str | None
-    ram_bytes: int | None
-    os_family: str
+    ``persisted_token`` is a UUID hermia mints once and stores on the machine. It
+    is the fallback for hosts whose firmware exposes nothing usable. It ranks
+    BELOW the firmware root because it lives on the filesystem, so a cloned disk
+    image duplicates it — the failure mode that makes VM fleets collapse into one
+    identity.
+    """
+
+    firmware_uuid: str | None = None
+    hardware_serial: str | None = None
+    persisted_token: str | None = None
     unavailable: tuple[str, ...] = field(default=())
 
     @property
-    def is_identifiable(self) -> bool:
-        """True only when the strong, machine-bound identifier was measured.
+    def usable(self) -> dict[str, str]:
+        """The identifiers that are present AND not known-bad placeholders."""
+        candidates = {
+            "firmware_uuid": self.firmware_uuid,
+            "hardware_serial": self.hardware_serial,
+            "persisted_token": self.persisted_token,
+        }
+        return {
+            k: v.strip()
+            for k, v in candidates.items()
+            if v is not None and is_usable_identifier(v)
+        }
 
-        CPU brand and RAM size are entropy, NOT identity: two identical laptops
-        share both. Requiring ``platform_uuid`` is what stops two laptops of
-        identical model and memory from hashing to the same ``machine_id``.
-        """
-        return bool(self.platform_uuid)
+    @property
+    def is_identifiable(self) -> bool:
+        return bool(self.usable)
+
+
+@dataclass(frozen=True)
+class MachineCapabilities:
+    """What the machine HAS. Recorded, reported, compared — never hashed.
+
+    A change here is information, not an identity crisis. ``nic_mac`` lives here
+    precisely because it is detachable: recording it lets an operator see that a
+    dock moved, without ever letting a dock define which machine answered.
+    """
+
+    cpu_brand: str | None = None
+    logical_cores: int | None = None
+    ram_bytes: int | None = None
+    model_identifier: str | None = None
+    os_family: str | None = None
+    os_version: str | None = None
+    nic_mac: str | None = None
+    is_virtual: bool | None = None
+    unavailable: tuple[str, ...] = field(default=())
 
 
 @dataclass(frozen=True)
 class MachineIdentity:
-    """A derived identity. ``machine_id is None`` is a valid, explicit outcome."""
+    """A derived identity. ``machine_id is None`` is a valid, explicit outcome.
+
+    ``source`` names which identifier produced it, so a weak identity can never
+    be silently read as a strong one, and a later change of source is visible
+    rather than appearing as a brand-new machine.
+    """
 
     machine_id: str | None
+    source: str
     basis: str
-    os_family: str
+
+
+@dataclass(frozen=True)
+class MachineObservation:
+    """One probe result: who it is, plus what it has."""
+
+    identifiers: MachineIdentifiers
+    capabilities: MachineCapabilities
 
 
 class HardwareProbe(Protocol):
-    """Measures hardware facts for one machine.
+    """Measures one machine. ``LocalProbe`` covers the machine hermia runs on.
 
-    ``LocalProbe`` implements this for the machine hermia runs on. Remote probes
-    (SSH, agent) implement the same Protocol later; nothing else in this package
-    may assume the facts came from localhost.
+    Remote probes (SSH, sidecar endpoint) implement this same Protocol later.
+    Nothing else in the package may assume the observation came from localhost —
+    for a fleet run it must not, or every row gets the client's identity.
     """
 
-    def probe(self) -> HardwareFacts: ...
+    def probe(self) -> MachineObservation: ...

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -125,3 +125,51 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
     out["hermia_version"] = __version__
     out["git_sha"] = __git_sha__
     return out
+
+
+# ---------------------------------------------------------------------------
+# machine_id pseudonymisation (hermia-cfqv)
+# ---------------------------------------------------------------------------
+
+
+def _pseudonym(index: int) -> str:
+    """``0 -> node-a`` … ``25 -> node-z``, ``26 -> node-aa``, spreadsheet-style."""
+    letters = ""
+    n = index
+    while True:
+        letters = chr(ord("a") + n % 26) + letters
+        n = n // 26 - 1
+        if n < 0:
+            break
+    return f"node-{letters}"
+
+
+def assign_machine_pseudonyms(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Replace ``machine_id`` with a dataset-stable ``machine_pseudonym``.
+
+    ``machine_id`` is a salted hash: locally unique, globally meaningless. It is
+    still not exported — it is replaced by ``node-a``, ``node-b``, … assigned in
+    first-appearance order, so a reader can tell rows apart by machine without
+    receiving any value that ties back to a box. Neither the salt nor this
+    mapping is ever written to output, and ``machine_id`` is deliberately absent
+    from ``SUBMIT_WHITELIST`` so it cannot leak through the normal path either.
+
+    A ``machine_id`` that is ``None`` or absent means NOT MEASURED, and yields a
+    ``None`` pseudonym rather than being pooled into a shared bucket — otherwise
+    every unidentified machine would look like one machine.
+
+    Input rows are never mutated; new dicts are returned.
+    """
+    assigned: dict[str, str] = {}
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        new = dict(row)
+        machine_id = new.pop("machine_id", None)
+        if isinstance(machine_id, str) and machine_id:
+            if machine_id not in assigned:
+                assigned[machine_id] = _pseudonym(len(assigned))
+            new["machine_pseudonym"] = assigned[machine_id]
+        else:
+            new["machine_pseudonym"] = None
+        out.append(new)
+    return out

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -137,8 +137,8 @@ def anonymize_row(row: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _pseudonym(index: int) -> str:
-    """``0 -> node-a`` … ``25 -> node-z``, ``26 -> node-aa``, spreadsheet-style."""
+def _letters(index: int) -> str:
+    """``0 -> a`` … ``25 -> z``, ``26 -> aa``, spreadsheet-style."""
     letters = ""
     n = index
     while True:
@@ -146,7 +146,12 @@ def _pseudonym(index: int) -> str:
         n = n // 26 - 1
         if n < 0:
             break
-    return f"node-{letters}"
+    return letters
+
+
+def _pseudonym(index: int) -> str:
+    """``0 -> node-a`` … ``25 -> node-z``, ``26 -> node-aa``, spreadsheet-style."""
+    return f"node-{_letters(index)}"
 
 
 def assign_machine_pseudonyms(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -166,6 +171,7 @@ def assign_machine_pseudonyms(rows: list[dict[str, Any]]) -> list[dict[str, Any]
     Input rows are never mutated; new dicts are returned.
     """
     assigned: dict[str, str] = {}
+    unidentified: dict[str, str] = {}
     out: list[dict[str, Any]] = []
     for row in rows:
         new = dict(row)
@@ -174,10 +180,21 @@ def assign_machine_pseudonyms(rows: list[dict[str, Any]]) -> list[dict[str, Any]
             if machine_id not in assigned:
                 assigned[machine_id] = _pseudonym(len(assigned))
             new["machine_pseudonym"] = assigned[machine_id]
-        elif "machine_pseudonym" not in new:
-            # Only claim "not identified" when nothing has been assigned yet.
-            # Rows that already carry a pseudonym (this ran after anonymisation,
-            # or is being applied twice) must not be blanked wholesale.
-            new["machine_pseudonym"] = None
+        elif "machine_pseudonym" in new:
+            pass  # already assigned; applying twice must not blank it
+        else:
+            # An id we could not derive is NOT the same as "one unknown
+            # machine". Emitting None for all of them pools ten unidentified
+            # boxes into a single bucket, and a reader sees one machine with ten
+            # runs. Separate them using the operator's own grouping key — which
+            # is dropped from the export either way, so nothing leaks — and fall
+            # back to None only when there is genuinely nothing to group on.
+            key = row.get("fleet_host_name") or row.get("host")
+            if isinstance(key, str) and key:
+                if key not in unidentified:
+                    unidentified[key] = f"unidentified-{_letters(len(unidentified))}"
+                new["machine_pseudonym"] = unidentified[key]
+            else:
+                new["machine_pseudonym"] = None
         out.append(new)
     return out

--- a/src/hermia/sink/anonymize.py
+++ b/src/hermia/sink/anonymize.py
@@ -46,6 +46,11 @@ SUBMIT_WHITELIST: frozenset[str] = frozenset(
         "cold_warm_delta_tps",
         "signals",
         "corpus_sha256",
+        # Dataset-stable pseudonym (node-a, node-b). Safe to export BY DESIGN and
+        # the reason machine_id itself stays out: without this entry the
+        # default-deny pass silently drops the pseudonym, and an export carries
+        # no way to tell one machine's rows from another's.
+        "machine_pseudonym",
     }
 )
 
@@ -169,7 +174,10 @@ def assign_machine_pseudonyms(rows: list[dict[str, Any]]) -> list[dict[str, Any]
             if machine_id not in assigned:
                 assigned[machine_id] = _pseudonym(len(assigned))
             new["machine_pseudonym"] = assigned[machine_id]
-        else:
+        elif "machine_pseudonym" not in new:
+            # Only claim "not identified" when nothing has been assigned yet.
+            # Rows that already carry a pseudonym (this ran after anonymisation,
+            # or is being applied twice) must not be blanked wholesale.
             new["machine_pseudonym"] = None
         out.append(new)
     return out

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -138,3 +138,57 @@ def test_no_temp_files_left_behind(tmp_path):
     record_observation("host-a", "1111000000000000", led)
     leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp"))
     assert leftovers == []
+
+
+# --- CodeRabbit: ledger index consistency + conflict persistence ---------
+
+
+def test_rebinding_a_label_removes_the_displaced_inverse_entry(tmp_path):
+    """Writing only the new pair leaves the ledger claiming BOTH
+    'host-a -> id-b' and 'id-a -> host-a' — mutually contradictory."""
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    resolve_conflict("host-a", "id-b", led)
+    data = json.loads(led.read_text())
+    assert data["label_to_id"] == {"host-a": "id-b"}
+    assert "id-a" not in data["id_to_label"], "stale inverse entry survived"
+
+
+def test_no_phantom_rename_warning_after_a_rebind(tmp_path):
+    """A stale inverse entry makes a later sighting of the old machine fire
+    machine_renamed against a binding that no longer exists."""
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    resolve_conflict("host-a", "id-b", led)
+    assert check_identity_consistency("host-c", "id-a", led) == []
+
+
+def test_rebinding_a_machine_removes_the_displaced_forward_entry(tmp_path):
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    record_observation("host-b", "id-a", led)
+    data = json.loads(led.read_text())
+    assert data["id_to_label"] == {"id-a": "host-b"}
+    assert "host-a" not in data["label_to_id"]
+
+
+def test_an_open_conflict_survives_the_original_pairing_returning(tmp_path):
+    """A box swapped in for one run and swapped back would otherwise clear the
+    conflict on the next run, leaving no trace that anything ever moved."""
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    assert [w.kind for w in check_identity_consistency("host-a", "id-b", led)] == [
+        "label_moved_machine"
+    ]
+    warns = check_identity_consistency("host-a", "id-a", led)
+    assert [w.kind for w in warns] == ["unresolved_conflict"]
+    assert "host-a" in pending_conflicts(led)
+
+
+def test_only_resolve_conflict_closes_an_open_conflict(tmp_path):
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    check_identity_consistency("host-a", "id-b", led)
+    resolve_conflict("host-a", "id-a", led)
+    assert pending_conflicts(led) == {}
+    assert check_identity_consistency("host-a", "id-a", led) == []

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -1,0 +1,160 @@
+"""Label/machine cross-check ledger (hermia-cfqv).
+
+This is the check that would have caught hermia-fqod at dispatch time instead
+of a month later during analysis.
+"""
+import json
+
+import pytest
+
+from hermia.identity.crosscheck import check_identity_consistency, record_observation
+
+
+def test_first_observation_produces_no_warning(tmp_path):
+    led = tmp_path / "ledger.json"
+    assert check_identity_consistency("host-a", "aaaa000000000000", led) == []
+
+
+def test_same_label_now_a_different_machine_warns(tmp_path):
+    """A name that silently starts pointing at different hardware."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "aaaa000000000000", led)
+    warns = check_identity_consistency("host-a", "bbbb111111111111", led)
+    assert len(warns) == 1
+    assert warns[0].kind == "label_moved_machine"
+    assert "host-a" in warns[0].message
+
+
+def test_same_machine_under_a_new_label_warns_as_rename(tmp_path):
+    """One box under several names."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-b", "cccc222222222222", led)
+    warns = check_identity_consistency("host-c", "cccc222222222222", led)
+    assert len(warns) == 1
+    assert warns[0].kind == "machine_renamed"
+
+
+def test_unknown_machine_id_never_warns(tmp_path):
+    """A null id means 'not measured'. It must not be treated as a machine."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "dddd333333333333", led)
+    assert check_identity_consistency("host-a", None, led) == []
+
+
+def test_corrupt_ledger_degrades_to_no_warnings_and_does_not_raise(tmp_path):
+    led = tmp_path / "ledger.json"
+    led.write_text("{not json")
+    assert check_identity_consistency("host-a", "eeee444444444444", led) == []
+
+
+def test_missing_ledger_does_not_raise(tmp_path):
+    assert check_identity_consistency("host-a", "eeee444444444444", tmp_path / "nope.json") == []
+
+
+def test_stable_pairing_repeated_many_times_stays_silent(tmp_path):
+    led = tmp_path / "ledger.json"
+    for _ in range(5):
+        record_observation("host-d", "ffff555555555555", led)
+        assert check_identity_consistency("host-d", "ffff555555555555", led) == []
+
+
+def test_record_observation_never_persists_a_null_id(tmp_path):
+    """Recording a null would make 'not measured' look like a machine."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", None, led)
+    assert check_identity_consistency("host-b", None, led) == []
+
+
+def test_both_warnings_can_fire_together(tmp_path):
+    """Label points somewhere new AND the machine had another name."""
+    led = tmp_path / "ledger.json"
+    record_observation("label-a", "1111000000000000", led)
+    record_observation("label-b", "2222000000000000", led)
+    warns = check_identity_consistency("label-a", "2222000000000000", led)
+    kinds = {w.kind for w in warns}
+    assert kinds == {"label_moved_machine", "machine_renamed"}
+
+
+# ---------------------------------------------------------------------------
+# Ledger robustness. The first implementation json.loads()'d the file and then
+# indexed ledger["label_to_id"] directly, so a file containing VALID json of the
+# wrong shape raised KeyError/TypeError out of a function documented never to
+# raise. Testing only malformed json ("{not json") missed this completely.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "[]",
+        '"just a string"',
+        "123",
+        "null",
+        '{"foo": 1}',
+        '{"label_to_id": "not-a-dict", "id_to_label": []}',
+        '{"label_to_id": {"a": 5}, "id_to_label": {"b": null}}',
+    ],
+)
+def test_valid_json_of_the_wrong_shape_never_raises(tmp_path, payload):
+    led = tmp_path / "ledger.json"
+    led.write_text(payload)
+    assert check_identity_consistency("host-a", "aaaa000000000000", led) == []
+    record_observation("host-a", "aaaa000000000000", led)
+
+
+def test_wrong_shape_ledger_is_repaired_on_next_write(tmp_path):
+    led = tmp_path / "ledger.json"
+    led.write_text('{"label_to_id": "not-a-dict"}')
+    record_observation("host-a", "aaaa000000000000", led)
+    data = json.loads(led.read_text())
+    assert data["label_to_id"]["host-a"] == "aaaa000000000000"
+    assert data["id_to_label"]["aaaa000000000000"] == "host-a"
+
+
+def test_consistent_check_records_so_a_later_swap_is_caught(tmp_path):
+    """Documented side effect: check() bootstraps the ledger when consistent."""
+    led = tmp_path / "ledger.json"
+    assert check_identity_consistency("host-a", "1111000000000000", led) == []
+    warns = check_identity_consistency("host-a", "2222000000000000", led)
+    assert [w.kind for w in warns] == ["label_moved_machine"]
+
+
+def test_a_firing_warning_persists_across_runs(tmp_path):
+    """A warning must not be silently absorbed on the second run."""
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "1111000000000000", led)
+    for _ in range(3):
+        warns = check_identity_consistency("host-a", "2222000000000000", led)
+        assert [w.kind for w in warns] == ["label_moved_machine"]
+
+
+def test_unwritable_ledger_location_does_not_raise(tmp_path):
+    d = tmp_path / "ro"
+    d.mkdir()
+    d.chmod(0o500)
+    try:
+        record_observation("host-a", "1111000000000000", d / "ledger.json")
+        assert check_identity_consistency("host-a", "1111000000000000", d / "l.json") == []
+    finally:
+        d.chmod(0o700)
+
+
+def test_concurrent_observations_do_not_lose_hosts(tmp_path):
+    """fleet.py runs hosts in a ThreadPoolExecutor; an unlocked
+    read-modify-write drops pairings and silently disarms swap detection."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    led = tmp_path / "ledger.json"
+    hosts = [(f"host-{i:02d}", f"{i:016x}") for i in range(24)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda h: record_observation(h[0], h[1], led), hosts))
+
+    data = json.loads(led.read_text())
+    assert len(data["label_to_id"]) == 24, "a concurrent write clobbered a host"
+    for label, mid in hosts:
+        assert data["label_to_id"][label] == mid
+
+
+def test_no_temp_files_are_left_behind(tmp_path):
+    led = tmp_path / "ledger.json"
+    record_observation("host-a", "1111000000000000", led)
+    assert [p.name for p in tmp_path.iterdir()] == ["ledger.json"]

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -192,3 +192,27 @@ def test_only_resolve_conflict_closes_an_open_conflict(tmp_path):
     resolve_conflict("host-a", "id-a", led)
     assert pending_conflicts(led) == {}
     assert check_identity_consistency("host-a", "id-a", led) == []
+
+
+def test_a_renamed_machine_does_not_poison_the_new_label_forever(tmp_path):
+    """host-2 first sees M1 (which belongs to host-1) -> machine_renamed. The
+    operator then points host-2 at its own hardware. It must be able to bind."""
+    led = tmp_path / "l.json"
+    record_observation("host-1", "M1", led)
+    assert [w.kind for w in check_identity_consistency("host-2", "M1", led)] == [
+        "machine_renamed"
+    ]
+    assert check_identity_consistency("host-2", "M2", led) == []
+    assert pending_conflicts(led) == {}
+    assert json.loads(led.read_text())["label_to_id"]["host-2"] == "M2"
+
+
+def test_a_swapped_and_swapped_back_box_still_reports(tmp_path):
+    """The other conflict shape must KEEP warning — this is the case where the
+    label had a real prior binding."""
+    led = tmp_path / "l.json"
+    record_observation("host-a", "id-a", led)
+    check_identity_consistency("host-a", "id-b", led)
+    assert [w.kind for w in check_identity_consistency("host-a", "id-a", led)] == [
+        "unresolved_conflict"
+    ]

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -1,160 +1,140 @@
-"""Label/machine cross-check ledger (hermia-cfqv).
-
-This is the check that would have caught hermia-fqod at dispatch time instead
-of a month later during analysis.
-"""
+"""Label/machine cross-check ledger (hermia-cfqv)."""
 import json
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from hermia.identity.crosscheck import check_identity_consistency, record_observation
+from hermia.identity.crosscheck import (
+    check_identity_consistency,
+    pending_conflicts,
+    record_observation,
+    resolve_conflict,
+)
 
 
 def test_first_observation_produces_no_warning(tmp_path):
-    led = tmp_path / "ledger.json"
-    assert check_identity_consistency("host-a", "aaaa000000000000", led) == []
+    assert check_identity_consistency("host-a", "aaaa000000000000", tmp_path / "l.json") == []
 
 
 def test_same_label_now_a_different_machine_warns(tmp_path):
-    """A name that silently starts pointing at different hardware."""
-    led = tmp_path / "ledger.json"
+    led = tmp_path / "l.json"
     record_observation("host-a", "aaaa000000000000", led)
     warns = check_identity_consistency("host-a", "bbbb111111111111", led)
-    assert len(warns) == 1
-    assert warns[0].kind == "label_moved_machine"
+    assert [w.kind for w in warns] == ["label_moved_machine"]
     assert "host-a" in warns[0].message
 
 
 def test_same_machine_under_a_new_label_warns_as_rename(tmp_path):
-    """One box under several names."""
-    led = tmp_path / "ledger.json"
+    led = tmp_path / "l.json"
     record_observation("host-b", "cccc222222222222", led)
-    warns = check_identity_consistency("host-c", "cccc222222222222", led)
-    assert len(warns) == 1
-    assert warns[0].kind == "machine_renamed"
+    assert [w.kind for w in check_identity_consistency("host-c", "cccc222222222222", led)] == [
+        "machine_renamed"
+    ]
 
 
-def test_unknown_machine_id_never_warns(tmp_path):
-    """A null id means 'not measured'. It must not be treated as a machine."""
-    led = tmp_path / "ledger.json"
-    record_observation("host-a", "dddd333333333333", led)
-    assert check_identity_consistency("host-a", None, led) == []
-
-
-def test_corrupt_ledger_degrades_to_no_warnings_and_does_not_raise(tmp_path):
-    led = tmp_path / "ledger.json"
-    led.write_text("{not json")
-    assert check_identity_consistency("host-a", "eeee444444444444", led) == []
-
-
-def test_missing_ledger_does_not_raise(tmp_path):
-    assert check_identity_consistency("host-a", "eeee444444444444", tmp_path / "nope.json") == []
-
-
-def test_stable_pairing_repeated_many_times_stays_silent(tmp_path):
-    led = tmp_path / "ledger.json"
-    for _ in range(5):
-        record_observation("host-d", "ffff555555555555", led)
-        assert check_identity_consistency("host-d", "ffff555555555555", led) == []
-
-
-def test_record_observation_never_persists_a_null_id(tmp_path):
-    """Recording a null would make 'not measured' look like a machine."""
-    led = tmp_path / "ledger.json"
+def test_null_machine_id_never_warns_and_is_never_recorded(tmp_path):
+    led = tmp_path / "l.json"
     record_observation("host-a", None, led)
+    assert check_identity_consistency("host-a", None, led) == []
     assert check_identity_consistency("host-b", None, led) == []
 
 
-def test_both_warnings_can_fire_together(tmp_path):
-    """Label points somewhere new AND the machine had another name."""
-    led = tmp_path / "ledger.json"
-    record_observation("label-a", "1111000000000000", led)
-    record_observation("label-b", "2222000000000000", led)
-    warns = check_identity_consistency("label-a", "2222000000000000", led)
-    kinds = {w.kind for w in warns}
-    assert kinds == {"label_moved_machine", "machine_renamed"}
+def test_stable_pairing_stays_silent(tmp_path):
+    led = tmp_path / "l.json"
+    for _ in range(5):
+        assert check_identity_consistency("host-d", "ffff555555555555", led) == []
 
-
-# ---------------------------------------------------------------------------
-# Ledger robustness. The first implementation json.loads()'d the file and then
-# indexed ledger["label_to_id"] directly, so a file containing VALID json of the
-# wrong shape raised KeyError/TypeError out of a function documented never to
-# raise. Testing only malformed json ("{not json") missed this completely.
-# ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize(
     "payload",
-    [
-        "[]",
-        '"just a string"',
-        "123",
-        "null",
-        '{"foo": 1}',
-        '{"label_to_id": "not-a-dict", "id_to_label": []}',
-        '{"label_to_id": {"a": 5}, "id_to_label": {"b": null}}',
-    ],
+    ["[]", '"str"', "123", "null", '{"foo": 1}',
+     '{"label_to_id": "nope", "id_to_label": []}',
+     '{"label_to_id": {"a": 5}, "id_to_label": {"b": null}}'],
 )
 def test_valid_json_of_the_wrong_shape_never_raises(tmp_path, payload):
-    led = tmp_path / "ledger.json"
+    led = tmp_path / "l.json"
     led.write_text(payload)
     assert check_identity_consistency("host-a", "aaaa000000000000", led) == []
     record_observation("host-a", "aaaa000000000000", led)
 
 
-def test_wrong_shape_ledger_is_repaired_on_next_write(tmp_path):
-    led = tmp_path / "ledger.json"
-    led.write_text('{"label_to_id": "not-a-dict"}')
-    record_observation("host-a", "aaaa000000000000", led)
-    data = json.loads(led.read_text())
-    assert data["label_to_id"]["host-a"] == "aaaa000000000000"
-    assert data["id_to_label"]["aaaa000000000000"] == "host-a"
+def test_corrupt_ledger_degrades_silently(tmp_path):
+    led = tmp_path / "l.json"
+    led.write_text("{not json")
+    assert check_identity_consistency("host-a", "eeee444444444444", led) == []
 
 
-def test_consistent_check_records_so_a_later_swap_is_caught(tmp_path):
-    """Documented side effect: check() bootstraps the ledger when consistent."""
-    led = tmp_path / "ledger.json"
-    assert check_identity_consistency("host-a", "1111000000000000", led) == []
-    warns = check_identity_consistency("host-a", "2222000000000000", led)
-    assert [w.kind for w in warns] == ["label_moved_machine"]
-
-
-def test_a_firing_warning_persists_across_runs(tmp_path):
-    """A warning must not be silently absorbed on the second run."""
-    led = tmp_path / "ledger.json"
-    record_observation("host-a", "1111000000000000", led)
-    for _ in range(3):
-        warns = check_identity_consistency("host-a", "2222000000000000", led)
-        assert [w.kind for w in warns] == ["label_moved_machine"]
-
-
-def test_unwritable_ledger_location_does_not_raise(tmp_path):
+def test_unwritable_location_does_not_raise(tmp_path):
     d = tmp_path / "ro"
     d.mkdir()
     d.chmod(0o500)
     try:
-        record_observation("host-a", "1111000000000000", d / "ledger.json")
+        record_observation("host-a", "1111000000000000", d / "l.json")
         assert check_identity_consistency("host-a", "1111000000000000", d / "l.json") == []
     finally:
         d.chmod(0o700)
 
 
-def test_concurrent_observations_do_not_lose_hosts(tmp_path):
-    """fleet.py runs hosts in a ThreadPoolExecutor; an unlocked
-    read-modify-write drops pairings and silently disarms swap detection."""
-    from concurrent.futures import ThreadPoolExecutor
+# --- THE LOCK-IN BUG -----------------------------------------------------
+# The old code recorded ONLY when no warning fired, so a misconfigured first run
+# was blessed permanently: the CORRECT machine then alarmed forever while the
+# WRONG one stayed silent, fixable only by hand-editing JSON.
 
-    led = tmp_path / "ledger.json"
+
+def test_a_wrong_first_pairing_can_be_corrected(tmp_path):
+    led = tmp_path / "l.json"
+    # Run 1: YAML typo -- the label reaches the wrong box. Nothing to compare to.
+    assert check_identity_consistency("lab-mac", "WRONG_BOX", led) == []
+    # Run 2: typo fixed. The real machine answers and is flagged.
+    assert [w.kind for w in check_identity_consistency("lab-mac", "REAL_MAC", led)] == [
+        "label_moved_machine"
+    ]
+    # The alarm PERSISTS -- it is not absorbed on the next run.
+    assert [w.kind for w in check_identity_consistency("lab-mac", "REAL_MAC", led)] == [
+        "label_moved_machine"
+    ]
+    assert "lab-mac" in pending_conflicts(led)
+    # ...but an operator can resolve it, without editing JSON by hand.
+    resolve_conflict("lab-mac", "REAL_MAC", led)
+    assert check_identity_consistency("lab-mac", "REAL_MAC", led) == []
+    assert pending_conflicts(led) == {}
+
+
+def test_the_wrong_box_now_alarms_after_resolution(tmp_path):
+    """Having corrected the record, reverting to the wrong box must be caught."""
+    led = tmp_path / "l.json"
+    check_identity_consistency("lab-mac", "WRONG_BOX", led)
+    resolve_conflict("lab-mac", "REAL_MAC", led)
+    assert [w.kind for w in check_identity_consistency("lab-mac", "WRONG_BOX", led)] == [
+        "label_moved_machine"
+    ]
+
+
+def test_conflict_records_both_sides(tmp_path):
+    led = tmp_path / "l.json"
+    record_observation("host-a", "AAA", led)
+    check_identity_consistency("host-a", "BBB", led)
+    conflict = pending_conflicts(led)["host-a"]
+    assert conflict["expected"] == "AAA"
+    assert conflict["observed"] == "BBB"
+
+
+# --- CONCURRENCY ---------------------------------------------------------
+
+
+def test_concurrent_observations_do_not_lose_hosts(tmp_path):
+    led = tmp_path / "l.json"
     hosts = [(f"host-{i:02d}", f"{i:016x}") for i in range(24)]
     with ThreadPoolExecutor(max_workers=8) as pool:
         list(pool.map(lambda h: record_observation(h[0], h[1], led), hosts))
-
     data = json.loads(led.read_text())
-    assert len(data["label_to_id"]) == 24, "a concurrent write clobbered a host"
+    assert len(data["label_to_id"]) == 24
     for label, mid in hosts:
         assert data["label_to_id"][label] == mid
 
 
-def test_no_temp_files_are_left_behind(tmp_path):
-    led = tmp_path / "ledger.json"
+def test_no_temp_files_left_behind(tmp_path):
+    led = tmp_path / "l.json"
     record_observation("host-a", "1111000000000000", led)
-    assert [p.name for p in tmp_path.iterdir()] == ["ledger.json"]
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp"))
+    assert leftovers == []

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -216,3 +216,36 @@ def test_a_swapped_and_swapped_back_box_still_reports(tmp_path):
     assert [w.kind for w in check_identity_consistency("host-a", "id-a", led)] == [
         "unresolved_conflict"
     ]
+
+
+# --- gpt-oss: an advisory module must never block a run -------------------
+
+
+def test_ledger_access_does_not_block_behind_a_held_lock(tmp_path):
+    """A plain blocking flock parks the run behind whoever holds the lock; if
+    that process is wedged the benchmark hangs with no output at all."""
+    import fcntl
+    import time
+
+    led = tmp_path / "l.json"
+    led.parent.mkdir(parents=True, exist_ok=True)
+    holder = open(led.with_name(led.name + ".lock"), "w")
+    fcntl.flock(holder, fcntl.LOCK_EX)
+    try:
+        start = time.monotonic()
+        record_observation("host-a", "id-a", led)          # must not hang
+        assert check_identity_consistency("host-a", "id-a", led) == []
+        assert time.monotonic() - start < 10, "ledger access blocked on a held lock"
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        holder.close()
+
+
+def test_a_corrupt_ledger_is_preserved_not_silently_discarded(tmp_path):
+    """Every recorded pairing is about to be dropped; leave the evidence."""
+    led = tmp_path / "l.json"
+    led.write_text('{"label_to_id": {"host-a": "id-a"}  <<<broken')
+    assert check_identity_consistency("host-b", "id-b", led) == []
+    corrupt = led.with_name(led.name + ".corrupt")
+    assert corrupt.exists()
+    assert "host-a" in corrupt.read_text()

--- a/tests/unit/identity/test_crosscheck.py
+++ b/tests/unit/identity/test_crosscheck.py
@@ -58,10 +58,13 @@ def test_valid_json_of_the_wrong_shape_never_raises(tmp_path, payload):
     record_observation("host-a", "aaaa000000000000", led)
 
 
-def test_corrupt_ledger_degrades_silently(tmp_path):
+def test_corrupt_ledger_degrades_without_raising_but_does_not_stay_silent(tmp_path):
+    """It must not raise — but silence here was the defect: a wiped ledger
+    disarms every open conflict, so the loss has to be reported."""
     led = tmp_path / "l.json"
     led.write_text("{not json")
-    assert check_identity_consistency("host-a", "eeee444444444444", led) == []
+    warns = check_identity_consistency("host-a", "eeee444444444444", led)
+    assert [w.kind for w in warns] == ["ledger_history_lost"]
 
 
 def test_unwritable_location_does_not_raise(tmp_path):
@@ -245,7 +248,27 @@ def test_a_corrupt_ledger_is_preserved_not_silently_discarded(tmp_path):
     """Every recorded pairing is about to be dropped; leave the evidence."""
     led = tmp_path / "l.json"
     led.write_text('{"label_to_id": {"host-a": "id-a"}  <<<broken')
-    assert check_identity_consistency("host-b", "id-b", led) == []
+    warns = check_identity_consistency("host-b", "id-b", led)
+    assert [w.kind for w in warns] == ["ledger_history_lost"]
     corrupt = led.with_name(led.name + ".corrupt")
     assert corrupt.exists()
     assert "host-a" in corrupt.read_text()
+
+
+def test_a_reset_ledger_announces_that_history_was_lost(tmp_path):
+    """Preserving the corrupt file is not enough: every open conflict is gone,
+    so a swap that was already flagged stops being flagged."""
+    led = tmp_path / "l.json"
+    led.write_text("{not json at all")
+    warns = check_identity_consistency("host-a", "id-a", led)
+    assert [w.kind for w in warns] == ["ledger_history_lost"]
+    assert "corrupt" in warns[0].message
+    assert led.with_name(led.name + ".corrupt").exists()
+
+
+def test_the_lost_history_warning_stops_once_hosts_are_re_observed(tmp_path):
+    led = tmp_path / "l.json"
+    led.write_text("{not json at all")
+    check_identity_consistency("host-a", "id-a", led)
+    record_observation("host-a", "id-a", led)
+    assert check_identity_consistency("host-a", "id-a", led) == []

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -124,3 +124,40 @@ def test_same_machine_reported_in_different_case_gives_one_id():
 def test_filler_serial_yields_no_identity_rather_than_a_shared_one():
     ident = MachineIdentifiers(hardware_serial="To Be Filled By O.E.M")
     assert derive_machine_id(ident, SALT).machine_id is None
+
+
+# --- qwen3.5: a clone-vulnerable identity must say so -------------------
+
+
+def test_a_cloned_vm_derives_the_same_id_but_is_flagged_transferable():
+    """Two VMs from one image share /etc/machine-id, so they share an id. That
+    is unavoidable — what is not acceptable is failing to SAY so."""
+    a = MachineIdentifiers(persisted_token="deadbeefcafe1234")  # noqa: S106 - field name, not a credential
+    b = MachineIdentifiers(persisted_token="deadbeefcafe1234")  # noqa: S106 - field name, not a credential
+    ia, ib = derive_machine_id(a, SALT), derive_machine_id(b, SALT)
+    assert ia.machine_id == ib.machine_id
+    assert ia.is_transferable
+    assert "transferable" in ia.basis
+    assert "clone" in ia.basis
+
+
+def test_a_firmware_rooted_identity_is_not_transferable():
+    got = derive_machine_id(FULL, SALT)
+    assert not got.is_transferable
+    assert "transferable" not in got.basis
+
+
+def test_an_unscoped_id_is_not_comparable():
+    """Bare bytes carry no scope, so the id must not be matched against a
+    scoped one — same shape, different namespace."""
+    bare = derive_machine_id(FULL, SALT)
+    scoped = derive_machine_id(FULL, SaltInfo(SALT, "fleet:file"))
+    assert bare.salt_scope == "unspecified"
+    assert not bare.is_comparable
+    assert scoped.is_comparable
+    assert bare.machine_id == scoped.machine_id  # identical value...
+    assert bare.is_comparable != scoped.is_comparable  # ...but not interchangeable
+
+
+def test_a_null_identity_is_never_comparable():
+    assert not derive_machine_id(MachineIdentifiers(), SaltInfo(SALT, "fleet:env")).is_comparable

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -41,12 +41,12 @@ def test_preference_order_strongest_first():
     assert select_source(FULL)[0] == "firmware-uuid+serial"
     assert select_source(MachineIdentifiers(firmware_uuid="U"))[0] == "firmware-uuid"
     assert select_source(MachineIdentifiers(hardware_serial="S"))[0] == "hardware-serial"
-    assert select_source(MachineIdentifiers(persisted_token="T"))[0] == "persisted-token"
+    assert select_source(MachineIdentifiers(persisted_token="T"))[0] == "persisted-token"  # noqa: S106 - field name, not a credential
 
 
 def test_firmware_root_outranks_the_on_disk_token():
     """A cloned disk image duplicates the token; firmware survives reinstall."""
-    ident = MachineIdentifiers(firmware_uuid="U", persisted_token="T")
+    ident = MachineIdentifiers(firmware_uuid="U", persisted_token="T")  # noqa: S106 - field name, not a credential
     assert derive_machine_id(ident, SALT).source == "firmware-uuid"
 
 
@@ -76,6 +76,6 @@ def test_raw_identifiers_never_appear_in_the_result():
 def test_source_change_is_visible_rather_than_silent():
     """Losing the firmware root changes the id -- but the source says why."""
     strong = derive_machine_id(FULL, SALT)
-    weak = derive_machine_id(MachineIdentifiers(persisted_token="T"), SALT)
+    weak = derive_machine_id(MachineIdentifiers(persisted_token="T"), SALT)  # noqa: S106 - field name, not a credential
     assert strong.source != weak.source
     assert strong.machine_id != weak.machine_id

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -1,0 +1,61 @@
+"""Salted machine_id derivation (hermia-cfqv)."""
+from hermia.identity.derive import derive_machine_id
+from hermia.identity.types import HardwareFacts
+
+SALT = b"\x01" * 32
+OTHER = b"\x02" * 32
+M1 = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "darwin")
+
+
+def test_id_is_16_hex_chars_and_deterministic():
+    a = derive_machine_id(M1, SALT)
+    b = derive_machine_id(M1, SALT)
+    assert a.machine_id == b.machine_id
+    assert a.machine_id is not None
+    assert len(a.machine_id) == 16
+    assert all(c in "0123456789abcdef" for c in a.machine_id)
+
+
+def test_different_salt_gives_different_id_for_same_machine():
+    assert (
+        derive_machine_id(M1, SALT).machine_id
+        != derive_machine_id(M1, OTHER).machine_id
+    )
+
+
+def test_two_identical_models_with_different_uuids_do_not_collide():
+    """Two laptops of identical model and memory must never share an id."""
+    a = HardwareFacts("UUID-A", "Apple M1 Pro", 17179869184, "darwin")
+    b = HardwareFacts("UUID-B", "Apple M1 Pro", 17179869184, "darwin")
+    assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id
+
+
+def test_missing_platform_uuid_yields_null_id_with_reason():
+    f = HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin")
+    got = derive_machine_id(f, SALT)
+    assert got.machine_id is None
+    assert got.basis == "unavailable:no-platform-uuid"
+
+
+def test_id_changes_when_ram_changes():
+    """RAM is entropy in the tuple, so a genuine hardware change is visible."""
+    more = HardwareFacts("UUID-1", "Apple M1 Pro", 34359738368, "darwin")
+    assert derive_machine_id(more, SALT).machine_id != derive_machine_id(M1, SALT).machine_id
+
+
+def test_raw_identifiers_never_appear_in_the_result():
+    got = derive_machine_id(M1, SALT)
+    blob = f"{got.machine_id}{got.basis}{got.os_family}"
+    assert "UUID-1" not in blob
+    assert "Apple M1 Pro" not in blob
+    assert "17179869184" not in blob
+
+
+def test_basis_records_what_was_measured_on_success():
+    assert derive_machine_id(M1, SALT).basis == "measured:platform-uuid+cpu+ram"
+
+
+def test_same_uuid_different_os_family_does_not_collide():
+    a = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "darwin")
+    b = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "linux")
+    assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -1,61 +1,81 @@
-"""Salted machine_id derivation (hermia-cfqv)."""
-from hermia.identity.derive import derive_machine_id
-from hermia.identity.types import HardwareFacts
+"""Exact identity derivation (hermia-cfqv)."""
+from hermia.identity.derive import derive_machine_id, select_source
+from hermia.identity.types import MachineIdentifiers
 
 SALT = b"\x01" * 32
 OTHER = b"\x02" * 32
-M1 = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "darwin")
+FULL = MachineIdentifiers(firmware_uuid="UUID-1", hardware_serial="SER-1")
 
 
-def test_id_is_16_hex_chars_and_deterministic():
-    a = derive_machine_id(M1, SALT)
-    b = derive_machine_id(M1, SALT)
+def test_id_is_16_hex_and_deterministic():
+    a, b = derive_machine_id(FULL, SALT), derive_machine_id(FULL, SALT)
     assert a.machine_id == b.machine_id
-    assert a.machine_id is not None
-    assert len(a.machine_id) == 16
+    assert a.machine_id is not None and len(a.machine_id) == 16
     assert all(c in "0123456789abcdef" for c in a.machine_id)
 
 
-def test_different_salt_gives_different_id_for_same_machine():
-    assert (
-        derive_machine_id(M1, SALT).machine_id
-        != derive_machine_id(M1, OTHER).machine_id
-    )
+def test_different_salt_gives_different_id():
+    assert derive_machine_id(FULL, SALT).machine_id != derive_machine_id(FULL, OTHER).machine_id
 
 
-def test_two_identical_models_with_different_uuids_do_not_collide():
-    """Two laptops of identical model and memory must never share an id."""
-    a = HardwareFacts("UUID-A", "Apple M1 Pro", 17179869184, "darwin")
-    b = HardwareFacts("UUID-B", "Apple M1 Pro", 17179869184, "darwin")
+def test_two_machines_same_model_do_not_collide():
+    a = MachineIdentifiers(firmware_uuid="UUID-A", hardware_serial="SER-A")
+    b = MachineIdentifiers(firmware_uuid="UUID-B", hardware_serial="SER-B")
     assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id
 
 
-def test_missing_platform_uuid_yields_null_id_with_reason():
-    f = HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin")
-    got = derive_machine_id(f, SALT)
+def test_no_usable_identifier_yields_null_with_reason():
+    got = derive_machine_id(MachineIdentifiers(), SALT)
     assert got.machine_id is None
-    assert got.basis == "unavailable:no-platform-uuid"
+    assert got.basis == "unavailable:no-usable-identifier"
+    assert got.source == "none"
 
 
-def test_id_changes_when_ram_changes():
-    """RAM is entropy in the tuple, so a genuine hardware change is visible."""
-    more = HardwareFacts("UUID-1", "Apple M1 Pro", 34359738368, "darwin")
-    assert derive_machine_id(more, SALT).machine_id != derive_machine_id(M1, SALT).machine_id
+def test_placeholder_identifiers_do_not_produce_an_identity():
+    """A vendor placeholder must never become a shared identity."""
+    ident = MachineIdentifiers(firmware_uuid="00000000-0000-0000-0000-000000000000")
+    assert derive_machine_id(ident, SALT).machine_id is None
+
+
+def test_preference_order_strongest_first():
+    assert select_source(FULL)[0] == "firmware-uuid+serial"
+    assert select_source(MachineIdentifiers(firmware_uuid="U"))[0] == "firmware-uuid"
+    assert select_source(MachineIdentifiers(hardware_serial="S"))[0] == "hardware-serial"
+    assert select_source(MachineIdentifiers(persisted_token="T"))[0] == "persisted-token"
+
+
+def test_firmware_root_outranks_the_on_disk_token():
+    """A cloned disk image duplicates the token; firmware survives reinstall."""
+    ident = MachineIdentifiers(firmware_uuid="U", persisted_token="T")
+    assert derive_machine_id(ident, SALT).source == "firmware-uuid"
+
+
+# --- THE POINT OF THE SPLIT ---------------------------------------------
+
+
+def test_capabilities_cannot_change_the_identity():
+    """A RAM upgrade, a kernel update, a new GPU: identity must not move.
+
+    The previous design hashed ram_bytes into the id, so a Linux kernel update
+    that shifts MemTotal looked exactly like a hardware swap.
+    """
+    before = derive_machine_id(FULL, SALT)
+    # There is deliberately no way to pass capabilities in at all.
+    after = derive_machine_id(
+        MachineIdentifiers(firmware_uuid="UUID-1", hardware_serial="SER-1"), SALT
+    )
+    assert before.machine_id == after.machine_id
 
 
 def test_raw_identifiers_never_appear_in_the_result():
-    got = derive_machine_id(M1, SALT)
-    blob = f"{got.machine_id}{got.basis}{got.os_family}"
-    assert "UUID-1" not in blob
-    assert "Apple M1 Pro" not in blob
-    assert "17179869184" not in blob
+    got = derive_machine_id(FULL, SALT)
+    blob = f"{got.machine_id}{got.source}{got.basis}"
+    assert "UUID-1" not in blob and "SER-1" not in blob
 
 
-def test_basis_records_what_was_measured_on_success():
-    assert derive_machine_id(M1, SALT).basis == "measured:platform-uuid+cpu+ram"
-
-
-def test_same_uuid_different_os_family_does_not_collide():
-    a = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "darwin")
-    b = HardwareFacts("UUID-1", "Apple M1 Pro", 17179869184, "linux")
-    assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id
+def test_source_change_is_visible_rather_than_silent():
+    """Losing the firmware root changes the id -- but the source says why."""
+    strong = derive_machine_id(FULL, SALT)
+    weak = derive_machine_id(MachineIdentifiers(persisted_token="T"), SALT)
+    assert strong.source != weak.source
+    assert strong.machine_id != weak.machine_id

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -1,5 +1,8 @@
 """Exact identity derivation (hermia-cfqv)."""
+import pytest
+
 from hermia.identity.derive import derive_machine_id, select_source
+from hermia.identity.salt import SaltInfo
 from hermia.identity.types import MachineIdentifiers
 
 SALT = b"\x01" * 32
@@ -79,3 +82,33 @@ def test_source_change_is_visible_rather_than_silent():
     weak = derive_machine_id(MachineIdentifiers(persisted_token="T"), SALT)  # noqa: S106 - field name, not a credential
     assert strong.source != weak.source
     assert strong.machine_id != weak.machine_id
+
+
+# --- CodeRabbit: a degenerate salt must fail loudly ----------------------
+
+
+@pytest.mark.parametrize("bad", [b"", b"x", b"\x00" * 31, b"\x00" * 33, "notbytes"])
+def test_invalid_salt_is_rejected(bad):
+    """An empty/short salt yields a confident id with a tiny keyspace, which
+    makes the underlying hardware identifier confirmable by brute force."""
+    with pytest.raises(ValueError, match="32 bytes"):
+        derive_machine_id(FULL, bad)
+
+
+def test_salt_scope_is_carried_onto_the_identity():
+    """salt.py requires the scope be recorded with any derived id; without this
+    an install-scoped id and a fleet-scoped id look identical in shape."""
+    info = SaltInfo(SALT, "fleet:env")
+    got = derive_machine_id(FULL, info)
+    assert got.salt_scope == "fleet:env"
+    assert got.machine_id is not None
+
+
+def test_scope_is_carried_even_when_nothing_is_identifiable():
+    got = derive_machine_id(MachineIdentifiers(), SaltInfo(SALT, "install"))
+    assert got.machine_id is None
+    assert got.salt_scope == "install"
+
+
+def test_bare_bytes_salt_reports_an_unspecified_scope():
+    assert derive_machine_id(FULL, SALT).salt_scope == "unspecified"

--- a/tests/unit/identity/test_derive.py
+++ b/tests/unit/identity/test_derive.py
@@ -7,7 +7,7 @@ from hermia.identity.types import MachineIdentifiers
 
 SALT = b"\x01" * 32
 OTHER = b"\x02" * 32
-FULL = MachineIdentifiers(firmware_uuid="UUID-1", hardware_serial="SER-1")
+FULL = MachineIdentifiers(firmware_uuid="UUID-0001-AAAA", hardware_serial="SERIAL-0001")
 
 
 def test_id_is_16_hex_and_deterministic():
@@ -22,8 +22,8 @@ def test_different_salt_gives_different_id():
 
 
 def test_two_machines_same_model_do_not_collide():
-    a = MachineIdentifiers(firmware_uuid="UUID-A", hardware_serial="SER-A")
-    b = MachineIdentifiers(firmware_uuid="UUID-B", hardware_serial="SER-B")
+    a = MachineIdentifiers(firmware_uuid="UUID-000A-AAAA", hardware_serial="SERIAL-000A")
+    b = MachineIdentifiers(firmware_uuid="UUID-000B-BBBB", hardware_serial="SERIAL-000B")
     assert derive_machine_id(a, SALT).machine_id != derive_machine_id(b, SALT).machine_id
 
 
@@ -42,14 +42,14 @@ def test_placeholder_identifiers_do_not_produce_an_identity():
 
 def test_preference_order_strongest_first():
     assert select_source(FULL)[0] == "firmware-uuid+serial"
-    assert select_source(MachineIdentifiers(firmware_uuid="U"))[0] == "firmware-uuid"
-    assert select_source(MachineIdentifiers(hardware_serial="S"))[0] == "hardware-serial"
-    assert select_source(MachineIdentifiers(persisted_token="T"))[0] == "persisted-token"  # noqa: S106 - field name, not a credential
+    assert select_source(MachineIdentifiers(firmware_uuid="UUID-0001-AAAA"))[0] == "firmware-uuid"
+    assert select_source(MachineIdentifiers(hardware_serial="SERIAL-0001"))[0] == "hardware-serial"
+    assert select_source(MachineIdentifiers(persisted_token="TOKEN-0001"))[0] == "persisted-token"  # noqa: S106 - field name, not a credential
 
 
 def test_firmware_root_outranks_the_on_disk_token():
     """A cloned disk image duplicates the token; firmware survives reinstall."""
-    ident = MachineIdentifiers(firmware_uuid="U", persisted_token="T")  # noqa: S106 - field name, not a credential
+    ident = MachineIdentifiers(firmware_uuid="UUID-0001-AAAA", persisted_token="TOKEN-0001")  # noqa: S106 - field name, not a credential
     assert derive_machine_id(ident, SALT).source == "firmware-uuid"
 
 
@@ -65,7 +65,7 @@ def test_capabilities_cannot_change_the_identity():
     before = derive_machine_id(FULL, SALT)
     # There is deliberately no way to pass capabilities in at all.
     after = derive_machine_id(
-        MachineIdentifiers(firmware_uuid="UUID-1", hardware_serial="SER-1"), SALT
+        MachineIdentifiers(firmware_uuid="UUID-0001-AAAA", hardware_serial="SERIAL-0001"), SALT
     )
     assert before.machine_id == after.machine_id
 
@@ -73,13 +73,13 @@ def test_capabilities_cannot_change_the_identity():
 def test_raw_identifiers_never_appear_in_the_result():
     got = derive_machine_id(FULL, SALT)
     blob = f"{got.machine_id}{got.source}{got.basis}"
-    assert "UUID-1" not in blob and "SER-1" not in blob
+    assert "UUID-0001-AAAA" not in blob and "SERIAL-0001" not in blob
 
 
 def test_source_change_is_visible_rather_than_silent():
     """Losing the firmware root changes the id -- but the source says why."""
     strong = derive_machine_id(FULL, SALT)
-    weak = derive_machine_id(MachineIdentifiers(persisted_token="T"), SALT)  # noqa: S106 - field name, not a credential
+    weak = derive_machine_id(MachineIdentifiers(persisted_token="TOKEN-0001"), SALT)  # noqa: S106 - field name, not a credential
     assert strong.source != weak.source
     assert strong.machine_id != weak.machine_id
 
@@ -112,3 +112,15 @@ def test_scope_is_carried_even_when_nothing_is_identifiable():
 
 def test_bare_bytes_salt_reports_an_unspecified_scope():
     assert derive_machine_id(FULL, SALT).salt_scope == "unspecified"
+
+
+def test_same_machine_reported_in_different_case_gives_one_id():
+    """Punctuation must not fork a physical machine into two identities."""
+    lower = MachineIdentifiers(firmware_uuid="4c4c4544-0031-104d-8032-b8c04f4a3633")
+    upper = MachineIdentifiers(firmware_uuid="4C4C4544-0031-104D-8032-B8C04F4A3633")
+    assert derive_machine_id(lower, SALT).machine_id == derive_machine_id(upper, SALT).machine_id
+
+
+def test_filler_serial_yields_no_identity_rather_than_a_shared_one():
+    ident = MachineIdentifiers(hardware_serial="To Be Filled By O.E.M")
+    assert derive_machine_id(ident, SALT).machine_id is None

--- a/tests/unit/identity/test_probes.py
+++ b/tests/unit/identity/test_probes.py
@@ -1,151 +1,121 @@
-"""Cross-platform local hardware probe (hermia-cfqv)."""
+"""Cross-platform probe: identifiers vs capabilities (hermia-cfqv)."""
+import platform as _platform
 from unittest.mock import patch
 
-from hermia.identity.probes import LocalProbe
+import pytest
 
-IOREG_OUT = '    "IOPlatformUUID" = "ABC-123"\n'
+from hermia.identity.probes import LocalProbe, _reg_value
 
 
 def _mac_run(cmd, **kwargs):
     joined = " ".join(cmd)
     if "ioreg" in joined:
-        return IOREG_OUT
+        return '  "IOPlatformUUID" = "ABC-123"\n  "IOPlatformSerialNumber" = "C02XY"\n'
     if "machdep.cpu.brand_string" in joined:
         return "Apple M1 Pro"
     if "hw.memsize" in joined:
         return "17179869184"
+    if "hw.logicalcpu" in joined:
+        return "10"
+    if "hw.model" in joined:
+        return "MacBookPro18,1"
     return None
 
 
-def test_macos_probe_parses_ioreg_and_sysctl():
+def test_macos_splits_identifiers_from_capabilities():
     with patch("hermia.identity.probes._run", side_effect=_mac_run):
-        f = LocalProbe(os_family="darwin").probe()
-    assert f.platform_uuid == "ABC-123"
-    assert f.cpu_brand == "Apple M1 Pro"
-    assert f.ram_bytes == 17179869184
-    assert f.is_identifiable
-    assert f.unavailable == ()
+        obs = LocalProbe(os_family="darwin").probe()
+    assert obs.identifiers.firmware_uuid == "ABC-123"
+    assert obs.identifiers.hardware_serial == "C02XY"
+    assert obs.capabilities.ram_bytes == 17179869184
+    assert obs.capabilities.cpu_brand == "Apple M1 Pro"
+    assert obs.capabilities.model_identifier == "MacBookPro18,1"
 
 
 def test_probe_failure_yields_none_not_a_guess():
     with patch("hermia.identity.probes._run", return_value=None):
-        f = LocalProbe(os_family="darwin").probe()
-    assert f.platform_uuid is None
-    assert not f.is_identifiable
-    assert "platform_uuid" in f.unavailable
+        obs = LocalProbe(os_family="darwin").probe()
+    assert obs.identifiers.firmware_uuid is None
+    assert not obs.identifiers.is_identifiable
+    assert "firmware_uuid" in obs.identifiers.unavailable
+    assert obs.capabilities.ram_bytes is None
 
 
-def test_unsupported_os_reports_unavailable_rather_than_raising():
-    f = LocalProbe(os_family="plan9").probe()
-    assert f.platform_uuid is None
-    assert f.os_family == "plan9"
-    assert not f.is_identifiable
+def test_unsupported_os_does_not_raise():
+    obs = LocalProbe(os_family="plan9").probe()
+    assert not obs.identifiers.is_identifiable
+    assert obs.capabilities.os_family == "plan9"
 
 
-def test_ram_bytes_is_never_zero_when_unmeasured():
-    """0 would read as a real measurement of a 0-byte machine."""
-    with patch("hermia.identity.probes._run", return_value=""):
-        f = LocalProbe(os_family="darwin").probe()
-    assert f.ram_bytes is None
+def test_default_os_family_is_platform_system_not_os_name():
+    """os.name returns 'posix' on macOS AND Linux, matching no branch at all."""
+    assert LocalProbe().os_family == _platform.system().lower()
+    assert LocalProbe().os_family not in {"posix", "nt", "java"}
 
 
-def test_non_numeric_ram_is_none_not_an_exception():
-    def bad(cmd, **kwargs):
-        return "not-a-number" if "hw.memsize" in " ".join(cmd) else _mac_run(cmd)
+def test_linux_prefers_the_firmware_root_over_the_on_disk_token():
+    """Regression: the old code read /etc/machine-id first and never fell
+    through to the firmware UUID, silently preferring the weakest identifier."""
 
-    with patch("hermia.identity.probes._run", side_effect=bad):
-        f = LocalProbe(os_family="darwin").probe()
-    assert f.ram_bytes is None
-    assert "ram_bytes" in f.unavailable
-
-
-def test_linux_meminfo_kb_is_converted_to_bytes():
     def read(path):
         return {
+            "/sys/class/dmi/id/product_uuid": "DMI-UUID-9\n",
+            "/sys/class/dmi/id/board_serial": "BOARD-7\n",
             "/etc/machine-id": "deadbeef\n",
-            "/proc/cpuinfo": "model name\t: AMD Ryzen 9\n",
+            "/proc/cpuinfo": "processor\t: 0\nmodel name\t: AMD Ryzen 9\n",
             "/proc/meminfo": "MemTotal:       32768000 kB\n",
         }.get(str(path))
 
     with patch("hermia.identity.probes._read_text", side_effect=read):
-        f = LocalProbe(os_family="linux").probe()
-    assert f.platform_uuid == "deadbeef"
-    assert f.cpu_brand == "AMD Ryzen 9"
-    assert f.ram_bytes == 32768000 * 1024
+        obs = LocalProbe(os_family="linux").probe()
+    assert obs.identifiers.firmware_uuid == "DMI-UUID-9"
+    assert obs.identifiers.hardware_serial == "BOARD-7"
+    assert obs.identifiers.persisted_token == "deadbeef"
+    assert obs.capabilities.ram_bytes == 32768000 * 1024
+    assert obs.capabilities.cpu_brand == "AMD Ryzen 9"
 
 
-def test_linux_falls_back_to_dmi_product_uuid_when_machine_id_absent():
+def test_linux_root_gated_dmi_falls_back_to_the_token_but_records_the_gap():
     def read(path):
-        return {
-            "/sys/class/dmi/id/product_uuid": "DMI-UUID-9\n",
-            "/proc/cpuinfo": "model name\t: AMD Ryzen 9\n",
-            "/proc/meminfo": "MemTotal:       1024 kB\n",
-        }.get(str(path))
+        return {"/etc/machine-id": "deadbeef\n"}.get(str(path))
 
     with patch("hermia.identity.probes._read_text", side_effect=read):
-        f = LocalProbe(os_family="linux").probe()
-    assert f.platform_uuid == "DMI-UUID-9"
+        obs = LocalProbe(os_family="linux").probe()
+    assert obs.identifiers.firmware_uuid is None
+    assert obs.identifiers.persisted_token == "deadbeef"
+    assert "firmware_uuid" in obs.identifiers.unavailable
 
 
-def test_no_mac_address_is_ever_collected():
-    """A MAC-derived identity would migrate with a dongle or dock."""
-    with patch("hermia.identity.probes._run", side_effect=_mac_run):
-        f = LocalProbe(os_family="darwin").probe()
-    assert not hasattr(f, "mac")
-    assert not hasattr(f, "mac_address")
-
-
-# ---------------------------------------------------------------------------
-# Regression tests for OS-family detection.
-#
-# The first fleet-generated implementation used `os.name` (which returns
-# "posix" on macOS AND Linux, "nt" on Windows) and matched the Windows branch
-# on "win32". Both are wrong for `platform.system().lower()`, so the default
-# constructor silently probed NOTHING on every platform and returned all-nulls.
-# The end-to-end determinism test did not catch it, because null == null is
-# perfectly stable. These assert the actual family strings.
-# ---------------------------------------------------------------------------
-
-
-def test_default_os_family_is_platform_system_not_os_name():
-    import platform as _platform
-
-    assert LocalProbe().os_family == _platform.system().lower()
-
-
-def test_default_os_family_is_never_a_posix_or_nt_style_value():
-    assert LocalProbe().os_family not in {"posix", "nt", "java"}
-
-
-def test_windows_branch_matches_the_string_platform_system_returns():
-    """platform.system().lower() is 'windows' — never 'win32'."""
+def test_windows_reads_the_firmware_uuid_not_only_machineguid():
+    """Regression: the old code read ONLY MachineGuid, an OS-install id."""
 
     def win_run(cmd, **kwargs):
         joined = " ".join(cmd)
+        if "csproduct" in joined and "UUID" in joined:
+            return "UUID\n4C4C4544-0031\n"
+        if "baseboard" in joined:
+            return "SerialNumber\nBOARD-XYZ\n"
         if "MachineGuid" in joined:
-            return "    MachineGuid    REG_SZ    GUID-XYZ\n"
-        if "wmic" in joined:
-            return "TotalPhysicalMemory\n34359738368\n"
+            return "    MachineGuid    REG_SZ    guid-abc\n"
         return None
 
     with patch("hermia.identity.probes._run", side_effect=win_run):
-        f = LocalProbe(os_family="windows").probe()
-    assert f.platform_uuid == "GUID-XYZ"
-    assert f.ram_bytes == 34359738368
-    assert f.is_identifiable
+        obs = LocalProbe(os_family="windows").probe()
+    assert obs.identifiers.firmware_uuid == "4C4C4544-0031"
+    assert obs.identifiers.hardware_serial == "BOARD-XYZ"
+    assert obs.identifiers.persisted_token == "guid-abc"
 
 
-def test_darwin_probe_actually_measures_on_this_machine_when_on_darwin():
-    """On a real Mac the default probe must produce a usable identity."""
-    import platform as _platform
-
-    import pytest
-
-    if _platform.system().lower() != "darwin":
-        pytest.skip("darwin-only: asserts the default probe measures real hardware")
-    f = LocalProbe().probe()
-    assert f.is_identifiable, f"default probe measured nothing: {f.unavailable}"
-    assert f.ram_bytes and f.ram_bytes > 0
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("    MachineGuid    REG_SZ    abc-123\n", "abc-123"),
+        ("    MachineGuid    REG_SZ    \n", None),
+        ("    MachineGuid    REG_SZ\n", None),
+    ],
+)
+def test_empty_registry_value_is_not_mistaken_for_an_identifier(line, expected):
+    assert _reg_value(line, "MachineGuid") == expected
 
 
 def test_blank_measurement_counts_as_unmeasured():
@@ -153,32 +123,15 @@ def test_blank_measurement_counts_as_unmeasured():
         return '  "IOPlatformUUID" = ""  ' if "ioreg" in " ".join(cmd) else "   "
 
     with patch("hermia.identity.probes._run", side_effect=blank):
-        f = LocalProbe(os_family="darwin").probe()
-    assert f.platform_uuid is None
-    assert f.cpu_brand is None
-    assert set(f.unavailable) == {"platform_uuid", "cpu_brand", "ram_bytes"}
+        obs = LocalProbe(os_family="darwin").probe()
+    assert obs.identifiers.firmware_uuid is None
+    assert obs.capabilities.cpu_brand is None
 
 
-def test_empty_windows_registry_value_is_not_mistaken_for_a_uuid():
-    """`reg query` prints '<name> <type> <value>'. An EMPTY value leaves only
-    two tokens, and taking the last one returns the literal type name 'REG_SZ'
-    — a fabricated identity that every affected box would share."""
-    from hermia.identity.probes import _windows_uuid
-
-    assert _windows_uuid("    MachineGuid    REG_SZ    \n") is None
-    assert _windows_uuid("    MachineGuid    REG_SZ\n") is None
-    assert _windows_uuid("    MachineGuid    REG_SZ    abc-123\n") == "abc-123"
-
-
-def test_windows_probe_with_empty_guid_is_not_identifiable():
-    def win_run(cmd, **kwargs):
-        joined = " ".join(cmd)
-        if "MachineGuid" in joined:
-            return "    MachineGuid    REG_SZ    \n"
-        return None
-
-    with patch("hermia.identity.probes._run", side_effect=win_run):
-        f = LocalProbe(os_family="windows").probe()
-    assert f.platform_uuid is None
-    assert not f.is_identifiable
-    assert "platform_uuid" in f.unavailable
+def test_real_probe_measures_something_on_this_machine():
+    if _platform.system().lower() != "darwin":
+        pytest.skip("darwin-only: asserts the default probe measures real hardware")
+    obs = LocalProbe().probe()
+    assert obs.identifiers.is_identifiable, f"measured nothing: {obs.identifiers.unavailable}"
+    assert obs.capabilities.ram_bytes and obs.capabilities.ram_bytes > 0
+    assert obs.capabilities.model_identifier

--- a/tests/unit/identity/test_probes.py
+++ b/tests/unit/identity/test_probes.py
@@ -1,0 +1,184 @@
+"""Cross-platform local hardware probe (hermia-cfqv)."""
+from unittest.mock import patch
+
+from hermia.identity.probes import LocalProbe
+
+IOREG_OUT = '    "IOPlatformUUID" = "ABC-123"\n'
+
+
+def _mac_run(cmd, **kwargs):
+    joined = " ".join(cmd)
+    if "ioreg" in joined:
+        return IOREG_OUT
+    if "machdep.cpu.brand_string" in joined:
+        return "Apple M1 Pro"
+    if "hw.memsize" in joined:
+        return "17179869184"
+    return None
+
+
+def test_macos_probe_parses_ioreg_and_sysctl():
+    with patch("hermia.identity.probes._run", side_effect=_mac_run):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.platform_uuid == "ABC-123"
+    assert f.cpu_brand == "Apple M1 Pro"
+    assert f.ram_bytes == 17179869184
+    assert f.is_identifiable
+    assert f.unavailable == ()
+
+
+def test_probe_failure_yields_none_not_a_guess():
+    with patch("hermia.identity.probes._run", return_value=None):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.platform_uuid is None
+    assert not f.is_identifiable
+    assert "platform_uuid" in f.unavailable
+
+
+def test_unsupported_os_reports_unavailable_rather_than_raising():
+    f = LocalProbe(os_family="plan9").probe()
+    assert f.platform_uuid is None
+    assert f.os_family == "plan9"
+    assert not f.is_identifiable
+
+
+def test_ram_bytes_is_never_zero_when_unmeasured():
+    """0 would read as a real measurement of a 0-byte machine."""
+    with patch("hermia.identity.probes._run", return_value=""):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.ram_bytes is None
+
+
+def test_non_numeric_ram_is_none_not_an_exception():
+    def bad(cmd, **kwargs):
+        return "not-a-number" if "hw.memsize" in " ".join(cmd) else _mac_run(cmd)
+
+    with patch("hermia.identity.probes._run", side_effect=bad):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.ram_bytes is None
+    assert "ram_bytes" in f.unavailable
+
+
+def test_linux_meminfo_kb_is_converted_to_bytes():
+    def read(path):
+        return {
+            "/etc/machine-id": "deadbeef\n",
+            "/proc/cpuinfo": "model name\t: AMD Ryzen 9\n",
+            "/proc/meminfo": "MemTotal:       32768000 kB\n",
+        }.get(str(path))
+
+    with patch("hermia.identity.probes._read_text", side_effect=read):
+        f = LocalProbe(os_family="linux").probe()
+    assert f.platform_uuid == "deadbeef"
+    assert f.cpu_brand == "AMD Ryzen 9"
+    assert f.ram_bytes == 32768000 * 1024
+
+
+def test_linux_falls_back_to_dmi_product_uuid_when_machine_id_absent():
+    def read(path):
+        return {
+            "/sys/class/dmi/id/product_uuid": "DMI-UUID-9\n",
+            "/proc/cpuinfo": "model name\t: AMD Ryzen 9\n",
+            "/proc/meminfo": "MemTotal:       1024 kB\n",
+        }.get(str(path))
+
+    with patch("hermia.identity.probes._read_text", side_effect=read):
+        f = LocalProbe(os_family="linux").probe()
+    assert f.platform_uuid == "DMI-UUID-9"
+
+
+def test_no_mac_address_is_ever_collected():
+    """A MAC-derived identity would migrate with a dongle or dock."""
+    with patch("hermia.identity.probes._run", side_effect=_mac_run):
+        f = LocalProbe(os_family="darwin").probe()
+    assert not hasattr(f, "mac")
+    assert not hasattr(f, "mac_address")
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for OS-family detection.
+#
+# The first fleet-generated implementation used `os.name` (which returns
+# "posix" on macOS AND Linux, "nt" on Windows) and matched the Windows branch
+# on "win32". Both are wrong for `platform.system().lower()`, so the default
+# constructor silently probed NOTHING on every platform and returned all-nulls.
+# The end-to-end determinism test did not catch it, because null == null is
+# perfectly stable. These assert the actual family strings.
+# ---------------------------------------------------------------------------
+
+
+def test_default_os_family_is_platform_system_not_os_name():
+    import platform as _platform
+
+    assert LocalProbe().os_family == _platform.system().lower()
+
+
+def test_default_os_family_is_never_a_posix_or_nt_style_value():
+    assert LocalProbe().os_family not in {"posix", "nt", "java"}
+
+
+def test_windows_branch_matches_the_string_platform_system_returns():
+    """platform.system().lower() is 'windows' — never 'win32'."""
+
+    def win_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "MachineGuid" in joined:
+            return "    MachineGuid    REG_SZ    GUID-XYZ\n"
+        if "wmic" in joined:
+            return "TotalPhysicalMemory\n34359738368\n"
+        return None
+
+    with patch("hermia.identity.probes._run", side_effect=win_run):
+        f = LocalProbe(os_family="windows").probe()
+    assert f.platform_uuid == "GUID-XYZ"
+    assert f.ram_bytes == 34359738368
+    assert f.is_identifiable
+
+
+def test_darwin_probe_actually_measures_on_this_machine_when_on_darwin():
+    """On a real Mac the default probe must produce a usable identity."""
+    import platform as _platform
+
+    import pytest
+
+    if _platform.system().lower() != "darwin":
+        pytest.skip("darwin-only: asserts the default probe measures real hardware")
+    f = LocalProbe().probe()
+    assert f.is_identifiable, f"default probe measured nothing: {f.unavailable}"
+    assert f.ram_bytes and f.ram_bytes > 0
+
+
+def test_blank_measurement_counts_as_unmeasured():
+    def blank(cmd, **kwargs):
+        return '  "IOPlatformUUID" = ""  ' if "ioreg" in " ".join(cmd) else "   "
+
+    with patch("hermia.identity.probes._run", side_effect=blank):
+        f = LocalProbe(os_family="darwin").probe()
+    assert f.platform_uuid is None
+    assert f.cpu_brand is None
+    assert set(f.unavailable) == {"platform_uuid", "cpu_brand", "ram_bytes"}
+
+
+def test_empty_windows_registry_value_is_not_mistaken_for_a_uuid():
+    """`reg query` prints '<name> <type> <value>'. An EMPTY value leaves only
+    two tokens, and taking the last one returns the literal type name 'REG_SZ'
+    — a fabricated identity that every affected box would share."""
+    from hermia.identity.probes import _windows_uuid
+
+    assert _windows_uuid("    MachineGuid    REG_SZ    \n") is None
+    assert _windows_uuid("    MachineGuid    REG_SZ\n") is None
+    assert _windows_uuid("    MachineGuid    REG_SZ    abc-123\n") == "abc-123"
+
+
+def test_windows_probe_with_empty_guid_is_not_identifiable():
+    def win_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "MachineGuid" in joined:
+            return "    MachineGuid    REG_SZ    \n"
+        return None
+
+    with patch("hermia.identity.probes._run", side_effect=win_run):
+        f = LocalProbe(os_family="windows").probe()
+    assert f.platform_uuid is None
+    assert not f.is_identifiable
+    assert "platform_uuid" in f.unavailable

--- a/tests/unit/identity/test_probes.py
+++ b/tests/unit/identity/test_probes.py
@@ -70,7 +70,7 @@ def test_linux_prefers_the_firmware_root_over_the_on_disk_token():
         obs = LocalProbe(os_family="linux").probe()
     assert obs.identifiers.firmware_uuid == "DMI-UUID-9"
     assert obs.identifiers.hardware_serial == "BOARD-7"
-    assert obs.identifiers.persisted_token == "deadbeef"
+    assert obs.identifiers.persisted_token == "deadbeef"  # noqa: S105 - field name, not a credential
     assert obs.capabilities.ram_bytes == 32768000 * 1024
     assert obs.capabilities.cpu_brand == "AMD Ryzen 9"
 
@@ -82,7 +82,7 @@ def test_linux_root_gated_dmi_falls_back_to_the_token_but_records_the_gap():
     with patch("hermia.identity.probes._read_text", side_effect=read):
         obs = LocalProbe(os_family="linux").probe()
     assert obs.identifiers.firmware_uuid is None
-    assert obs.identifiers.persisted_token == "deadbeef"
+    assert obs.identifiers.persisted_token == "deadbeef"  # noqa: S105 - field name, not a credential
     assert "firmware_uuid" in obs.identifiers.unavailable
 
 
@@ -103,7 +103,7 @@ def test_windows_reads_the_firmware_uuid_not_only_machineguid():
         obs = LocalProbe(os_family="windows").probe()
     assert obs.identifiers.firmware_uuid == "4C4C4544-0031"
     assert obs.identifiers.hardware_serial == "BOARD-XYZ"
-    assert obs.identifiers.persisted_token == "guid-abc"
+    assert obs.identifiers.persisted_token == "guid-abc"  # noqa: S105 - field name, not a credential
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/identity/test_public_api.py
+++ b/tests/unit/identity/test_public_api.py
@@ -1,0 +1,41 @@
+"""Public API surface for machine identity (hermia-cfqv)."""
+
+
+def test_public_api_exports():
+    import hermia.identity as ident
+
+    for name in (
+        "HardwareFacts",
+        "MachineIdentity",
+        "HardwareProbe",
+        "LocalProbe",
+        "derive_machine_id",
+        "load_or_create_salt",
+        "check_identity_consistency",
+    ):
+        assert hasattr(ident, name), name
+
+
+def test_end_to_end_local_identity_is_stable(tmp_path):
+    from hermia.identity import LocalProbe, derive_machine_id, load_or_create_salt
+
+    salt = load_or_create_salt(tmp_path / "salt")
+    facts = LocalProbe().probe()
+    a = derive_machine_id(facts, salt)
+    b = derive_machine_id(facts, salt)
+    assert a.machine_id == b.machine_id
+    assert a.basis
+
+
+def test_no_mac_anywhere_in_the_package_source():
+    """Guard the core invariant against future well-meaning additions."""
+    import pathlib
+
+    import hermia.identity as ident
+
+    pkg = pathlib.Path(ident.__file__).parent
+    for py in pkg.glob("*.py"):
+        text = py.read_text().lower()
+        assert "getmac" not in text, py
+        assert "uuid.getnode" not in text, py
+        assert "mac_address" not in text, py

--- a/tests/unit/identity/test_public_api.py
+++ b/tests/unit/identity/test_public_api.py
@@ -1,17 +1,15 @@
-"""Public API surface for machine identity (hermia-cfqv)."""
+"""Public API surface (hermia-cfqv)."""
+import pathlib
 
 
 def test_public_api_exports():
     import hermia.identity as ident
 
     for name in (
-        "HardwareFacts",
-        "MachineIdentity",
-        "HardwareProbe",
-        "LocalProbe",
-        "derive_machine_id",
-        "load_or_create_salt",
-        "check_identity_consistency",
+        "MachineIdentifiers", "MachineCapabilities", "MachineIdentity",
+        "MachineObservation", "HardwareProbe", "LocalProbe", "SaltInfo",
+        "derive_machine_id", "load_salt", "check_identity_consistency",
+        "resolve_conflict", "pending_conflicts",
     ):
         assert hasattr(ident, name), name
 
@@ -20,22 +18,30 @@ def test_end_to_end_local_identity_is_stable(tmp_path):
     from hermia.identity import LocalProbe, derive_machine_id, load_or_create_salt
 
     salt = load_or_create_salt(tmp_path / "salt")
-    facts = LocalProbe().probe()
-    a = derive_machine_id(facts, salt)
-    b = derive_machine_id(facts, salt)
+    obs = LocalProbe().probe()
+    a = derive_machine_id(obs.identifiers, salt)
+    b = derive_machine_id(obs.identifiers, salt)
     assert a.machine_id == b.machine_id
-    assert a.basis
+    assert a.source and a.basis
 
 
-def test_no_mac_anywhere_in_the_package_source():
-    """Guard the core invariant against future well-meaning additions."""
-    import pathlib
+def test_identity_never_consumes_a_capability_or_network_identifier():
+    """Guards the core invariant against future well-meaning additions.
+
+    Substring matching would be wrong here -- "match" contains "mac". Match on
+    whole identifiers only.
+    """
+    import re
 
     import hermia.identity as ident
 
-    pkg = pathlib.Path(ident.__file__).parent
-    for py in pkg.glob("*.py"):
-        text = py.read_text().lower()
-        assert "getmac" not in text, py
-        assert "uuid.getnode" not in text, py
-        assert "mac_address" not in text, py
+    derive = (pathlib.Path(ident.__file__).parent / "derive.py").read_text()
+    banned = (
+        "ram_bytes", "cpu_brand", "logical_cores", "model_identifier",
+        "nic_mac", "mac_address", "getnode", "hostname", "ip_address",
+        "MachineCapabilities",
+    )
+    for token in banned:
+        assert not re.search(rf"\b{re.escape(token)}\b", derive), (
+            f"{token} must never reach identity derivation"
+        )

--- a/tests/unit/identity/test_salt.py
+++ b/tests/unit/identity/test_salt.py
@@ -100,3 +100,42 @@ def test_install_scope_is_not_silently_equivalent_to_fleet(tmp_path, monkeypatch
     b = load_salt(tmp_path / "nf2", tmp_path / "i2")
     assert a.scope == b.scope == "install"
     assert a.salt != b.salt
+
+
+# --- CodeRabbit: deterministic write-failure + creation race -------------
+
+
+def test_write_failure_returns_an_ephemeral_salt_without_persisting(tmp_path, monkeypatch):
+    """chmod 0500 does not stop a privileged process, so the directory-based
+    test proves nothing when CI runs as root. Force the failure instead."""
+    def boom(*a, **k):
+        raise PermissionError("read-only")
+
+    monkeypatch.setattr("hermia.identity.salt.os.open", boom)
+    p = tmp_path / "machine_salt"
+    assert len(load_or_create_salt(p)) == 32
+    assert not p.exists()
+
+
+def test_concurrent_first_creation_agrees_on_one_salt(tmp_path):
+    """Two processes starting together must not each mint a salt and have the
+    second clobber the first — ids either side of that would disagree."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    p = tmp_path / "machine_salt"
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        salts = list(pool.map(lambda _: load_or_create_salt(p), range(8)))
+    assert len({s.hex() for s in salts}) == 1, "racing writers minted different salts"
+    assert salts[0] == load_or_create_salt(p)
+
+
+def test_passphrase_uses_a_slow_kdf_not_a_bare_digest(tmp_path, monkeypatch):
+    import hashlib
+
+    monkeypatch.setenv("HERMIA_FLEET_SALT", "a shared team phrase")
+    info = load_salt(tmp_path / "f", tmp_path / "i")
+    assert info.salt != hashlib.sha256(b"a shared team phrase").digest()
+    assert info.salt == hashlib.scrypt(
+        b"a shared team phrase", salt=b"hermia-fleet-salt-v1",
+        n=2**14, r=8, p=1, dklen=32,
+    )

--- a/tests/unit/identity/test_salt.py
+++ b/tests/unit/identity/test_salt.py
@@ -169,3 +169,31 @@ def test_a_good_salt_is_never_clobbered_when_hard_links_are_unavailable(tmp_path
 
     monkeypatch.setattr("hermia.identity.salt.os.link", no_links)
     assert load_or_create_salt(p) == original
+
+
+# --- gpt-oss: an unpersistable salt must announce itself -----------------
+
+
+def test_unpersistable_salt_is_reported_as_ephemeral(tmp_path, monkeypatch):
+    """A salt that cannot be written is regenerated every invocation, so every
+    run derives a DIFFERENT id for the same box. Labelling that 'install' hides
+    real instability behind a scope that implies stability."""
+    monkeypatch.delenv("HERMIA_FLEET_SALT", raising=False)
+    d = tmp_path / "ro"
+    d.mkdir()
+    d.chmod(0o500)
+    try:
+        info = load_salt(d / "fleet", d / "install")
+        assert info.scope == "ephemeral"
+        assert not info.is_stable
+        assert len(info.salt) == 32
+    finally:
+        d.chmod(0o700)
+
+
+def test_a_persisted_salt_reports_a_stable_scope(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMIA_FLEET_SALT", raising=False)
+    info = load_salt(tmp_path / "fleet", tmp_path / "install")
+    assert info.scope == "install"
+    assert info.is_stable
+    assert load_salt(tmp_path / "fleet", tmp_path / "install").salt == info.salt

--- a/tests/unit/identity/test_salt.py
+++ b/tests/unit/identity/test_salt.py
@@ -139,3 +139,33 @@ def test_passphrase_uses_a_slow_kdf_not_a_bare_digest(tmp_path, monkeypatch):
         b"a shared team phrase", salt=b"hermia-fleet-salt-v1",
         n=2**14, r=8, p=1, dklen=32,
     )
+
+
+def test_a_zero_byte_salt_file_is_repaired_not_re_minted_forever(tmp_path):
+    """Left unrepaired, every run mints a throwaway salt and the machine gets a
+    brand new id every single time, silently and forever."""
+    p = tmp_path / "machine_salt"
+    p.write_text("")
+    first = load_or_create_salt(p)
+    assert p.stat().st_size > 0, "corrupt salt file was never repaired"
+    assert load_or_create_salt(p) == first
+
+
+def test_a_truncated_salt_file_is_repaired(tmp_path):
+    p = tmp_path / "machine_salt"
+    p.write_text("abcd")
+    first = load_or_create_salt(p)
+    assert load_or_create_salt(p) == first
+    assert len(first) == 32
+
+
+def test_a_good_salt_is_never_clobbered_when_hard_links_are_unavailable(tmp_path, monkeypatch):
+    """The no-hardlink fallback must not become an unconditional overwrite."""
+    p = tmp_path / "machine_salt"
+    original = load_or_create_salt(p)
+
+    def no_links(*a, **k):
+        raise OSError("hard links unsupported")
+
+    monkeypatch.setattr("hermia.identity.salt.os.link", no_links)
+    assert load_or_create_salt(p) == original

--- a/tests/unit/identity/test_salt.py
+++ b/tests/unit/identity/test_salt.py
@@ -1,0 +1,71 @@
+"""Per-install salt store (hermia-cfqv)."""
+import stat
+
+from hermia.identity.salt import load_or_create_salt
+
+
+def test_creates_salt_and_is_stable_across_calls(tmp_path):
+    p = tmp_path / "machine_salt"
+    a = load_or_create_salt(p)
+    b = load_or_create_salt(p)
+    assert a == b
+    assert len(a) == 32
+
+
+def test_salt_file_is_owner_only(tmp_path):
+    p = tmp_path / "machine_salt"
+    load_or_create_salt(p)
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+def test_distinct_paths_get_distinct_salts(tmp_path):
+    assert load_or_create_salt(tmp_path / "a") != load_or_create_salt(tmp_path / "b")
+
+
+def test_corrupt_salt_file_is_regenerated_not_crashed(tmp_path):
+    p = tmp_path / "machine_salt"
+    p.write_text("not-hex-at-all!!")
+    s = load_or_create_salt(p)
+    assert len(s) == 32
+
+
+def test_wrong_length_salt_is_regenerated(tmp_path):
+    """A truncated but valid-hex file must not yield a short salt."""
+    p = tmp_path / "machine_salt"
+    p.write_text("abcd")
+    assert len(load_or_create_salt(p)) == 32
+
+
+def test_unwritable_location_still_returns_a_usable_salt(tmp_path):
+    """A read-only home must degrade to an ephemeral salt, not crash the CLI."""
+    d = tmp_path / "ro"
+    d.mkdir()
+    d.chmod(0o500)
+    try:
+        s = load_or_create_salt(d / "machine_salt")
+        assert len(s) == 32
+    finally:
+        d.chmod(0o700)
+
+
+def test_existing_salt_with_loose_permissions_is_repaired_on_read(tmp_path):
+    """A salt restored from backup or written by an older build must not stay
+    world-readable just because its contents are valid."""
+    p = tmp_path / "machine_salt"
+    p.write_text("ab" * 32)
+    p.chmod(0o644)
+    load_or_create_salt(p)
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+def test_salt_is_never_world_readable_even_under_a_loose_umask(tmp_path):
+    """write_text() then chmod() would expose the secret in between."""
+    import os
+
+    old = os.umask(0o022)
+    try:
+        p = tmp_path / "machine_salt"
+        load_or_create_salt(p)
+        assert stat.S_IMODE(p.stat().st_mode) == 0o600
+    finally:
+        os.umask(old)

--- a/tests/unit/identity/test_salt.py
+++ b/tests/unit/identity/test_salt.py
@@ -1,56 +1,27 @@
-"""Per-install salt store (hermia-cfqv)."""
+"""Fleet-scoped salt (hermia-cfqv)."""
+import os
 import stat
 
-from hermia.identity.salt import load_or_create_salt
+from hermia.identity.salt import load_or_create_salt, load_salt
 
 
-def test_creates_salt_and_is_stable_across_calls(tmp_path):
+def test_stable_across_calls_and_owner_only(tmp_path):
     p = tmp_path / "machine_salt"
     a = load_or_create_salt(p)
-    b = load_or_create_salt(p)
-    assert a == b
+    assert a == load_or_create_salt(p)
     assert len(a) == 32
-
-
-def test_salt_file_is_owner_only(tmp_path):
-    p = tmp_path / "machine_salt"
-    load_or_create_salt(p)
     assert stat.S_IMODE(p.stat().st_mode) == 0o600
 
 
-def test_distinct_paths_get_distinct_salts(tmp_path):
-    assert load_or_create_salt(tmp_path / "a") != load_or_create_salt(tmp_path / "b")
-
-
-def test_corrupt_salt_file_is_regenerated_not_crashed(tmp_path):
-    p = tmp_path / "machine_salt"
-    p.write_text("not-hex-at-all!!")
-    s = load_or_create_salt(p)
-    assert len(s) == 32
-
-
-def test_wrong_length_salt_is_regenerated(tmp_path):
-    """A truncated but valid-hex file must not yield a short salt."""
-    p = tmp_path / "machine_salt"
+def test_corrupt_or_short_salt_is_regenerated(tmp_path):
+    p = tmp_path / "s"
+    p.write_text("not-hex!!")
+    assert len(load_or_create_salt(p)) == 32
     p.write_text("abcd")
     assert len(load_or_create_salt(p)) == 32
 
 
-def test_unwritable_location_still_returns_a_usable_salt(tmp_path):
-    """A read-only home must degrade to an ephemeral salt, not crash the CLI."""
-    d = tmp_path / "ro"
-    d.mkdir()
-    d.chmod(0o500)
-    try:
-        s = load_or_create_salt(d / "machine_salt")
-        assert len(s) == 32
-    finally:
-        d.chmod(0o700)
-
-
-def test_existing_salt_with_loose_permissions_is_repaired_on_read(tmp_path):
-    """A salt restored from backup or written by an older build must not stay
-    world-readable just because its contents are valid."""
+def test_existing_loose_permissions_are_repaired_on_read(tmp_path):
     p = tmp_path / "machine_salt"
     p.write_text("ab" * 32)
     p.chmod(0o644)
@@ -58,10 +29,7 @@ def test_existing_salt_with_loose_permissions_is_repaired_on_read(tmp_path):
     assert stat.S_IMODE(p.stat().st_mode) == 0o600
 
 
-def test_salt_is_never_world_readable_even_under_a_loose_umask(tmp_path):
-    """write_text() then chmod() would expose the secret in between."""
-    import os
-
+def test_never_world_readable_even_under_a_loose_umask(tmp_path):
     old = os.umask(0o022)
     try:
         p = tmp_path / "machine_salt"
@@ -69,3 +37,66 @@ def test_salt_is_never_world_readable_even_under_a_loose_umask(tmp_path):
         assert stat.S_IMODE(p.stat().st_mode) == 0o600
     finally:
         os.umask(old)
+
+
+def test_unwritable_location_still_returns_a_usable_salt(tmp_path):
+    d = tmp_path / "ro"
+    d.mkdir()
+    d.chmod(0o500)
+    try:
+        assert len(load_or_create_salt(d / "machine_salt")) == 32
+    finally:
+        d.chmod(0o700)
+
+
+# --- FLEET SCOPE ---------------------------------------------------------
+# Regression: a per-install salt meant the SAME fleet host derived a different
+# id depending on which workstation ran the eval, so one machine appeared as
+# two in the corpus.
+
+
+def test_env_salt_wins_and_is_reported_as_fleet_scope(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMIA_FLEET_SALT", "ab" * 32)
+    info = load_salt(tmp_path / "fleet", tmp_path / "install")
+    assert info.scope == "fleet:env"
+    assert info.salt == bytes.fromhex("ab" * 32)
+
+
+def test_env_passphrase_is_accepted_and_stretched(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMIA_FLEET_SALT", "a shared team phrase")
+    info = load_salt(tmp_path / "fleet", tmp_path / "install")
+    assert info.scope == "fleet:env"
+    assert len(info.salt) == 32
+
+
+def test_two_installs_sharing_a_fleet_salt_agree(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMIA_FLEET_SALT", "shared")
+    a = load_salt(tmp_path / "f1", tmp_path / "i1")
+    b = load_salt(tmp_path / "f2", tmp_path / "i2")
+    assert a.salt == b.salt, "same fleet salt must give the same material"
+
+
+def test_fleet_file_outranks_install_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMIA_FLEET_SALT", raising=False)
+    fleet, install = tmp_path / "fleet", tmp_path / "install"
+    fleet.write_text("cd" * 32)
+    install.write_text("ef" * 32)
+    info = load_salt(fleet, install)
+    assert info.scope == "fleet:file"
+    assert info.salt == bytes.fromhex("cd" * 32)
+
+
+def test_falls_back_to_install_scope_and_says_so(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMIA_FLEET_SALT", raising=False)
+    info = load_salt(tmp_path / "nofleet", tmp_path / "install")
+    assert info.scope == "install"
+    assert len(info.salt) == 32
+
+
+def test_install_scope_is_not_silently_equivalent_to_fleet(tmp_path, monkeypatch):
+    """Ids from different scopes are not comparable; the scope must be visible."""
+    monkeypatch.delenv("HERMIA_FLEET_SALT", raising=False)
+    a = load_salt(tmp_path / "nf1", tmp_path / "i1")
+    b = load_salt(tmp_path / "nf2", tmp_path / "i2")
+    assert a.scope == b.scope == "install"
+    assert a.salt != b.salt

--- a/tests/unit/identity/test_types.py
+++ b/tests/unit/identity/test_types.py
@@ -1,4 +1,6 @@
 """Identifier/capability split (hermia-cfqv)."""
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from hermia.identity.types import (
@@ -11,7 +13,7 @@ from hermia.identity.types import (
 
 def test_identifiers_are_frozen():
     i = MachineIdentifiers(firmware_uuid="U")
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         i.firmware_uuid = "other"  # type: ignore[misc]
 
 

--- a/tests/unit/identity/test_types.py
+++ b/tests/unit/identity/test_types.py
@@ -12,7 +12,7 @@ from hermia.identity.types import (
 
 
 def test_identifiers_are_frozen():
-    i = MachineIdentifiers(firmware_uuid="U")
+    i = MachineIdentifiers(firmware_uuid="UUID-0001-AAAA")
     with pytest.raises(FrozenInstanceError):
         i.firmware_uuid = "other"  # type: ignore[misc]
 
@@ -74,3 +74,56 @@ def test_only_placeholders_means_not_identifiable():
 def test_identity_null_id_still_carries_source_and_basis():
     m = MachineIdentity(None, "none", "unavailable:no-usable-identifier")
     assert m.machine_id is None and m.source and m.basis
+
+
+# --- Antigravity: the placeholder screen was trivially evaded -------------
+
+
+@pytest.mark.parametrize(
+    "filler",
+    [
+        "To Be Filled By O.E.M",      # no trailing dot — the variant that slipped through
+        "To Be Filled By O.E.M.",
+        "TO_BE_FILLED_BY_OEM",
+        "to be filled by oem",
+        "Default String",
+        "Default string ",
+        "System Serial Number",
+        "Base Board Serial Number",
+        "Chassis Serial Number",
+        "00000000",
+        "0000000000000000",
+        "FFFFFFFF",
+        "xxxxxxxxxxxx",
+        "None",
+        "N/A",
+        "Not Specified",
+        "0",
+        "123",
+    ],
+)
+def test_vendor_filler_never_counts_as_an_identity(filler):
+    """Two DIY boxes sharing a filler serial derived the SAME machine id."""
+    assert not is_usable_identifier(filler)
+
+
+@pytest.mark.parametrize(
+    "real", ["4C4C4544-0031-104D-8032-B8C04F4A3633", "C02XY1234567", "deadbeefcafe"]
+)
+def test_real_identifiers_still_pass(real):
+    assert is_usable_identifier(real)
+
+
+def test_two_boxes_with_the_same_filler_serial_do_not_collide():
+    a = MachineIdentifiers(hardware_serial="To Be Filled By O.E.M")
+    b = MachineIdentifiers(hardware_serial="To Be Filled By O.E.M")
+    assert a.usable == {} and b.usable == {}
+    assert not a.is_identifiable
+
+
+def test_case_and_hyphenation_are_formatting_not_identity():
+    """One motherboard reported by Linux (lowercase) and Windows (uppercase)."""
+    lower = MachineIdentifiers(firmware_uuid="4c4c4544-0031-104d-8032-b8c04f4a3633")
+    upper = MachineIdentifiers(firmware_uuid="4C4C4544-0031-104D-8032-B8C04F4A3633")
+    bare = MachineIdentifiers(firmware_uuid="4c4c45440031104d8032b8c04f4a3633")
+    assert lower.usable == upper.usable == bare.usable

--- a/tests/unit/identity/test_types.py
+++ b/tests/unit/identity/test_types.py
@@ -1,34 +1,74 @@
-"""Types for machine identity (hermia-cfqv)."""
+"""Identifier/capability split (hermia-cfqv)."""
 import pytest
 
-from hermia.identity.types import HardwareFacts, MachineIdentity
+from hermia.identity.types import (
+    MachineCapabilities,
+    MachineIdentifiers,
+    MachineIdentity,
+    is_usable_identifier,
+)
 
 
-def test_hardware_facts_is_frozen():
-    f = HardwareFacts(platform_uuid="U", cpu_brand="C", ram_bytes=1, os_family="darwin")
+def test_identifiers_are_frozen():
+    i = MachineIdentifiers(firmware_uuid="U")
     with pytest.raises(Exception):
-        f.platform_uuid = "other"  # type: ignore[misc]
+        i.firmware_uuid = "other"  # type: ignore[misc]
 
 
-def test_hardware_facts_defaults_unmeasured_to_none_not_empty_string():
-    f = HardwareFacts(
-        platform_uuid=None, cpu_brand=None, ram_bytes=None, os_family="linux"
+def test_unmeasured_is_none_not_empty_string():
+    i = MachineIdentifiers()
+    assert i.firmware_uuid is None and i.hardware_serial is None
+    assert i.persisted_token is None and i.unavailable == ()
+
+
+def test_identifiers_carry_nothing_detachable():
+    """A MAC/IP-derived identity follows the dongle, not the machine."""
+    fields = set(MachineIdentifiers.__dataclass_fields__)
+    assert not fields & {"mac", "nic_mac", "mac_address", "ip", "hostname"}
+
+
+def test_capabilities_carry_the_mac_instead():
+    assert "nic_mac" in MachineCapabilities.__dataclass_fields__
+
+
+def test_capabilities_are_not_identifiers():
+    """RAM/CPU must not be reachable as identity material."""
+    fields = set(MachineIdentifiers.__dataclass_fields__)
+    assert not fields & {"ram_bytes", "cpu_brand", "logical_cores"}
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        "",
+        "   ",
+        "00000000-0000-0000-0000-000000000000",
+        "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+        "03000200-0400-0500-0006-000700080009",
+        "To Be Filled By O.E.M.",
+        "  default string  ",
+        "Not Specified",
+    ],
+)
+def test_known_bad_placeholders_are_not_usable(bad):
+    assert not is_usable_identifier(bad)
+
+
+def test_real_values_are_usable():
+    assert is_usable_identifier("ABC-123")
+    assert is_usable_identifier("C02XY1234567")
+
+
+def test_only_placeholders_means_not_identifiable():
+    i = MachineIdentifiers(
+        firmware_uuid="00000000-0000-0000-0000-000000000000",
+        hardware_serial="To Be Filled By O.E.M.",
     )
-    assert f.platform_uuid is None
-    assert f.cpu_brand is None
-    assert f.ram_bytes is None
-    assert f.unavailable == ()
+    assert i.usable == {}
+    assert not i.is_identifiable
 
 
-def test_is_identifiable_requires_platform_uuid():
-    """CPU+RAM alone must NOT count: identical laptop models share both."""
-    assert HardwareFacts("U", "Apple M1 Pro", 17179869184, "darwin").is_identifiable
-    assert not HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin").is_identifiable
-
-
-def test_machine_identity_null_id_still_carries_a_basis():
-    m = MachineIdentity(
-        machine_id=None, basis="unavailable:no-platform-uuid", os_family="linux"
-    )
-    assert m.machine_id is None
-    assert m.basis
+def test_identity_null_id_still_carries_source_and_basis():
+    m = MachineIdentity(None, "none", "unavailable:no-usable-identifier")
+    assert m.machine_id is None and m.source and m.basis

--- a/tests/unit/identity/test_types.py
+++ b/tests/unit/identity/test_types.py
@@ -1,0 +1,34 @@
+"""Types for machine identity (hermia-cfqv)."""
+import pytest
+
+from hermia.identity.types import HardwareFacts, MachineIdentity
+
+
+def test_hardware_facts_is_frozen():
+    f = HardwareFacts(platform_uuid="U", cpu_brand="C", ram_bytes=1, os_family="darwin")
+    with pytest.raises(Exception):
+        f.platform_uuid = "other"  # type: ignore[misc]
+
+
+def test_hardware_facts_defaults_unmeasured_to_none_not_empty_string():
+    f = HardwareFacts(
+        platform_uuid=None, cpu_brand=None, ram_bytes=None, os_family="linux"
+    )
+    assert f.platform_uuid is None
+    assert f.cpu_brand is None
+    assert f.ram_bytes is None
+    assert f.unavailable == ()
+
+
+def test_is_identifiable_requires_platform_uuid():
+    """CPU+RAM alone must NOT count: identical laptop models share both."""
+    assert HardwareFacts("U", "Apple M1 Pro", 17179869184, "darwin").is_identifiable
+    assert not HardwareFacts(None, "Apple M1 Pro", 17179869184, "darwin").is_identifiable
+
+
+def test_machine_identity_null_id_still_carries_a_basis():
+    m = MachineIdentity(
+        machine_id=None, basis="unavailable:no-platform-uuid", os_family="linux"
+    )
+    assert m.machine_id is None
+    assert m.basis

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -371,3 +371,46 @@ def test_applying_pseudonyms_twice_does_not_blank_them():
     once = assign_machine_pseudonyms([{"machine_id": "aaaa"}])
     twice = assign_machine_pseudonyms(once)
     assert twice[0]["machine_pseudonym"] == "node-a"
+
+
+def test_unidentified_machines_are_not_pooled_into_one_bucket():
+    """Ten unidentified boxes exported as a single null read as ONE machine
+    that ran ten times."""
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    rows = [
+        {"machine_id": None, "fleet_host_name": "box-1"},
+        {"machine_id": None, "fleet_host_name": "box-2"},
+        {"machine_id": None, "fleet_host_name": "box-1"},
+    ]
+    got = assign_machine_pseudonyms(rows)
+    names = [r["machine_pseudonym"] for r in got]
+    assert names == ["unidentified-a", "unidentified-b", "unidentified-a"]
+    assert len(set(names)) == 2
+
+
+def test_the_grouping_key_itself_is_never_exported():
+    """Separating them must not leak the operator's host names."""
+    from hermia.sink.anonymize import SUBMIT_WHITELIST, anonymize_row, assign_machine_pseudonyms
+
+    assert "fleet_host_name" not in SUBMIT_WHITELIST
+    row = assign_machine_pseudonyms([{"machine_id": None, "fleet_host_name": "secret-box"}])[0]
+    out = anonymize_row(row)
+    assert out["machine_pseudonym"] == "unidentified-a"
+    assert "secret-box" not in str(out)
+
+
+def test_nothing_to_group_on_still_yields_null():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    assert assign_machine_pseudonyms([{"machine_id": None}])[0]["machine_pseudonym"] is None
+
+
+def test_identified_and_unidentified_use_distinct_namespaces():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    got = assign_machine_pseudonyms([
+        {"machine_id": "aaaa"}, {"machine_id": None, "host": "h1"},
+    ])
+    assert got[0]["machine_pseudonym"] == "node-a"
+    assert got[1]["machine_pseudonym"] == "unidentified-a"

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -285,3 +285,64 @@ def test_property_no_forbidden_key_or_value_leaks(
     assert set(out).issubset(_ALLOWED_OUTPUT_KEYS), (
         f"Non-whitelisted key in output: {set(out) - _ALLOWED_OUTPUT_KEYS}"
     )
+
+
+# ---------------------------------------------------------------------------
+# machine_id pseudonymisation (hermia-cfqv)
+# ---------------------------------------------------------------------------
+
+
+def test_machine_id_is_not_whitelisted():
+    """Default-deny must keep the salted hash out of community submissions."""
+    from hermia.sink.anonymize import SUBMIT_WHITELIST
+
+    assert "machine_id" not in SUBMIT_WHITELIST
+    assert "machine_id_basis" not in SUBMIT_WHITELIST
+
+
+def test_pseudonyms_are_stable_and_ordered_by_first_appearance():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    rows = [{"machine_id": "bbbb"}, {"machine_id": "aaaa"}, {"machine_id": "bbbb"}]
+    got = assign_machine_pseudonyms(rows)
+    assert [r["machine_pseudonym"] for r in got] == ["node-a", "node-b", "node-a"]
+
+
+def test_null_machine_id_gets_null_pseudonym_not_a_node_name():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    got = assign_machine_pseudonyms([{"machine_id": None}])
+    assert got[0]["machine_pseudonym"] is None
+
+
+def test_absent_machine_id_key_yields_null_pseudonym():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    got = assign_machine_pseudonyms([{"model": "x"}])
+    assert got[0]["machine_pseudonym"] is None
+
+
+def test_original_machine_id_is_removed_from_the_output():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    got = assign_machine_pseudonyms([{"machine_id": "aaaa"}])
+    assert "machine_id" not in got[0]
+
+
+def test_input_rows_are_not_mutated():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    rows = [{"machine_id": "aaaa"}]
+    assign_machine_pseudonyms(rows)
+    assert rows[0]["machine_id"] == "aaaa"
+
+
+def test_pseudonyms_extend_past_z():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    rows = [{"machine_id": f"id{i:03d}"} for i in range(28)]
+    got = assign_machine_pseudonyms(rows)
+    names = [r["machine_pseudonym"] for r in got]
+    assert names[0] == "node-a"
+    assert names[25] == "node-z"
+    assert len(set(names)) == 28

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -345,4 +345,6 @@ def test_pseudonyms_extend_past_z():
     names = [r["machine_pseudonym"] for r in got]
     assert names[0] == "node-a"
     assert names[25] == "node-z"
+    assert names[26] == "node-aa"   # spreadsheet-style rollover
+    assert names[27] == "node-ab"
     assert len(set(names)) == 28

--- a/tests/unit/test_anonymize.py
+++ b/tests/unit/test_anonymize.py
@@ -348,3 +348,26 @@ def test_pseudonyms_extend_past_z():
     assert names[26] == "node-aa"   # spreadsheet-style rollover
     assert names[27] == "node-ab"
     assert len(set(names)) == 28
+
+
+def test_machine_pseudonym_survives_the_default_deny_pass():
+    """Without a whitelist entry the pseudonym is silently dropped, and an
+    export carries no way to tell one machine's rows from another's."""
+    from hermia.sink.anonymize import (
+        SUBMIT_WHITELIST,
+        anonymize_row,
+        assign_machine_pseudonyms,
+    )
+
+    assert "machine_pseudonym" in SUBMIT_WHITELIST
+    assert "machine_id" not in SUBMIT_WHITELIST
+    rows = assign_machine_pseudonyms([{"model": "m", "machine_id": "aaaa"}])
+    assert anonymize_row(rows[0])["machine_pseudonym"] == "node-a"
+
+
+def test_applying_pseudonyms_twice_does_not_blank_them():
+    from hermia.sink.anonymize import assign_machine_pseudonyms
+
+    once = assign_machine_pseudonyms([{"machine_id": "aaaa"}])
+    twice = assign_machine_pseudonyms(once)
+    assert twice[0]["machine_pseudonym"] == "node-a"


### PR DESCRIPTION
## Why

A row's machine identity has been `fleet_host_name` — a string typed into a fleet YAML, verified against nothing. It has been wrong four independent ways in this corpus: one machine under several names, tunnel ports repointed between machines, DHCP reservations bound to **detachable USB/Thunderbolt adapters**, and a Thunderbolt **dock** whose MAC follows whichever laptop is docked.

`hermia-fqod` (870 rows attributed to the wrong machine *and* the wrong compute backend) went undetected for a month because nothing in the schema could contradict the label.

## What this adds

A self-contained `hermia.identity` package built on one split:

| | |
|---|---|
| **`MachineIdentifiers`** | firmware UUID, hardware serial, minted on-host token. Non-transferable. The **only** input to a `machine_id`. |
| **`MachineCapabilities`** | CPU, cores, RAM, model, OS, MAC, virtualisation. Recorded and reported — **never hashed**. |

Identity is an **exact** match on a fixed preference order (`firmware uuid+serial` > `uuid` > `serial` > `persisted token`). No weights, no thresholds, no fuzzy matching. A RAM upgrade is a recorded capability change, not a new machine.

MAC and IP are deliberately excluded from identity: a network-derived id follows the accessory, not the computer. The MAC is still recorded — as a capability — so an operator can *see* that a dock moved without letting a dock decide which machine answered.

## Adversarial review shaped this

The first cut used a single required UUID; a proposed successor used weighted threshold matching. Both were rejected by two independent outside-family reviews (Antigravity in a container, and `gpt-oss:120b` run on local hardware), which converged without seeing each other's output:

> Any threshold loose enough to tolerate a hardware repair merges two identical laptops; any threshold tight enough to keep them apart is just an exact match on the strongest identifier.

One reviewer additionally walked the dock-swap scenario and found threshold matching would **not** alarm on it — a dock change touches only the lowest-weight field, which such a scheme tolerates by design.

**Four confirmed defects fixed, each with a regression test:**

1. **The ledger locked in whatever it saw first.** It recorded only when no warning fired, so a misconfigured first run was blessed permanently — the *correct* machine then alarmed on every run while the *wrong* one stayed silent, fixable only by hand-editing JSON. Reproduced before fixing. Conflicts are now explicit and cleared via `resolve_conflict()`.
2. **Linux preferred the weakest identifier.** It read `/etc/machine-id` first and never fell through to the firmware UUID. That file is now correctly demoted to `persisted_token` — a reinstall resets it, a cloned image duplicates it.
3. **Windows never read the firmware UUID at all** — only `MachineGuid`, also an OS-install id.
4. **The salt was per-install**, so the same fleet host derived different ids from different workstations, splitting one machine into several. Now fleet-scoped, with the scope returned alongside the salt because ids are only comparable within a scope.

A fifth needed no fix: `MemTotal` drifts with kernel updates, so hashing it made a routine update look like a hardware swap. Moving memory to capabilities retires that failure mode.

Also added: known-bad placeholder blocklist (all-zero/all-FF SMBIOS UUIDs, mass-duplicated vendor UUIDs, `To Be Filled By O.E.M.` — this fleet has DIY builds), cross-process file locking, virtualisation detection.

## Deliberately NOT in this PR

**Nothing stamps a result row.** On a fleet run the model executes on a remote host while hermia runs locally, so stamping the *local* machine onto a *remote* row would manufacture exactly the misattribution this exists to prevent. Row wiring lands with the remote-probe transport decision.

**Naming collision to resolve before wiring:** corpus rows already use `machine_id` for a human-readable alias applied retroactively; this one is a salted hash. They must never meet in one row.

## Verification

- **2104 passed** (2025 at branch point). ruff + mypy clean.
- 9 deselected are `test_detect_gpu_*`, a known macOS portability issue (`hermia-2ess`), pre-existing on `dev` and unrelated.
- ⚠️ The **pre-push fleet-review hook skipped** (`LITELLM_DISPATCH_KEY` unset — `hermia-wiw1`). That gate did not run on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform machine identity detection with stable, privacy-preserving identifiers.
  * Added configurable salt handling for consistent identity derivation across installations.
  * Added identity consistency checks that detect machine relabeling and label reassignment, with conflict inspection and resolution.
  * Added machine-ID pseudonymization for safely presenting submitted data.
* **Tests**
  * Added comprehensive coverage for identity detection, derivation, persistence, conflict handling, salt security, and anonymization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->