### PR TITLE
feat(witness): a second shrink-only register, and a loud one-shot way to widen either

### DIFF
--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -33,10 +33,35 @@ TARGET = "tests/unit/test_schemas.py"
 # ratchet green — the same shape as every bypass above, one level up. That is exactly the
 # drift SECURITY_TEST_IDS exists to prevent, and how the original GREEN-while-blind bug
 # happened. So: the allowlist may only shrink, and the scope may only grow.
+# A SECOND shrink-only register, with a DIFFERENT meaning from the first. The raw-coverage
+# allowlist answers "is a detector configured?" — membership. This one answers "has a detector
+# ever been shown to fire?" — behaviour. Conflating them would make one list mean two things,
+# and since both may only shrink, that muddle would be permanent. Asserting membership as a
+# proxy for behaviour is the precise error this framework exists to catch.
+UNPROVEN_CONST = "WITNESS_UNPROVEN_DETECTOR_ALLOWLIST"
+
 SCOPE_CONST = "SECURITY_TEST_IDS"
 SCOPE_TARGET = "src/hermia/schemas.py"
 
 WORKFLOW = ".github/workflows/witness-ratchet.yml"
+
+# The allowlist may only shrink — but "never grows" is not survivable. A security test can
+# legitimately enter the registry before anyone has built a detector for it, and refusing that
+# outright would just push people to route around this script.
+#
+# So widening is possible and DELIBERATELY expensive: the change must declare, in the same file,
+# exactly which ids it is adding and why. The declaration must match the additions EXACTLY —
+# no more, no less — so it can neither authorize a silent extra entry nor be written in advance.
+#
+# It also cannot linger. Once an id reaches the base ref it is in the allowlist proper, and a
+# declaration still naming it is STALE and fails the build. A widening is a one-shot token that
+# must be spent and then removed; it can never become a standing permission.
+#
+# ⚠️ Be honest about what this buys. It does NOT stop someone with merge rights from adding an
+# entry and its justification in one diff. It makes widening LOUD, attributable and reviewed
+# instead of a silent line in a frozenset — which is the whole thing the ratchet was ever for.
+WIDENING_CONST = "WITNESS_ALLOWLIST_WIDENING"
+_MIN_REASON = 40
 
 # Guards that live in TARGET and must stay alive. The equivalence guard is the load-bearing
 # one: it compares what this script reads statically against what Python actually produces,
@@ -513,6 +538,155 @@ def _guard_change_problems(repo: Path, base: str, allowlist_changed: bool) -> li
     return problems
 
 
+def _extract_widening(source: str, origin: str) -> dict[str, str] | None:
+    """Read the widening declaration: a module-scope dict of {test_id: reason} string literals.
+
+    Same discipline as the allowlist — refuse anything that cannot be resolved statically,
+    rather than guessing. Returns None when the declaration is absent, which means no widening
+    is authorised at all.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:  # pragma: no cover - the caller already parsed HEAD
+        raise SystemExit(f"FAIL: could not parse {origin}: {exc}") from exc
+
+    values, other = _const_bindings(tree, WIDENING_CONST)
+    if other or len(values) > 1:
+        raise SystemExit(
+            f"FAIL: {WIDENING_CONST} in {origin} is bound more than once, or in a form this "
+            "script cannot resolve. Declare it exactly once, as a plain dict literal."
+        )
+    if not values:
+        return None
+
+    node = values[0]
+    if not isinstance(node, ast.Dict):
+        raise SystemExit(
+            f"FAIL: {WIDENING_CONST} in {origin} is not a literal dict, so this script cannot "
+            "read which additions it claims to authorise. Write it inline as "
+            '{"test-id": "reason", ...} with string literals only.'
+        )
+
+    out: dict[str, str] = {}
+    for key, value in zip(node.keys, node.values, strict=True):
+        ok_key = isinstance(key, ast.Constant) and isinstance(key.value, str)
+        ok_val = isinstance(value, ast.Constant) and isinstance(value.value, str)
+        if not (ok_key and ok_val):
+            raise SystemExit(
+                f"FAIL: {WIDENING_CONST} in {origin} contains a non-literal key or value. "
+                "Every entry must be a plain string constant so the ratchet can compare it."
+            )
+        out[key.value] = value.value
+    return out
+
+
+def _widening_problems(
+    widening: dict[str, str] | None, added: set[str], base: set[str]
+) -> list[str]:
+    """Does the declaration authorise exactly these additions, and nothing else?"""
+    problems: list[str] = []
+
+    stale = sorted(set(widening or {}) & base)
+    for entry in stale:
+        problems.append(
+            f"{entry!r} is declared in {WIDENING_CONST} but is already in the allowlist at the "
+            "base ref. A spent widening must be deleted, not left standing."
+        )
+
+    if not added:
+        return problems
+
+    if widening is None:
+        return [
+            *problems,
+            f"the allowlist grows by {len(added)} entr"
+            f"{'y' if len(added) == 1 else 'ies'} with no {WIDENING_CONST} declaration at all",
+        ]
+
+    undeclared = sorted(added - set(widening))
+    for entry in undeclared:
+        problems.append(f"{entry!r} is being added but is not declared in {WIDENING_CONST}")
+
+    unused = sorted(set(widening) - added - base)
+    for entry in unused:
+        problems.append(
+            f"{entry!r} is declared in {WIDENING_CONST} but is not actually being added — a "
+            "declaration written in advance is a standing permission, which is not allowed"
+        )
+
+    for entry in sorted(added & set(widening)):
+        reason = widening[entry].strip()
+        if len(reason) < _MIN_REASON:
+            problems.append(
+                f"{entry!r} is declared with a {len(reason)}-character reason; a widening needs "
+                f"an actual justification (at least {_MIN_REASON} characters) that a reviewer "
+                "can weigh"
+            )
+    return problems
+
+
+def _shrink_only(
+    repo: Path, base_ref: str, const: str, widening: dict[str, str] | None
+) -> int:
+    """Enforce "may only shrink" on one allowlist constant in TARGET. Returns an exit code.
+
+    Both WITNESS registers obey the same rule and the same widening discipline, so the rule is
+    written once. A register absent from the base ref is a bootstrap — permitted only while the
+    gate itself is new there, exactly as for the primary allowlist.
+    """
+    head, base = _read_const(repo, base_ref, TARGET, const)
+
+    if head is None and base is None:
+        # The register does not exist on either side. It has not been introduced yet, which is
+        # not a failure — the machinery may legitimately land before the data it will govern.
+        return 0
+
+    if head is None:
+        print(f"FAIL: {const} existed at {base_ref} but is missing from {TARGET} in the working "
+              "tree.")
+        print(
+            "The ratchet cannot verify a register that was deleted or renamed. If that was "
+            "deliberate, land that change on its own, reviewed, first."
+        )
+        return 1
+
+    # Introducing the register is not a free pass. Every entry it arrives with is an addition,
+    # and must be declared exactly as a later one would be — otherwise "create a new register"
+    # becomes the way to add blind spots silently. A RENAME cannot reach this branch: the old
+    # name would vanish from HEAD and be caught as a deletion above.
+    base_entries: set[str] = set() if base is None else base
+    added = sorted(head - base_entries)
+    for entry in sorted(base_entries - head):
+        print(f"  {const} removed (good):  {entry}")
+
+    problems = _widening_problems(widening, set(added), base_entries)
+    if problems:
+        print()
+        print(f"FAIL: {const} may only shrink.")
+        for entry in added:
+            print(f"  ADDED: {entry}")
+        print()
+        for problem in problems:
+            print(f"  {problem}")
+        print()
+        print(
+            "Each entry is a security test whose compromises cannot be detected. Adding one "
+            f"widens a declared blind spot. If that is genuinely intended, declare it in "
+            f"{WIDENING_CONST} as {{test_id: reason}} in the same change — an explicit decision "
+            "recorded where a reviewer reads it, not a silent line."
+        )
+        return 1
+
+    if added:
+        print()
+        print(f"WIDENING: {const} gains {len(added)} entr{'y' if len(added) == 1 else 'ies'}, "
+              f"declared in {WIDENING_CONST} and therefore recorded rather than silent:")
+        for entry in added:
+            print(f"  ADDED: {entry}")
+            print(f"    {(widening or {})[entry]}")
+    return 0
+
+
 def _read_const(
     repo: Path, base: str, target: str, const: str
 ) -> tuple[set[str] | None, set[str] | None]:
@@ -627,6 +801,12 @@ def main() -> int:
             )
             return 1
 
+    # ---- 4b. The unproven-detector register obeys the same shrink-only rule.
+    widening = _extract_widening((repo / TARGET).read_text(encoding="utf-8"), "working tree")
+    unproven_rc = _shrink_only(repo, args.base, UNPROVEN_CONST, widening)
+    if unproven_rc:
+        return unproven_rc
+
     # ---- 5. The allowlist itself may only shrink.
     if base is None:
         print(f"BOOTSTRAP: {CONST} does not exist at {args.base}, and neither does {WORKFLOW}.")
@@ -646,20 +826,41 @@ def main() -> int:
     for entry in removed:
         print(f"  removed (good):  {entry}")
 
-    if added:
+    widening_problems = _widening_problems(widening, set(added), base)
+
+    if widening_problems:
         print()
         print("FAIL: the WITNESS raw-coverage allowlist may only shrink.")
         for entry in added:
             print(f"  ADDED: {entry}")
         print()
+        for problem in widening_problems:
+            print(f"  {problem}")
+        print()
         print(
-            "Each entry is a security test on which a compromise cannot be detected. "
-            "Adding one widens a declared blind spot. If that is genuinely intended, it "
-            "needs an explicit decision recorded on the pull request — not a silent line."
+            "Each entry is a security test on which a compromise cannot be detected. Adding one "
+            f"widens a declared blind spot. If that is genuinely intended, declare it in "
+            f"{WIDENING_CONST} as {{test_id: reason}} in the same change — an explicit decision "
+            "recorded where a reviewer reads it, not a silent line in a frozenset."
         )
         return 1
 
-    print(f"OK: allowlist shrank or held; guards alive; {SCOPE_CONST} did not shrink.")
+    if added:
+        print()
+        print(f"WIDENING: {len(added)} entr{'y' if len(added) == 1 else 'ies'} added, declared "
+              f"in {WIDENING_CONST} and therefore recorded rather than silent:")
+        for entry in added:
+            print(f"  ADDED: {entry}")
+            print(f"    {(widening or {})[entry]}")
+        print()
+        print(
+            "This is a deliberate widening of a declared blind spot. The ratchet permits it "
+            "ONLY because it is written down; it does not endorse it. The declaration must be "
+            "deleted once these entries reach the base ref."
+        )
+
+    print(f"OK: both WITNESS registers shrank or held; guards alive; "
+          f"{SCOPE_CONST} did not shrink.")
     return 0
 
 

--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -625,21 +625,19 @@ def _widening_problems(
     return problems
 
 
-def _shrink_only(
-    repo: Path, base_ref: str, const: str, widening: dict[str, str] | None
-) -> int:
-    """Enforce "may only shrink" on one allowlist constant in TARGET. Returns an exit code.
+def _register_added(repo: Path, base_ref: str, const: str) -> tuple[int, set[str], set[str]]:
+    """(status, added, base_entries) for one shrink-only register. status is an exit code.
 
-    Both WITNESS registers obey the same rule and the same widening discipline, so the rule is
-    written once. A register absent from the base ref is a bootstrap — permitted only while the
-    gate itself is new there, exactly as for the primary allowlist.
+    Additions are computed for EVERY register before the widening declaration is validated,
+    because one change may legitimately widen more than one of them and the declaration covers
+    all of it at once. Validating per register rejected a declared id destined for the other
+    register as an unused declaration, making a simultaneous widening impossible and blaming
+    the declaration for it. Caught by CodeRabbit on PR #168 and reproduced before fixing.
     """
     head, base = _read_const(repo, base_ref, TARGET, const)
 
     if head is None and base is None:
-        # The register does not exist on either side. It has not been introduced yet, which is
-        # not a failure — the machinery may legitimately land before the data it will govern.
-        return 0
+        return 0, set(), set()
 
     if head is None:
         print(f"FAIL: {const} existed at {base_ref} but is missing from {TARGET} in the working "
@@ -648,43 +646,27 @@ def _shrink_only(
             "The ratchet cannot verify a register that was deleted or renamed. If that was "
             "deliberate, land that change on its own, reviewed, first."
         )
-        return 1
+        return 1, set(), set()
 
-    # Introducing the register is not a free pass. Every entry it arrives with is an addition,
-    # and must be declared exactly as a later one would be — otherwise "create a new register"
-    # becomes the way to add blind spots silently. A RENAME cannot reach this branch: the old
-    # name would vanish from HEAD and be caught as a deletion above.
     base_entries: set[str] = set() if base is None else base
-    added = sorted(head - base_entries)
-    for entry in sorted(base_entries - head):
+    return 0, head - base_entries, base_entries
+
+
+def _report_register(
+    const: str, added: set[str], removed: set[str], widening: dict[str, str] | None
+) -> None:
+    """Print what one register did. The declaration is validated by the caller, once, across
+    every register — see _register_added for why per-register validation was wrong."""
+    for entry in sorted(removed):
         print(f"  {const} removed (good):  {entry}")
-
-    problems = _widening_problems(widening, set(added), base_entries)
-    if problems:
-        print()
-        print(f"FAIL: {const} may only shrink.")
-        for entry in added:
-            print(f"  ADDED: {entry}")
-        print()
-        for problem in problems:
-            print(f"  {problem}")
-        print()
-        print(
-            "Each entry is a security test whose compromises cannot be detected. Adding one "
-            f"widens a declared blind spot. If that is genuinely intended, declare it in "
-            f"{WIDENING_CONST} as {{test_id: reason}} in the same change — an explicit decision "
-            "recorded where a reviewer reads it, not a silent line."
-        )
-        return 1
-
-    if added:
-        print()
-        print(f"WIDENING: {const} gains {len(added)} entr{'y' if len(added) == 1 else 'ies'}, "
-              f"declared in {WIDENING_CONST} and therefore recorded rather than silent:")
-        for entry in added:
-            print(f"  ADDED: {entry}")
-            print(f"    {(widening or {})[entry]}")
-    return 0
+    if not added:
+        return
+    print()
+    print(f"WIDENING: {const} gains {len(added)} entr{'y' if len(added) == 1 else 'ies'}, "
+          f"declared in {WIDENING_CONST} and therefore recorded rather than silent:")
+    for entry in sorted(added):
+        print(f"  ADDED: {entry}")
+        print(f"    {(widening or {})[entry]}")
 
 
 def _read_const(
@@ -801,11 +783,49 @@ def main() -> int:
             )
             return 1
 
-    # ---- 4b. The unproven-detector register obeys the same shrink-only rule.
+    # ---- 4b. Both shrink-only registers, validated together.
+    #
+    # The declaration is checked ONCE against every register's additions at the same time. One
+    # change may legitimately widen more than one register, and validating them separately
+    # rejected a declared id destined for the other register as an "unused declaration" —
+    # making a valid simultaneous widening impossible, and blaming the declaration for it.
     widening = _extract_widening((repo / TARGET).read_text(encoding="utf-8"), "working tree")
-    unproven_rc = _shrink_only(repo, args.base, UNPROVEN_CONST, widening)
+
+    unproven_rc, unproven_added, unproven_base = _register_added(repo, args.base, UNPROVEN_CONST)
     if unproven_rc:
         return unproven_rc
+
+    primary_base: set[str] = set() if base is None else base
+    primary_added = head - primary_base
+
+    all_added = primary_added | unproven_added
+    all_base = primary_base | unproven_base
+    widening_problems = _widening_problems(widening, all_added, all_base)
+
+    if widening_problems:
+        print()
+        print("FAIL: the WITNESS registers may only shrink.")
+        for entry in sorted(all_added):
+            print(f"  ADDED: {entry}")
+        print()
+        for problem in widening_problems:
+            print(f"  {problem}")
+        print()
+        print(
+            "Each entry is a security test whose compromises cannot be detected. Adding one "
+            f"widens a declared blind spot. If that is genuinely intended, declare it in "
+            f"{WIDENING_CONST} as {{test_id: reason}} in the same change — an explicit decision "
+            "recorded where a reviewer reads it, not a silent line."
+        )
+        return 1
+
+    unproven_head, _ = _read_const(repo, args.base, TARGET, UNPROVEN_CONST)
+    _report_register(
+        UNPROVEN_CONST,
+        unproven_added,
+        unproven_base - (unproven_head or set()),
+        widening,
+    )
 
     # ---- 5. The allowlist itself may only shrink.
     if base is None:
@@ -825,25 +845,6 @@ def main() -> int:
     print(f"head:              {len(head)} entr{'y' if len(head) == 1 else 'ies'}")
     for entry in removed:
         print(f"  removed (good):  {entry}")
-
-    widening_problems = _widening_problems(widening, set(added), base)
-
-    if widening_problems:
-        print()
-        print("FAIL: the WITNESS raw-coverage allowlist may only shrink.")
-        for entry in added:
-            print(f"  ADDED: {entry}")
-        print()
-        for problem in widening_problems:
-            print(f"  {problem}")
-        print()
-        print(
-            "Each entry is a security test on which a compromise cannot be detected. Adding one "
-            f"widens a declared blind spot. If that is genuinely intended, declare it in "
-            f"{WIDENING_CONST} as {{test_id: reason}} in the same change — an explicit decision "
-            "recorded where a reviewer reads it, not a silent line in a frozenset."
-        )
-        return 1
 
     if added:
         print()

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1526,6 +1526,18 @@ def test_witness_widening_must_be_declared_and_cannot_linger():
     # and a no-op change with no declaration is fine
     assert ratchet._widening_problems(None, set(), {"a"}) == []
 
+    # A single change may legitimately widen BOTH registers, and the declaration covers all of
+    # it at once. Validating per register rejected a declared id destined for the other
+    # register as an "unused declaration" — a valid simultaneous widening was impossible, and
+    # the error blamed the declaration. Caught by CodeRabbit on PR #168, reproduced, fixed by
+    # validating once against the union of every register's additions.
+    assert ratchet._widening_problems(
+        {"raw-id": reason, "unproven-id": reason}, {"raw-id", "unproven-id"}, set()
+    ) == []
+    assert ratchet._widening_problems(
+        {"raw-id": reason, "unproven-id": reason}, {"unproven-id"}, set()
+    ), "validating one register's additions against a declaration covering both must not pass"
+
     for widening, added, base, why in [
         (None, {"a"}, set(), "growing with no declaration at all"),
         ({"a": "because"}, {"a"}, set(), "a token reason a reviewer cannot weigh"),

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1493,6 +1493,79 @@ def test_security_test_ids_is_statically_readable_for_the_scope_ratchet():
     )
 
 
+def test_witness_widening_must_be_declared_and_cannot_linger():
+    """The allowlist may grow, but only loudly, and the permission is single-use.
+
+    "Never grows" is not survivable — a security test can legitimately enter the registry
+    before anyone has built a detector for it, and an absolute rule just pushes people to
+    route around the ratchet. So a widening is allowed and made expensive: the change must
+    declare exactly which ids it adds and why, in the same file a reviewer is already reading.
+
+    Two properties carry the weight. The declaration must match the additions EXACTLY, so it
+    can neither wave through an extra entry nor be written in advance as a standing permission.
+    And it goes STALE the moment its ids reach the base ref, so a spent widening cannot sit in
+    the tree quietly authorising the next one.
+
+    Be honest about the limit: this does not stop someone with merge rights from adding an entry
+    and its justification in one diff. It makes widening attributable instead of silent, which
+    is the whole thing the ratchet was ever for.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+
+    reason = "detector is keyed to system-prompt echo, which no real corpus compromise produces"
+
+    # the only shape that passes: declared exactly, with an actual justification
+    assert ratchet._widening_problems({"a": reason}, {"a"}, set()) == []
+    # and a no-op change with no declaration is fine
+    assert ratchet._widening_problems(None, set(), {"a"}) == []
+
+    for widening, added, base, why in [
+        (None, {"a"}, set(), "growing with no declaration at all"),
+        ({"a": "because"}, {"a"}, set(), "a token reason a reviewer cannot weigh"),
+        ({"a": reason}, {"a", "b"}, set(), "adding more ids than were declared"),
+        ({"a": reason, "z": reason}, {"a"}, set(), "declaring an id in advance"),
+        ({"a": reason}, set(), {"a"}, "a spent declaration left standing"),
+    ]:
+        assert ratchet._widening_problems(widening, added, base), why
+
+
+def test_witness_widening_declaration_refuses_what_it_cannot_read():
+    """Same discipline as the allowlist: resolve it statically or refuse.
+
+    A declaration the ratchet cannot read is not an empty declaration — it is an unreadable
+    one, and reading it as empty would silently disable the check that makes widening loud.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+    const = ratchet.WIDENING_CONST
+
+    assert ratchet._extract_widening(f'{const} = {{"a": "b"}}', "x") == {"a": "b"}
+    assert ratchet._extract_widening("SOMETHING_ELSE = 1", "x") is None
+
+    for unreadable in (
+        f'{const} = dict(a="b")',
+        f"other = {{}}\n{const} = other",
+        f"{const} = {{**other}}",
+        f'{const} = {{"a": SOME_NAME}}',
+        f'{const} = {{SOME_KEY: "b"}}',
+    ):
+        with pytest.raises(SystemExit):
+            ratchet._extract_widening(unreadable, "x")
+
+
 def test_witness_allowlist_is_defined_readably():
     """The live allowlist must be in the shape the ratchet can actually read.
 


### PR DESCRIPTION
Machinery only. No allowlist data moves in this PR — the ratchet's own separation rule refuses
to move a register in the same diff that changes the machinery guarding it, and that rule
applies to this change as much as to anyone else's. I confirmed it by trying: it stopped me.

The data change is **PR B**, which lands after this one.

## 1. Widening is possible, but only loudly and once

"May only shrink" cannot survive contact. A security test can legitimately enter the registry
before anyone has built a detector for it, and a gate that makes a legitimate act impossible
gets routed around rather than obeyed.

A change that grows a register must now declare, in the same file, exactly which ids it adds
and why:

```python
WITNESS_ALLOWLIST_WIDENING: dict[str, str] = {"some-test-id": "why nothing witnesses it"}
```

- **Exact match** — names precisely the additions, no more and no less. It cannot wave through
  an extra entry alongside a justified one, and it cannot be written in advance, because
  declaring an id that is not actually being added is itself a failure.
- **Single use** — it goes stale the moment its ids reach the base ref, and a stale declaration
  fails the build. A spent widening cannot sit in the tree authorising the next one.
- Reasons must be substantive (40 chars), so `"x"` does not pass as a justification.
- Read with the same discipline as the allowlist: a literal dict of string constants, refusing
  `dict()` calls, aliases, unpacking, and non-literal keys or values — a declaration this
  script cannot read is not an empty one.

## 2. A second register, with a different meaning

`WITNESS_RAW_COVERAGE_ALLOWLIST` answers **"is a detector configured?"** — membership.
`WITNESS_UNPROVEN_DETECTOR_ALLOWLIST` answers **"has a detector ever been shown to fire?"** —
behaviour. Both may only shrink and both obey the widening discipline, so the rule is written
once and applied to each.

**That split was forced, not planned.** An earlier draft put three ids on the raw-coverage list
and `test_witness_allowlist_only_shrinks` rejected them — all three *do* have markers and
canaries configured, they have simply never caught anything. Conflating the two would have made
one register mean two things, and since both may only shrink that muddle would have been
permanent. Asserting membership as a proxy for behaviour is the precise error this framework
exists to catch, and it is worth recording that the machinery caught it rather than the author.

A register absent from **both** sides is tolerated — the machinery may land before the data it
governs, which is exactly what this PR does. Absent from HEAD after existing at the base is a
deletion and still fails. Introducing a register is treated as adding every entry it arrives
with, so "create a new register" cannot become the quiet way to add blind spots.

## Honest limit

None of this stops someone with merge rights from adding an entry and its justification in one
diff. It makes widening loud, attributable and reviewed instead of a silent line in a
frozenset — the only thing the ratchet was ever able to do. Claiming more would be the
overstatement this project has already had broken twice.

## Verification

End to end in a throwaway git repo with a real base commit, exit codes measured directly rather
than through a pipe:

| scenario | expected | got |
|---|---|---|
| widen with no declaration | 1 | ✓ 1 |
| widen with a declared substantive reason | 0 | ✓ 0 |
| widen with a token reason | 1 | ✓ 1 |
| stale declaration, no additions | 1 | ✓ 1 |

Unit tests cover exact-match, advance-declaration and single-use, plus five unreadable
declaration shapes.

Suite: **2412 passed, 30 skipped**. The six `test_metrics.py` failures are pre-existing and
unrelated — GPU-detection tests that silently assume Linux, tracked separately. ruff and mypy
clean; the real gate still runs and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controlled widening declarations for witness allowlists, requiring explicit per-entry reasons.
  - Added validation to ensure declarations match newly added entries exactly and do not remain after entries are incorporated.

- **Bug Fixes**
  - Prevented undocumented allowlist additions and invalid or unreadable widening declarations.
  - Added minimum justification requirements and continued enforcement of shrink-only register behavior.

- **Tests**
  - Added coverage for valid, stale, missing, and malformed widening declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->