### PR TITLE
fix(witness): six defects found by three outside-family reviewers on #168

### DIFF
--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -199,6 +199,17 @@ def _definition_header_nodes(node: ast.AST) -> list[ast.AST]:
     return out
 
 
+def _assigned_values(node: ast.AST) -> list[ast.expr]:
+    """Right-hand sides of any assignment form, so an alias can be spotted wherever it is made."""
+    if isinstance(node, ast.Assign):
+        return [node.value]
+    if isinstance(node, (ast.AnnAssign, ast.AugAssign)) and node.value is not None:
+        return [node.value]
+    if isinstance(node, ast.NamedExpr):
+        return [node.value]
+    return []
+
+
 def _namespace_writes_from_any_scope(tree: ast.Module, const: str) -> set[str]:
     """Rebindings of the module namespace reachable from INSIDE a function body.
 
@@ -261,6 +272,17 @@ def _namespace_writes_from_any_scope(tree: ast.Module, const: str) -> set[str]:
         # write to it, so that is what is refused — from any scope, whatever the callee.
         # Passing a fresh dict stays legal, which matters: this module's own regression tests
         # call exec(compile(...), namespace) with a local dict to drive the attacks.
+        # BYPASS 15, found by qwen3.5:122b. Every dynamic-builtin check matched on the NAME at
+        # the call site, so binding the builtin to another name defeated all of them:
+        #     _g = globals
+        #     _g()["WITNESS_RAW_COVERAGE_ALLOWLIST"] = frozenset({"a", "sneaky"})
+        # Reproduced: ratchet read {"a"}, runtime was {"a", "sneaky"}. Refusing the ALIAS
+        # itself is the fix — a bare reference to one of these builtins as a value has no
+        # legitimate use in this module, and it cannot be laundered through a rename.
+        for value in _assigned_values(node):
+            if isinstance(value, ast.Name) and value.id in _DYNAMIC_BUILTINS:
+                found.add(f"aliasing {value.id}")
+
         if isinstance(node, ast.Call):
             for arg in [*node.args, *(kw.value for kw in node.keywords)]:
                 if (
@@ -440,8 +462,19 @@ def _literal_strings(
 
 
 def _git(repo: Path, *argv: str) -> subprocess.CompletedProcess[str]:
-    """Run git in the repo. The gate shells out to git and NOTHING else, ever."""
-    return subprocess.run(["git", *argv], cwd=repo, capture_output=True, text=True, check=False)
+    """Run git in the repo. The gate shells out to git and NOTHING else, ever.
+
+    A missing git binary used to raise FileNotFoundError and surface as an internal error,
+    which reads as an infrastructure hiccup rather than as the gate not having run. Found by
+    qwen3.5:122b. Fail closed and say so.
+    """
+    try:
+        return subprocess.run(
+            ["git", *argv], cwd=repo, capture_output=True, text=True, check=False
+        )
+    except OSError as exc:
+        print(f"FAIL: could not execute git ({exc}). The ratchet has NOT run — not a pass.")
+        raise SystemExit(1) from exc
 
 
 def _exists_at_ref(repo: Path, ref: str, path: str) -> bool:
@@ -489,8 +522,17 @@ def _guard_liveness_problems(tree: ast.Module) -> list[str]:
         if node is None:
             problems.append(f"{name} is missing from {TARGET} (deleted or renamed)")
             continue
-        if not any(isinstance(n, ast.Assert) for n in ast.walk(node)):
+        asserts = [n for n in ast.walk(node) if isinstance(n, ast.Assert)]
+        if not asserts:
             problems.append(f"{name} contains no assert — it can no longer fail")
+        elif all(isinstance(a.test, ast.Constant) for a in asserts):
+            # `assert True` alongside a bare reference to the required names satisfied both the
+            # has-an-assert and mentions-the-names checks while enforcing nothing. Found by
+            # gpt-oss:120b. This does not make liveness prove EFFECTIVENESS — nothing here can
+            # — but a guard whose every assertion is a literal cannot fail by construction.
+            problems.append(
+                f"{name} asserts only literal constants — it cannot fail, whatever it mentions"
+            )
         names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)} | {
             n.attr for n in ast.walk(node) if isinstance(n, ast.Attribute)
         }
@@ -586,11 +628,28 @@ def _widening_problems(
     """Does the declaration authorise exactly these additions, and nothing else?"""
     problems: list[str] = []
 
-    stale = sorted(set(widening or {}) & base)
+    declared = set(widening or {})
+
+    stale = sorted(declared & base)
     for entry in stale:
         problems.append(
             f"{entry!r} is declared in {WIDENING_CONST} but is already in the allowlist at the "
             "base ref. A spent widening must be deleted, not left standing."
+        )
+
+    # ⚠️ Checked whether or not this diff adds anything. It used to sit behind an
+    # `if not added: return problems` early exit, which let a declaration land on its own —
+    # and that is a two-step, not an oversight. PR1 lands only the declaration and passes;
+    # PR2 then adds the id, matching a declaration ALREADY on the base, so `undeclared` is
+    # empty and `stale` does not fire because the id is not yet in the allowlist. The
+    # justification and the addition are never reviewed in the same diff, which was the one
+    # thing this mechanism existed to guarantee. Found by Antigravity on PR #168, reproduced.
+    unused = sorted(declared - added - base)
+    for entry in unused:
+        problems.append(
+            f"{entry!r} is declared in {WIDENING_CONST} but is not actually being added — a "
+            "declaration that outlives its own diff is a standing permission, which is exactly "
+            "what this must never become"
         )
 
     if not added:
@@ -606,13 +665,6 @@ def _widening_problems(
     undeclared = sorted(added - set(widening))
     for entry in undeclared:
         problems.append(f"{entry!r} is being added but is not declared in {WIDENING_CONST}")
-
-    unused = sorted(set(widening) - added - base)
-    for entry in unused:
-        problems.append(
-            f"{entry!r} is declared in {WIDENING_CONST} but is not actually being added — a "
-            "declaration written in advance is a standing permission, which is not allowed"
-        )
 
     for entry in sorted(added & set(widening)):
         reason = widening[entry].strip()
@@ -745,9 +797,24 @@ def main() -> int:
         )
         return 1
 
-    # ---- 3. Guards and gate may not move in the same diff as the allowlist.
+    # ---- 3. Guards and gate may not move in the same diff as EITHER register.
+    #
+    # `changed` used to be computed from the raw-coverage allowlist alone, so a change that
+    # moved only WITNESS_UNPROVEN_DETECTOR_ALLOWLIST could rewrite this script, the workflow or
+    # the guard tests in the same diff and skip this check entirely. Every shrink-only register
+    # has to count. Found by Antigravity on PR #168.
+    unproven_rc, unproven_added, unproven_base = _register_added(repo, args.base, UNPROVEN_CONST)
+    if unproven_rc:
+        return unproven_rc
+    unproven_head, _unproven_base_raw = _read_const(repo, args.base, TARGET, UNPROVEN_CONST)
+
     if not bootstrapping:
-        changed = base is None or head != base
+        changed = (
+            base is None
+            or head != base
+            or bool(unproven_added)
+            or bool(unproven_base - (unproven_head or set()))
+        )
         guard_problems = _guard_change_problems(repo, args.base, changed)
         if guard_problems:
             print("FAIL: the allowlist moved in the same change as the machinery guarding it.")
@@ -791,14 +858,17 @@ def main() -> int:
     # making a valid simultaneous widening impossible, and blaming the declaration for it.
     widening = _extract_widening((repo / TARGET).read_text(encoding="utf-8"), "working tree")
 
-    unproven_rc, unproven_added, unproven_base = _register_added(repo, args.base, UNPROVEN_CONST)
-    if unproven_rc:
-        return unproven_rc
-
     primary_base: set[str] = set() if base is None else base
     primary_added = head - primary_base
 
-    all_added = primary_added | unproven_added
+    # ⚠️ A genuine bootstrap — this gate does not exist at the base ref at all — establishes the
+    # BASELINE. Its entries are not additions and cannot be declared, because there is nothing
+    # to declare them against. Validating them as additions demanded a justification for every
+    # pre-existing entry, failed, and made the bootstrap handler below unreachable. That was
+    # live: `main` is still pre-allowlist, so the next dev->main promotion would have failed a
+    # required check with a message blaming a declaration that was not the problem. Found by
+    # Antigravity on PR #168 and reproduced against origin/main.
+    all_added = set() if bootstrapping else (primary_added | unproven_added)
     all_base = primary_base | unproven_base
     widening_problems = _widening_problems(widening, all_added, all_base)
 
@@ -819,7 +889,6 @@ def main() -> int:
         )
         return 1
 
-    unproven_head, _ = _read_const(repo, args.base, TARGET, UNPROVEN_CONST)
     _report_register(
         UNPROVEN_CONST,
         unproven_added,

--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -237,6 +237,35 @@ def _namespace_writes_from_any_scope(tree: ast.Module, const: str) -> set[str]:
     """
     watched = {const} | _CONSTRUCTORS
     found: set[str] = set()
+
+    # BYPASS 15 AND 16, and the reason this refuses a CLASS rather than a list of forms.
+    #
+    # Every dynamic-builtin check matched on the NAME at the call site, so binding the builtin
+    # to another name defeated all of them at once (qwen3.5:122b). Fixing only the assignment
+    # form left three more ways in, found by CodeRabbit and by probing around its finding:
+    #     def rewrite(g=globals): ...      # a parameter default binds without an assignment
+    #     f(globals)                       # passed as an argument
+    #     def pick(): return globals       # returned from a helper
+    # All reproduced: the ratchet read the old literal while runtime widened the namespace.
+    #
+    # So the rule is not "these binding forms are refused" — that list does not terminate, as
+    # fifteen bypasses have already demonstrated. A reference to one of these builtins is
+    # allowed ONLY as the direct callee of a call. Used as a VALUE in any other position it is
+    # refused, whatever syntax carries it there.
+    called_directly = {
+        id(node.func)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in _DYNAMIC_BUILTINS
+            and id(node) not in called_directly
+        ):
+            found.add(f"referencing {node.id} as a value")
+
     for node in ast.walk(tree):
         if isinstance(node, ast.Global):
             hit = watched.intersection(node.names)
@@ -272,17 +301,6 @@ def _namespace_writes_from_any_scope(tree: ast.Module, const: str) -> set[str]:
         # write to it, so that is what is refused — from any scope, whatever the callee.
         # Passing a fresh dict stays legal, which matters: this module's own regression tests
         # call exec(compile(...), namespace) with a local dict to drive the attacks.
-        # BYPASS 15, found by qwen3.5:122b. Every dynamic-builtin check matched on the NAME at
-        # the call site, so binding the builtin to another name defeated all of them:
-        #     _g = globals
-        #     _g()["WITNESS_RAW_COVERAGE_ALLOWLIST"] = frozenset({"a", "sneaky"})
-        # Reproduced: ratchet read {"a"}, runtime was {"a", "sneaky"}. Refusing the ALIAS
-        # itself is the fix — a bare reference to one of these builtins as a value has no
-        # legitimate use in this module, and it cannot be laundered through a rename.
-        for value in _assigned_values(node):
-            if isinstance(value, ast.Name) and value.id in _DYNAMIC_BUILTINS:
-                found.add(f"aliasing {value.id}")
-
         if isinstance(node, ast.Call):
             for arg in [*node.args, *(kw.value for kw in node.keywords)]:
                 if (
@@ -502,6 +520,21 @@ def _guard_fingerprint(node: ast.FunctionDef) -> str:
     return ast.dump(ast.Module(body=body, type_ignores=[]))
 
 
+def _is_literal_only(expr: ast.expr) -> bool:
+    """True when an expression can only ever evaluate to the same thing.
+
+    `assert True` was rejected by checking for ast.Constant, and `assert 1 == 1` walked straight
+    past it because a Compare is not a Constant — a guard could keep its required-name
+    references and still enforce nothing. Found by CodeRabbit on PR #170. An expression that
+    reads no name, attribute, subscript or call has no input and cannot depend on the state the
+    guard exists to check.
+    """
+    return not any(
+        isinstance(n, (ast.Name, ast.Attribute, ast.Subscript, ast.Call))
+        for n in ast.walk(expr)
+    )
+
+
 def _guard_liveness_problems(tree: ast.Module) -> list[str]:
     """Each guard must still exist, still assert, and still mention what makes it a guard.
 
@@ -525,7 +558,7 @@ def _guard_liveness_problems(tree: ast.Module) -> list[str]:
         asserts = [n for n in ast.walk(node) if isinstance(n, ast.Assert)]
         if not asserts:
             problems.append(f"{name} contains no assert — it can no longer fail")
-        elif all(isinstance(a.test, ast.Constant) for a in asserts):
+        elif all(_is_literal_only(a.test) for a in asserts):
             # `assert True` alongside a bare reference to the required names satisfied both the
             # has-an-assert and mentions-the-names checks while enforcing nothing. Found by
             # gpt-oss:120b. This does not make liveness prove EFFECTIVENESS — nothing here can

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1578,6 +1578,93 @@ def test_witness_widening_declaration_refuses_what_it_cannot_read():
             ratchet._extract_widening(unreadable, "x")
 
 
+def test_witness_outside_review_findings_stay_fixed():
+    """Regressions for what three outside-family reviewers found on PR #168.
+
+    Antigravity, gpt-oss:120b and qwen3.5:122b reviewed the same diff and their findings barely
+    overlapped, which is the whole argument for running a panel rather than a favourite.
+
+    Each case below was reproduced as a working bypass before being fixed.
+    """
+    import ast
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+    const = "WITNESS_RAW_COVERAGE_ALLOWLIST"
+    reason = "a genuine justification long enough to satisfy the reviewer-facing minimum"
+
+    # Antigravity: a declaration that adds nothing used to pass, so it could land in one pull
+    # request and be spent by the next — the justification and the addition never reviewed
+    # together, which was the one thing the mechanism existed to guarantee.
+    assert ratchet._widening_problems({"future": reason}, set(), set()), (
+        "an advance declaration with no additions must be refused"
+    )
+    assert ratchet._widening_problems({"a": reason}, {"a"}, set()) == []
+    assert ratchet._widening_problems(None, set(), {"a"}) == []
+
+    # qwen: every dynamic-builtin check matched the NAME at the call site, so binding the
+    # builtin to another name defeated all of them at once.
+    for aliased in (
+        f'_g = globals\n{const} = frozenset({{"a"}})\n_g()["{const}"] = 1\n',
+        f'{const} = frozenset({{"a"}})\ndef f():\n    g = globals\n    g()["x"] = 1\n',
+        f"{const} = frozenset({{'a'}})\n_e: object = exec\n",
+        f"{const} = frozenset({{'a'}})\nprint(_v := vars)\n",
+    ):
+        with pytest.raises(SystemExit):
+            ratchet.extract(aliased, "aliased")
+
+    # ...but aliasing something harmless is ordinary Python and must not fail the build
+    assert ratchet.extract(f'{const} = frozenset({{"a"}})\n_p = print\n', "x") == {"a"}
+
+    # gpt-oss: `assert True` beside a bare reference to the guarded names satisfied both the
+    # has-an-assert and mentions-the-names checks while enforcing nothing.
+    gutted = (
+        "def test_witness_allowlist_only_shrinks():\n"
+        "    _ = WITNESS_RAW_COVERAGE_ALLOWLIST, SECURITY_TEST_IDS\n"
+        "    assert True\n"
+    )
+    assert [
+        p for p in ratchet._guard_liveness_problems(ast.parse(gutted)) if "only_shrinks" in p
+    ], "a guard whose every assertion is a literal cannot fail and must be reported"
+
+    real = (
+        "def test_witness_allowlist_only_shrinks():\n"
+        "    x = WITNESS_RAW_COVERAGE_ALLOWLIST - set(SECURITY_TEST_IDS)\n"
+        "    assert not x\n"
+    )
+    assert not [
+        p for p in ratchet._guard_liveness_problems(ast.parse(real)) if "only_shrinks" in p
+    ]
+
+
+def test_witness_ratchet_bootstrap_survives_a_promotion():
+    """A genuine bootstrap establishes the BASELINE; its entries are not additions.
+
+    Antigravity found that the joint widening validation ran unconditionally, so during a
+    bootstrap it treated every pre-existing entry as an unjustified addition and made the
+    bootstrap handler unreachable. That was live: `main` is still pre-allowlist, so the next
+    dev->main promotion would have failed a required check while blaming a declaration that
+    was not the problem.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+
+    # bootstrap: nothing to compare against, so nothing is an addition and no declaration
+    # can exist. The gate must not demand one.
+    assert ratchet._widening_problems(None, set(), set()) == []
+
+
 def test_witness_allowlist_is_defined_readably():
     """The live allowlist must be in the shape the ratchet can actually read.
 

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1609,28 +1609,44 @@ def test_witness_outside_review_findings_stay_fixed():
 
     # qwen: every dynamic-builtin check matched the NAME at the call site, so binding the
     # builtin to another name defeated all of them at once.
+    # Fixing only the assignment form left three more ways in, found by CodeRabbit on PR #170
+    # and by probing around its finding. The rule refuses the CLASS — a reference to one of
+    # these builtins is legal only as the direct callee of a call — because the list of binding
+    # forms does not terminate, as fifteen bypasses have already demonstrated.
     for aliased in (
         f'_g = globals\n{const} = frozenset({{"a"}})\n_g()["{const}"] = 1\n',
         f'{const} = frozenset({{"a"}})\ndef f():\n    g = globals\n    g()["x"] = 1\n',
         f"{const} = frozenset({{'a'}})\n_e: object = exec\n",
         f"{const} = frozenset({{'a'}})\nprint(_v := vars)\n",
+        f'{const} = frozenset({{"a"}})\ndef w(g=globals):\n    g()["x"] = 1\n',
+        f'{const} = frozenset({{"a"}})\ndef f(g):\n    g()["x"] = 1\nf(globals)\n',
+        f'{const} = frozenset({{"a"}})\ndef pick():\n    return globals\n',
+        f'{const} = frozenset({{"a"}})\nT = {{"g": globals}}\n',
     ):
         with pytest.raises(SystemExit):
             ratchet.extract(aliased, "aliased")
 
-    # ...but aliasing something harmless is ordinary Python and must not fail the build
+    # ...but aliasing something harmless, and CALLING one directly, both stay legal
     assert ratchet.extract(f'{const} = frozenset({{"a"}})\n_p = print\n', "x") == {"a"}
+    assert ratchet.extract(
+        f'def t():\n    return globals()\n{const} = frozenset({{"a"}})\n', "x"
+    ) == {"a"}
 
     # gpt-oss: `assert True` beside a bare reference to the guarded names satisfied both the
     # has-an-assert and mentions-the-names checks while enforcing nothing.
-    gutted = (
-        "def test_witness_allowlist_only_shrinks():\n"
-        "    _ = WITNESS_RAW_COVERAGE_ALLOWLIST, SECURITY_TEST_IDS\n"
-        "    assert True\n"
-    )
-    assert [
-        p for p in ratchet._guard_liveness_problems(ast.parse(gutted)) if "only_shrinks" in p
-    ], "a guard whose every assertion is a literal cannot fail and must be reported"
+    # `assert 1 == 1` walked past the first version of this check, because a Compare is not a
+    # Constant. Found by CodeRabbit on PR #170 — the test has to be on the whole expression.
+    for trivial in ("assert True", "assert 1 == 1", "assert (2 > 1) and True"):
+        gutted = (
+            "def test_witness_allowlist_only_shrinks():\n"
+            "    _ = WITNESS_RAW_COVERAGE_ALLOWLIST, SECURITY_TEST_IDS\n"
+            f"    {trivial}\n"
+        )
+        assert [
+            p
+            for p in ratchet._guard_liveness_problems(ast.parse(gutted))
+            if "only_shrinks" in p
+        ], f"a guard whose every assertion is literal ({trivial}) cannot fail and must be reported"
 
     real = (
         "def test_witness_allowlist_only_shrinks():\n"


### PR DESCRIPTION
Antigravity, `gpt-oss:120b` and `qwen3.5:122b` reviewed the same diff. **Their findings barely
overlapped** — which is the argument for running a panel rather than a favourite. Every defect
below was reproduced as a working failure before being fixed.

| # | Defect | Found by |
|---|---|---|
| 1 | **Live:** the bootstrap path was unreachable | Antigravity |
| 2 | An advance declaration could land in its own PR and be spent by the next | Antigravity |
| 3 | The separation check was blind to the second register | Antigravity |
| 4 | **Bypass 15:** aliasing a namespace-rewriting builtin | qwen3.5:122b |
| 5 | A guard could satisfy liveness while asserting only literals | gpt-oss:120b |
| 6 | A missing `git` binary crashed instead of failing closed | qwen3.5:122b |

## The live one

The joint widening validation ran unconditionally, so during a genuine bootstrap it treated
every pre-existing entry as an unjustified addition and returned 1 before the bootstrap handler
could run. **`main` is still pre-allowlist, so the next `dev`→`main` promotion would have failed
a required check** — with a message blaming a declaration that wasn't the problem, which is the
worst shape of gate error because it sends the author to fix something already correct.

A bootstrap establishes the baseline; its entries are not additions and cannot be declared
against anything. Verified against `origin/main`: reports `BOOTSTRAP`, exits 0.

## The two-step

`_widening_problems` returned early when the diff added nothing, so the check that stops a
declaration being written in advance never ran. PR1 lands only the declaration and passes; PR2
adds the id, matching a declaration already on the base, and nothing fires. The justification
and the addition are then never reviewed in the same diff — the single thing the mechanism
existed to guarantee.

## Bypass 15

Every dynamic-builtin check matched on the **name at the call site**, so one rename defeated all
of them together:

```python
_g = globals
WITNESS_RAW_COVERAGE_ALLOWLIST = frozenset({"a"})
_g()["WITNESS_RAW_COVERAGE_ALLOWLIST"] = frozenset({"a", "sneaky"})
```

Ratchet read `{"a"}`; runtime was `{"a", "sneaky"}`. The **alias itself** is now refused, from
any scope and through any assignment form including annotation and walrus — a bare reference to
one of these builtins as a value has no legitimate use in that module, and refusing the alias
cannot be laundered through a rename the way the call site could. Aliasing something harmless
(`_p = print`) is still ordinary Python and passes.

## Deliberately not fixed here

- `grade_response` never applies the raw-text gates despite a docstring claiming it mirrors
  `runner.run_test`. Real, but **pre-existing** and a change to grading semantics — its own PR.
- Guard logic relocated to a helper module would evade the fingerprint. Fixing it properly needs
  a declaration mechanism of its own.

Both are filed as beads rather than bundled in.

## Scope limit, unchanged

None of this makes liveness prove **effectiveness**. A guard can still be made useless while
satisfying every check here. That limit has been broken by outside review twice before and it
stands.

Suite: **2414 passed, 30 skipped**. Six pre-existing `test_metrics.py` failures unrelated. ruff
and mypy clean; the gate exits 0 against both `origin/dev` and `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to detect additional ways permissions or namespace access could be bypassed.
  - Rejects ineffective guards that cannot fail, including assertions using only constant values.
  - Flags standalone widening declarations that grant no new entries.
  - Correctly handles initial bootstrapping without requiring pre-existing entries to be redeclared.
  - Detects changes across all relevant allowlists.
  - Provides a clear failure message when Git is unavailable.

- **Tests**
  - Added regression coverage for bypass detection, guard validation, declaration handling, allowlist changes, and bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->