### PR TITLE
fix(witness): a bootstrap has no additions to judge a declaration against (hermia-6ejy)

### DIFF
--- a/scripts/witness_allowlist_ratchet.py
+++ b/scripts/witness_allowlist_ratchet.py
@@ -797,9 +797,32 @@ def _extract_widening(source: str, origin: str) -> dict[str, str] | None:
 
 
 def _widening_problems(
-    widening: dict[str, str] | None, added: set[str], base: set[str]
+    widening: dict[str, str] | None,
+    added: set[str],
+    base: set[str],
+    *,
+    bootstrapping: bool = False,
 ) -> list[str]:
-    """Does the declaration authorise exactly these additions, and nothing else?"""
+    """Does the declaration authorise exactly these additions, and nothing else?
+
+    At a BOOTSTRAP the question has no answer. The gate does not exist at the base ref, so
+    every entry in the working tree is the baseline rather than a change to it, and main()
+    already zeroes `added` to say so. Judging a declaration against that empty set reported a
+    CORRECT declaration as an orphan, because `unused = declared - added - base` matched it --
+    and that failure is live: verified 2026-09-12, a dev->main promotion carrying the
+    classification-routing widening exited 1 with "is declared ... but is not actually being
+    added", which is the opposite of true.
+
+    The advance-declaration rule below is right and is NOT weakened. A bootstrap simply has no
+    additions to judge against, so the widening question is not asked at all. Skipping it here
+    is safe in the direction that matters: a bootstrap cannot smuggle an addition past the
+    ratchet, because at a bootstrap there is no earlier state for an addition to be measured
+    against -- the baseline being established IS the whole working tree, and every other guard
+    (registers shrink-only, guards alive, SECURITY_TEST_IDS does not shrink) still runs.
+    """
+    if bootstrapping:
+        return []
+
     problems: list[str] = []
 
     declared = set(widening or {})
@@ -1077,7 +1100,9 @@ def main() -> int:
     # Antigravity on PR #168 and reproduced against origin/main.
     all_added = set() if bootstrapping else (primary_added | unproven_added)
     all_base = primary_base | unproven_base
-    widening_problems = _widening_problems(widening, all_added, all_base)
+    widening_problems = _widening_problems(
+        widening, all_added, all_base, bootstrapping=bootstrapping
+    )
 
     if widening_problems:
         print()

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1728,6 +1728,21 @@ def test_witness_outside_review_findings_stay_fixed():
     assert ratchet._widening_problems({"a": reason}, {"a"}, set()) == []
     assert ratchet._widening_problems(None, set(), {"a"}) == []
 
+    # A BOOTSTRAP is the one place where "is this an addition?" has no answer: the gate does
+    # not exist at the base ref, so every entry in the working tree is the baseline rather than
+    # a change to it. main() already zeroes `added` there -- and that alone turned a CORRECT
+    # declaration into an orphan, because `unused = declared - added - base` then matched it.
+    # Verified against origin/main on 2026-09-12: the promotion path exited 1 with
+    # "'classification-routing' is declared ... but is not actually being added", which is the
+    # opposite of true. The rule above is right and must not be weakened; the bootstrap simply
+    # has no additions to judge it against, so no widening question is asked at all.
+    assert (
+        ratchet._widening_problems({"future": reason}, set(), set(), bootstrapping=True) == []
+    ), "a bootstrap has no additions, so a declaration there is neither required nor orphaned"
+    assert ratchet._widening_problems({"future": reason}, set(), set()), (
+        "and OUTSIDE a bootstrap the advance-declaration rule must still refuse it"
+    )
+
     # qwen: every dynamic-builtin check matched the NAME at the call site, so binding the
     # builtin to another name defeated all of them at once.
     # Fixing only the assignment form left three more ways in, found by CodeRabbit on PR #170


### PR DESCRIPTION
## The bug

A `dev` → `main` promotion PR **fails a required check today**, and the message blames the wrong thing.

`origin/main` does not contain `WITNESS_RAW_COVERAGE_ALLOWLIST` **at all** — absent, not empty. So a promotion takes the **bootstrap** path, which deliberately zeroes `added`, because at a bootstrap the working tree *is* the baseline rather than a change to it. But `_widening_problems` was still called with that empty set, and `unused = declared - added - base` then matched a **correct** declaration and reported it as a standing permission.

Measured on the `hermia-lrzq` branch (#176), before this fix:

```
--base origin/dev   EXIT 0
--base origin/main  EXIT 1
  'classification-routing' is declared in WITNESS_ALLOWLIST_WIDENING
   but is not actually being added
```

— which is the opposite of true. After: **both exit 0.**

## What this is not

**Not a promotion special case.** No branch-name detection, no skipped gate — a check that skips is the exact failure mode WITNESS exists to catch, and `witness-ratchet.yml` already documents that lesson in its own header.

The bootstrap concept was already here, added when Antigravity found a related hole on PR #168. It was simply one-sided: it said *"these are not additions, so do not demand a declaration"* and forgot *"and do not punish one either."* This completes it.

## The advance-declaration rule is not weakened

That rule — an advance declaration with no additions must be refused — came from PR #168 and is load-bearing. It is untouched. Six negative controls, all verified by execution:

| Case | Required | Result |
|---|---|---|
| Advance declaration, not bootstrap | FAIL | ✅ |
| Undeclared addition, not bootstrap | FAIL | ✅ |
| Spent declaration already in base | FAIL | ✅ |
| Reason under the minimum length | FAIL | ✅ |
| Legitimate declared addition | PASS | ✅ |
| Bootstrap carrying a declaration | PASS | ✅ |

Safe in the direction that matters: a bootstrap cannot smuggle an addition past the ratchet, because there is no earlier state to measure an addition against — and every other guard (registers shrink-only, guards alive, `SECURITY_TEST_IDS` does not shrink) still runs.

## Provenance

Antigravity flagged a promotion deadlock on #176. **Its predicted mechanism was wrong** — it expected `undeclared` to fire because the declaration gets deleted from `dev`. The real failure is the opposite, and the mechanism decided the fix. The conclusion was right; the reasoning was not.

## Verification

- TDD: the RED was `TypeError: _widening_problems() got an unexpected keyword argument 'bootstrapping'`
- Suite: 2483 passed, 29 skipped. The 6 failures are exactly the pre-existing Apple Silicon GPU set fixed in #175 — zero others
- ruff and mypy clean

## Merge order

Must stay separate from #176: the ratchet refuses a diff that changes `scripts/witness_allowlist_ratchet.py` and the allowlist together, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initial witness allowlist setup so existing entries are not incorrectly flagged as undeclared or orphaned.
  * Continued enforcing advance declarations when operating against an established baseline.

* **Tests**
  * Added regression coverage for bootstrap and established-baseline validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->