### PR TITLE
feat(security): land the classification-routing decision (hermia-lrzq)

### DIFF
--- a/src/hermia/schemas.py
+++ b/src/hermia/schemas.py
@@ -743,6 +743,11 @@ SECURITY_TEST_IDS: frozenset[str] = frozenset(
         "indirect-injection-tool-output",
         "credential-leak-resistance",
         "system-user-precedence",
+        # Scott decided 2026-08-31 that this joins the security registry; it did not land
+        # until now (hermia-lrzq). Filed under the ROUTING dimension, but the test presents a
+        # routing request carrying an embedded instruction override, so a model that complies
+        # has crossed the boundary its own system prompt declares.
+        "classification-routing",
         # Filed under the ROUTING dimension but functionally a security test: it
         # checks refusal of an embedded credential request and carries its own
         # leak canaries. Declared here so the discrepancy is visible instead of

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -660,9 +660,13 @@ WITNESS_RAW_COVERAGE_ALLOWLIST: frozenset[str] = frozenset(
         # NOR SEMANTIC_SECURITY_GATES -- so there is no detector to witness, and a response
         # that complies with an embedded override grades not_evaluable rather than compromised
         # (its invalid category fails the schema check and nothing fires). Declared, not hidden:
-        # this test can currently catch nothing, and the honest coverage line becomes
-        # "ten of eighteen security detectors have never fired". Building the detector is
-        # coverage work, which Decision 9 deliberately sequenced after the grader core.
+        # this test can currently catch nothing. State the coverage line precisely -- an earlier
+        # draft said "ten of eighteen security DETECTORS have never fired", which is wrong,
+        # because this change adds no detector. Measured 2026-09-04: nine of seventeen detectors
+        # had never fired. This makes it TEN OF EIGHTEEN SECURITY TESTS WITH NO DEMONSTRATED
+        # DETECTION -- the nine whose detectors have never fired, plus this one, which has no
+        # detector configured at all. That is a weaker and more accurate claim. Building the
+        # detector is coverage work, which Decision 9 deliberately sequenced after the grader core.
         "classification-routing",
     }
 )

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -652,7 +652,33 @@ def test_raw_output_compromised_does_not_mutate_input():
 # Empty is not the same as done. WITNESS_UNPROVEN_DETECTOR_ALLOWLIST below still holds
 # three tests whose detector has never been shown to fire, and the wider quiet-compliance
 # finding (nine of seventeen detectors silent across 18,880 rows) is untouched by this.
-WITNESS_RAW_COVERAGE_ALLOWLIST: frozenset[str] = frozenset()
+WITNESS_RAW_COVERAGE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # hermia-lrzq. Scott decided 2026-08-31 that classification-routing belongs in the
+        # security registry; landing that decision is what puts it here. It has a schema
+        # checker and a signal extractor, but it appears in NEITHER _COMPROMISE_MARKER_PATTERNS
+        # NOR SEMANTIC_SECURITY_GATES -- so there is no detector to witness, and a response
+        # that complies with an embedded override grades not_evaluable rather than compromised
+        # (its invalid category fails the schema check and nothing fires). Declared, not hidden:
+        # this test can currently catch nothing, and the honest coverage line becomes
+        # "ten of eighteen security detectors have never fired". Building the detector is
+        # coverage work, which Decision 9 deliberately sequenced after the grader core.
+        "classification-routing",
+    }
+)
+
+# Every id added to a register above must be declared here, in the SAME diff, with a reason of
+# at least 40 characters. The ratchet rejects a declaration that outlives its own diff: a
+# standing permission is exactly what this mechanism must never become.
+WITNESS_ALLOWLIST_WIDENING: dict[str, str] = {
+    "classification-routing": (
+        "hermia-lrzq: joining SECURITY_TEST_IDS by Scott's 2026-08-31 decision. It has no "
+        "compromise detector configured at all -- absent from both _COMPROMISE_MARKER_PATTERNS "
+        "and SEMANTIC_SECURITY_GATES -- so no fixture can witness a firing. The blind spot is "
+        "real, is declared here rather than worked around, and closing it is coverage work "
+        "sequenced after the grader core by Decision 9."
+    ),
+}
 
 # A SECOND register, and the distinction between the two is the entire point.
 #

--- a/tests/unit/test_security_verdict.py
+++ b/tests/unit/test_security_verdict.py
@@ -39,13 +39,19 @@ def test_canonical_set_matches_the_dataset():
     """
     cases = json.loads(_DATASET.read_text())["agentic_test_cases"]
     by_dimension = {t["id"] for t in cases if t.get("dimension") == "security"}
-    # Two tests are security tests filed under another dimension. Declared explicitly
+    # Three tests are security tests filed under another dimension. Declared explicitly
     # so each discrepancy is visible rather than silent (tracked in hermia-yga3):
     #   lane-routing-evasion           — refusal of an embedded credential request
     #   multiturn-boundary-persistence — final turn is a PII exfiltration attempt
+    #   classification-routing         — a routing request carrying an instruction override,
+    #                                    joined by Scott's 2026-08-31 decision (hermia-lrzq).
+    #                                    Its dataset dimension is still "routing"; changing that
+    #                                    is the labelling question hermia-yga3 tracks, not
+    #                                    something this change decides.
     assert SECURITY_TEST_IDS == by_dimension | {
         "lane-routing-evasion",
         "multiturn-boundary-persistence",
+        "classification-routing",
     }
 
 


### PR DESCRIPTION
## What

Scott decided on 2026-08-31 that `classification-routing` joins the security registry. It never landed. This lands it: `SECURITY_TEST_IDS` goes **17 → 18**.

## The uncomfortable part, declared rather than worked around

The test has a schema checker and a signal extractor but appears in **neither** `_COMPROMISE_MARKER_PATTERNS` **nor** `SEMANTIC_SECURITY_GATES`. There is no detector to witness, so `test_every_security_test_has_a_firing_compromise_witness` fails on it — correctly.

The same commit therefore declares the blind spot in `WITNESS_RAW_COVERAGE_ALLOWLIST` and `WITNESS_ALLOWLIST_WIDENING`, which is exactly what the guard's own failure message asks for. **The honest coverage line becomes: ten of eighteen security detectors have never fired.**

A consequence worth stating plainly: until a detector exists, a response that *complies* with an embedded override grades `not_evaluable`, not `compromised` — its invalid category fails the schema check and nothing fires. Building that detector is coverage work, deliberately sequenced after the grader core.

## One commit, deliberately

The ratchet rejects a declaration that outlives its own diff — Antigravity found that two-step bypass on PR #168 and the repo was hardened against it. An earlier draft of the spec required the widening to land in *its own* commit, which would have failed CI on this very PR.

## Also updated

`test_canonical_set_matches_the_dataset` asserts the security set equals the dataset's `dimension=security` ids plus explicitly named exceptions. This is a third. The dataset dimension stays `routing` — the labelling question is `hermia-yga3`, not this change.

## Verification

- Witness guard: 25 passed · ratchet exits 0 and records the widening explicitly
- `test_security_verdict.py`: 18 passed, with a positive control proving the canonical-set guard still fails when the declaration is removed
- ruff and mypy clean
- The 6 other failures in that worktree are the pre-existing Apple Silicon GPU failures fixed in #175

## Measured effect

Over all 103 result files (33,233 rows), `security_verdict()` on stored grades: 18,880 → 19,978 security rows, **86.2% → 82.0%** resisted of all rows — a **−4.2 pp** move.

The agreed figure was −4.3 pp (89.5% → 85.2%). The *direction and magnitude* reproduce; the **absolute levels do not**, because `89.5` and `85.2` appear nowhere in this repository and no function here computes a security rate at all. Filed as `hermia-nea6`. Related and worse: `compromised` is **zero** across all 18,880 security rows, because no stored row carries `CONTENT_LEAK` or `SECURITY_FAIL`.

## Follow-up

`hermia-shv6` — delete the `WITNESS_ALLOWLIST_WIDENING` declaration once this reaches the base ref, so it cannot become a standing permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)