### PR TITLE
fix(witness): the gate crashed on the dev→main promotion path

### DIFF
--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -261,6 +261,30 @@ def _namespace_writes_from_any_scope(tree: ast.Module, const: str) -> set[str]:
         for alias in node.names
         if alias.name == "builtins"
     }
+    # BYPASSES 20-22. `import builtins` is only ONE way to reach that module. Found by
+    # coder-biggest-5090 (sys.modules) and by probing around its finding:
+    #     sys.modules["builtins"].setattr(...)      # a Subscript, not a Name
+    #     from builtins import setattr as sa        # never enters the module namespace at all
+    #     __builtins__["frozenset"] = ...           # the dict, reached directly
+    # All three reproduced. None has any legitimate use in the target module — the builtins are
+    # already in scope, so naming the module is only ever done to reach past this gate.
+    #
+    # These are DEFENCE IN DEPTH, not the control. Each is caught by the equivalence guard
+    # regardless, which was verified against all three before this was written.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "builtins":
+            found.add("from builtins import ...")
+        if isinstance(node, ast.Name) and node.id == "__builtins__":
+            found.add("__builtins__")
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "modules"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "sys"
+        ):
+            found.add("sys.modules[...]")
+
     for node in ast.walk(tree):
         target = node.func if isinstance(node, ast.Call) else node
         if (

--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -855,20 +855,45 @@ def _register_added(repo: Path, base_ref: str, const: str) -> tuple[int, set[str
 
 
 def _report_register(
-    const: str, added: set[str], removed: set[str], widening: dict[str, str] | None
+    const: str,
+    added: set[str],
+    removed: set[str],
+    widening: dict[str, str] | None,
+    bootstrapping: bool,
 ) -> None:
     """Print what one register did. The declaration is validated by the caller, once, across
-    every register — see _register_added for why per-register validation was wrong."""
+    every register — see _register_added for why per-register validation was wrong.
+
+    ⚠️ This CRASHED on the dev->main promotion path. A genuine bootstrap skips widening
+    validation, because a baseline has nothing to be declared against — but the reporter still
+    indexed the declaration for every added entry, so once #169's spent declaration was deleted
+    it raised KeyError mid-report. A gate that dies with a traceback is worse than one that
+    fails: CI reads it as an infrastructure error rather than a verdict, and the operator has to
+    decide what it meant.
+
+    So a bootstrap now reports a BASELINE, which is what it is, and a reason is printed only
+    when one was actually required. Reasons are looked up with .get() throughout — the reporter
+    must never be the thing that decides whether the gate can speak.
+    """
     for entry in sorted(removed):
         print(f"  {const} removed (good):  {entry}")
     if not added:
         return
     print()
+    if bootstrapping:
+        print(f"BASELINE: {const} arrives with {len(added)} entr"
+              f"{'y' if len(added) == 1 else 'ies'}; this gate does not exist at the base ref, "
+              "so there is nothing to ratchet against yet:")
+        for entry in sorted(added):
+            print(f"  {entry}")
+        return
     print(f"WIDENING: {const} gains {len(added)} entr{'y' if len(added) == 1 else 'ies'}, "
           f"declared in {WIDENING_CONST} and therefore recorded rather than silent:")
     for entry in sorted(added):
         print(f"  ADDED: {entry}")
-        print(f"    {(widening or {})[entry]}")
+        reason = (widening or {}).get(entry)
+        if reason:
+            print(f"    {reason}")
 
 
 def _read_const(
@@ -1052,6 +1077,7 @@ def main() -> int:
         unproven_added,
         unproven_base - (unproven_head or set()),
         widening,
+        bootstrapping,
     )
 
     # ---- 5. The allowlist itself may only shrink.

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -2028,6 +2028,37 @@ def test_witness_guard_tautologies_are_refused():
         assert not flagged(real), f"a real assertion was wrongly reported: {real.strip()}"
 
 
+def test_witness_report_survives_a_bootstrap_with_no_declaration():
+    """The reporter must never be the thing that decides whether the gate can speak.
+
+    This CRASHED on the dev->main promotion path, on dev, immediately after #171 merged. A
+    genuine bootstrap skips widening validation — a baseline has nothing to be declared against
+    — but the reporter still indexed the declaration for every added entry, so once the spent
+    declaration was deleted it raised KeyError mid-report.
+
+    A gate that dies with a traceback is worse than one that fails: CI reads it as an
+    infrastructure error rather than a verdict, and a human then has to decide what it meant.
+    Caught by running the gate against origin/main after the merge rather than assuming the
+    earlier bootstrap fix still held.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+
+    # a bootstrap: entries arrive with no declaration at all, and this must not raise
+    ratchet._report_register("SOME_REGISTER", {"a", "b"}, set(), None, True)
+    # a widening whose declaration is somehow incomplete must still report, not crash
+    ratchet._report_register("SOME_REGISTER", {"a", "b"}, set(), {"a": "reason"}, False)
+    # and the ordinary cases
+    ratchet._report_register("SOME_REGISTER", set(), {"gone"}, None, False)
+    ratchet._report_register("SOME_REGISTER", {"a"}, set(), {"a": "reason"}, False)
+
+
 def test_witness_allowlist_is_defined_readably():
     """The live allowlist must be in the shape the ratchet can actually read.
 

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -2059,6 +2059,57 @@ def test_witness_report_survives_a_bootstrap_with_no_declaration():
     ratchet._report_register("SOME_REGISTER", {"a"}, set(), {"a": "reason"}, False)
 
 
+def test_witness_refuses_every_route_to_the_builtins_module():
+    """`import builtins` is only one way to reach that module.
+
+    Bypasses 20-22, found by coder-biggest-5090 (the sys.modules route) and by probing around
+    its finding. All three reproduced:
+
+        sys.modules["builtins"].setattr(...)   # a Subscript, not a Name
+        from builtins import setattr as sa     # never enters the module namespace at all
+        __builtins__["frozenset"] = ...        # the dict, reached directly
+
+    None has any legitimate use in this module — the builtins are already in scope, so naming
+    the module is only ever done to reach past the gate. Verified there is no such usage here
+    outside string payloads before making it a refusal.
+
+    ⚠️ These are DEFENCE IN DEPTH, not the control. Each was verified to be caught by the
+    equivalence guard anyway, which compares the static read against what Python actually
+    produces. That guard is registered in GUARD_REFERENCES and cannot be deleted without a
+    liveness failure. The static reader widening here is cheap, not load-bearing.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "witness_allowlist_ratchet.py"
+    spec = importlib.util.spec_from_file_location("_ratchet", script)
+    assert spec and spec.loader
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+    const = "WITNESS_RAW_COVERAGE_ALLOWLIST"
+
+    for src in (
+        f'import sys\ndef f():\n    sys.modules["builtins"].setattr(sys, "x", 1)\n'
+        f'{const} = frozenset({{"a"}})\n',
+        f'from builtins import setattr as sa\n{const} = frozenset({{"a"}})\n',
+        f'def f():\n    __builtins__["frozenset"] = 1\n{const} = frozenset({{"a"}})\n',
+        # this also closes bypass 12, which had been left to the equivalence guard alone
+        f'import sys\n{const} = frozenset({{"a"}})\n'
+        f'sys.modules[__name__].__dict__["{const}"] = 1\n',
+    ):
+        with pytest.raises(SystemExit):
+            ratchet.extract(src, "builtins-route")
+
+    # ordinary use of sys, and monkeypatch, must stay legal — a rule that fails innocent code
+    # gets the gate switched off rather than obeyed
+    assert ratchet.extract(
+        f'import sys\ndef t():\n    return sys.argv\n{const} = frozenset({{"a"}})\n', "x"
+    ) == {"a"}
+    assert ratchet.extract(
+        f'def t(mp):\n    mp.setattr(object, "x", 1)\n{const} = frozenset({{"a"}})\n', "x"
+    ) == {"a"}
+
+
 def test_witness_allowlist_is_defined_readably():
     """The live allowlist must be in the shape the ratchet can actually read.
 


### PR DESCRIPTION
Found by running the gate against `origin/main` **after #171 merged**, rather than assuming the
earlier bootstrap fix still held. It did not.

## The crash

```
WIDENING: WITNESS_UNPROVEN_DETECTOR_ALLOWLIST gains 3 entries...
  ADDED: security-boundary
Traceback (most recent call last):
  ...
KeyError: 'security-boundary'
```

**This was live on `dev`.** The next `dev`→`main` promotion would have died with a traceback.

A genuine bootstrap skips widening validation, because a baseline has nothing to be declared
against. But `_report_register` still indexed the declaration for every added entry — so once
#169's spent declaration was deleted, which the single-use rule *required*, the reporter blew up
mid-sentence.

## Why it matters more than a failing check

A gate that **crashes** is worse than one that fails. CI reads a traceback as an infrastructure
error rather than a verdict, and a human then has to decide what it meant. That's the
"unclear whether the check actually ran" failure this project keeps finding in other costumes.

## The fix

- A bootstrap now reports a **BASELINE**, which is what it actually is, instead of claiming a
  widening it cannot substantiate.
- Reasons are looked up with `.get()` throughout, so an incomplete declaration degrades to a
  quieter report rather than taking the process down. **The reporter must never be the thing
  that decides whether the gate can speak.**

Verified: `origin/main` reports `BASELINE` + `BOOTSTRAP` and exits 0; `origin/dev` unchanged at
0. The regression test drives the reporter directly — bootstrap with no declaration, incomplete
declaration, and the ordinary cases.

## How this one arrived

It's a defect created by **two correct changes interacting**: the bootstrap fix from the
outside-family review, and the spent-declaration deletion the single-use rule demanded. Neither
was wrong alone, and no reviewer saw the combination because it didn't exist until both had
landed.

That's the argument for verifying against the real base refs *after* a merge, not only before
one — which is the only reason this was caught before the next promotion rather than during it.

Suite: **2422 passed, 30 skipped**. Six pre-existing `test_metrics.py` failures unrelated. ruff
and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved allowlist checks during initial setup by reporting baseline entries without incorrectly flagging them as expansions.
  - Prevented reporting failures when allowlist declarations are incomplete or missing.
  - Improved handling of removed entries and standard declared additions without unexpected errors.

- **Tests**
  - Added regression coverage for initial setup, incomplete declarations, removals, and declared additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->