### PR TITLE
chore(witness): spend the classification-routing widening (hermia-shv6)

### DIFF
--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -674,15 +674,13 @@ WITNESS_RAW_COVERAGE_ALLOWLIST: frozenset[str] = frozenset(
 # Every id added to a register above must be declared here, in the SAME diff, with a reason of
 # at least 40 characters. The ratchet rejects a declaration that outlives its own diff: a
 # standing permission is exactly what this mechanism must never become.
-WITNESS_ALLOWLIST_WIDENING: dict[str, str] = {
-    "classification-routing": (
-        "hermia-lrzq: joining SECURITY_TEST_IDS by Scott's 2026-08-31 decision. It has no "
-        "compromise detector configured at all -- absent from both _COMPROMISE_MARKER_PATTERNS "
-        "and SEMANTIC_SECURITY_GATES -- so no fixture can witness a firing. The blind spot is "
-        "real, is declared here rather than worked around, and closing it is coverage work "
-        "sequenced after the grader core by Decision 9."
-    ),
-}
+#
+# EMPTY IS THE RESTING STATE. classification-routing's widening was spent when #176 landed on
+# dev (hermia-lrzq), and the ratchet then refused every subsequent PR with "is declared in
+# WITNESS_ALLOWLIST_WIDENING but is already in the allowlist at the base ref" -- verified by
+# execution on 2026-09-12, exit 1 on a branch that changed nothing else. That refusal is the
+# mechanism working: a declaration is a one-shot token, and deleting it here is how it is spent.
+WITNESS_ALLOWLIST_WIDENING: dict[str, str] = {}
 
 # A SECOND register, and the distinction between the two is the entire point.
 #


### PR DESCRIPTION
## Urgent: `dev` is currently blocked

Since #176 landed, **every pull request against `dev` fails the WITNESS ratchet.** Verified by execution on a branch that changed nothing else:

```
ratchet --base origin/dev  ->  EXIT 1
  'classification-routing' is declared in WITNESS_ALLOWLIST_WIDENING but is
  already in the allowlist at the base ref. A spent widening must be deleted,
  not left standing.
```

## Why this is the mechanism working

A widening declaration is a **one-shot token**. #176 landed the allowlist entry and its justification in a single diff — the guarantee the mechanism exists to provide. The token is now spent: the id is in the allowlist at the base ref, so the declaration must go.

Leaving it would turn a reviewed, one-time decision into a standing permission — which is the failure PR #168 was hardened against.

## A note on how this was misdiagnosed earlier today

I hit this same check from the other direction and called it a promotion deadlock. I tested exactly one configuration — declaration present — and generalised. The fix I built on that reopened the PR #168 two-step bypass, and its test asserted the bypass as correct behaviour. That work is closed unmerged (#177).

Measured afterwards, with the unmodified ratchet against `origin/main`:

| Scenario | Exit |
|---|---|
| Declaration deleted — this PR | **0** |
| Declaration left standing | **1** |

There was never a deadlock. This deletion was always the answer, and the ratchet said so in its own output.

## Scope

**Only the declaration is spent.** The `WITNESS_RAW_COVERAGE_ALLOWLIST` entry for `classification-routing` stays until the test has a real compromise detector — coverage work sequenced after the grader core by Decision 9, tracked in `hermia-nlpy` (*a model that fully obeys the routing injection triggers no regression alert*).

## Verification

| Check | Result |
|---|---|
| `ratchet --base origin/dev` | **1 → 0** |
| `ratchet --base origin/main` (promotion path) | **0**, unchanged |
| Allowlist entry for the test | intact |
| Full suite | 2489 passed, 29 skipped, **0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)