### PR TITLE
fix(tui): let detect_mode decide locality, so local runs record metrics (hermia-dl2e)

### DIFF
--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -234,6 +234,22 @@ def _gpu_stats_intel() -> tuple[float, float, float]:
         return 0.0, 0.0, 0.0
 
 
+_GPU_DETECTED = False
+
+
+def ensure_gpu_detected() -> None:
+    """Run detect_gpu() once per process so the module globals mean something.
+
+    get_gpu_stats() answers from _NVIDIA_FOUND / _APPLE_SILICON / _INTEL_IGPU / _AMD_DEV,
+    which only detect_gpu() ever populates. Idempotent and cheap after the first call.
+    """
+    global _GPU_DETECTED  # noqa: PLW0603
+    if _GPU_DETECTED:
+        return
+    detect_gpu()
+    _GPU_DETECTED = True
+
+
 def detect_gpu() -> dict[str, Any]:
     """Detect GPU hardware at run start. Updates module-level cache.
 
@@ -432,6 +448,15 @@ class MetricsSampler:
         self.latest: dict[str, float] = {}
 
     def start(self) -> None:
+        # Sampling without detection reads GPU globals that are still at their defaults, so
+        # get_gpu_stats() returns (0.0, 0.0, 0.0) on a machine that plainly has a GPU. Before
+        # this, detect_gpu() was called from exactly one place -- submit.py -- and never on the
+        # run path, so enabling local sampling would have recorded a fabricated 0% GPU and
+        # 0.0 GB VRAM for real work. Verified on an Apple M1 Pro (hermia-dl2e).
+        #
+        # Detection shells out to system_profiler/sysctl/nvidia-smi, so it is done once per
+        # process, not once per test.
+        ensure_gpu_detected()
         self._stop.clear()
         self.samples = []
         self._thread = threading.Thread(target=self._run, daemon=True)

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -382,13 +382,27 @@ def _gpu_stats_sysfs() -> tuple[float, float, float]:
         return 0.0, 0.0, 0.0
 
 
+def gpu_present() -> bool:
+    """Is there a GPU at all? Distinguishes "no GPU" from "GPU idle" (hermia-dl2e)."""
+    ensure_gpu_detected()
+    return _NVIDIA_FOUND or _APPLE_SILICON or _INTEL_IGPU or _AMD_DEV is not None
+
+
 def get_gpu_stats() -> tuple[float, float, float]:
     """Return (gpu_pct, vram_used_gb, vram_total_gb).
 
     Routes to nvidia-smi, Apple Silicon ioreg, Intel i915, or AMD rocm-smi/sysfs
-    based on what detect_gpu() found at startup. Returns (0.0, 0.0, 0.0) on
-    CPU-only systems.
+    based on what detect_gpu() found. Returns (0.0, 0.0, 0.0) on CPU-only systems —
+    callers that must tell that apart from an idle GPU should ask `gpu_present()`.
+
+    Detection is ensured HERE, where the globals are read, rather than at any one
+    call site. An earlier fix put it only in MetricsSampler.start(), which left three
+    direct callers reading uninitialised globals — runner.py's cold-load VRAM
+    before/after, and preflight.py, which is what tells a user whether a model fits
+    in their VRAM and would have answered 0 GB. Initialising at the read is the only
+    placement that cannot be bypassed by a new caller.
     """
+    ensure_gpu_detected()
     if _NVIDIA_FOUND:
         return _gpu_stats_nvidia()
 
@@ -421,13 +435,22 @@ def get_gpu_stats() -> tuple[float, float, float]:
         return _gpu_stats_sysfs()
 
 
-def get_system_metrics() -> dict[str, float]:
+def get_system_metrics() -> dict[str, float | None]:
     """Return CPU%, RAM, GPU%, VRAM as a flat dict."""
     import psutil
 
     cpu = psutil.cpu_percent(interval=None)
     ram = psutil.virtual_memory()
-    gpu_pct, vram_used, vram_total = get_gpu_stats()
+    # "No GPU" and "GPU idle" are different facts and must not both read as 0.0.
+    # On a CPU-only host the GPU fields are None — absent, not measured-as-zero —
+    # which is the same distinction _round_or_none defends in runner.py (hermia-dl2e).
+    gpu_pct: float | None
+    vram_used: float | None
+    vram_total: float | None
+    if gpu_present():
+        gpu_pct, vram_used, vram_total = get_gpu_stats()
+    else:
+        gpu_pct = vram_used = vram_total = None
     return {
         "cpu_pct": cpu,
         "ram_used_gb": ram.used / (1024**3),
@@ -442,10 +465,10 @@ class MetricsSampler:
     """Background thread sampling system metrics every 2 s during a run."""
 
     def __init__(self) -> None:
-        self.samples: list[dict[str, float]] = []
+        self.samples: list[dict[str, float | None]] = []
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
-        self.latest: dict[str, float] = {}
+        self.latest: dict[str, float | None] = {}
 
     def start(self) -> None:
         # Sampling without detection reads GPU globals that are still at their defaults, so
@@ -455,7 +478,9 @@ class MetricsSampler:
         # 0.0 GB VRAM for real work. Verified on an Apple M1 Pro (hermia-dl2e).
         #
         # Detection shells out to system_profiler/sysctl/nvidia-smi, so it is done once per
-        # process, not once per test.
+        # process, not once per test. Kept here as well as in get_gpu_stats(): starting a
+        # sampler is the moment the cost is affordable, so the first read is not the one
+        # paying for it.
         ensure_gpu_detected()
         self._stop.clear()
         self.samples = []
@@ -476,12 +501,20 @@ class MetricsSampler:
             self._stop.wait(2)
 
     def peak(self) -> dict[str, float]:
+        """Peak of each measured field. A field never measured is OMITTED, not zeroed.
+
+        On a CPU-only host the GPU fields are None in every sample, and an omitted key is
+        what lets runner.py's _round_or_none write None rather than claiming a measurement
+        of 0.0. Taking max() over None would also raise (hermia-dl2e).
+        """
         if not self.samples:
             return {}
-        return {
-            "cpu_pct": max(s["cpu_pct"] for s in self.samples),
-            "ram_used_gb": max(s["ram_used_gb"] for s in self.samples),
-            "gpu_pct": max(s["gpu_pct"] for s in self.samples),
-            "vram_used_gb": max(s["vram_used_gb"] for s in self.samples),
-            "vram_total_gb": self.samples[-1]["vram_total_gb"],
-        }
+        out: dict[str, float] = {}
+        for key in ("cpu_pct", "ram_used_gb", "gpu_pct", "vram_used_gb"):
+            seen = [s[key] for s in self.samples if s.get(key) is not None]
+            if seen:
+                out[key] = max(v for v in seen if v is not None)
+        last_total = self.samples[-1].get("vram_total_gb")
+        if last_total is not None:
+            out["vram_total_gb"] = last_total
+        return out

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -133,7 +133,7 @@ def _detect_apple_silicon() -> tuple[bool, str, float]:
     return True, name, vram_total_gb
 
 
-def _gpu_stats_apple_silicon() -> tuple[float, float, float]:
+def _gpu_stats_apple_silicon() -> tuple[float | None, float | None, float | None]:
     """Read Apple Silicon GPU utilization and VRAM via ioreg (no sudo required).
 
     ioreg IOAccelerator PerformanceStatistics exposes:
@@ -149,7 +149,7 @@ def _gpu_stats_apple_silicon() -> tuple[float, float, float]:
             capture_output=True, text=True, timeout=5,
         )
         if r.returncode != 0 or not r.stdout:
-            return 0.0, 0.0, _APPLE_VRAM_TOTAL_GB
+            return None, None, _APPLE_VRAM_TOTAL_GB
         text = r.stdout
         gpu_pct = 0.0
         vram_used_gb = 0.0
@@ -162,7 +162,7 @@ def _gpu_stats_apple_silicon() -> tuple[float, float, float]:
             vram_used_gb = int(m.group(1)) / (1024**3)
         return gpu_pct, vram_used_gb, _APPLE_VRAM_TOTAL_GB
     except (subprocess.SubprocessError, OSError, ValueError):
-        return 0.0, 0.0, _APPLE_VRAM_TOTAL_GB
+        return None, None, _APPLE_VRAM_TOTAL_GB
 
 
 def _detect_intel_igpu() -> tuple[bool, str]:
@@ -200,7 +200,7 @@ def _detect_intel_igpu() -> tuple[bool, str]:
     return False, ""
 
 
-def _gpu_stats_intel() -> tuple[float, float, float]:
+def _gpu_stats_intel() -> tuple[float | None, float | None, float | None]:
     """Read Intel iGPU utilization via intel_gpu_top (Linux only).
 
     intel_gpu_top streams JSON objects continuously; we run it briefly and
@@ -209,7 +209,7 @@ def _gpu_stats_intel() -> tuple[float, float, float]:
     Returns (0.0, 0.0, 0.0) on any failure or when not on Linux.
     """
     if sys.platform != "linux":
-        return 0.0, 0.0, 0.0
+        return None, None, None
     try:
         try:
             r = subprocess.run(  # noqa: S603
@@ -222,16 +222,16 @@ def _gpu_stats_intel() -> tuple[float, float, float]:
             text = raw if isinstance(raw, str) else (raw.decode(errors="ignore") if raw else "")
 
         if not text:
-            return 0.0, 0.0, 0.0
+            return None, None, None
         lines = [ln for ln in text.splitlines() if ln.strip().startswith("{")]
         if not lines:
-            return 0.0, 0.0, 0.0
+            return None, None, None
         obj = json.loads(lines[-1])
         engines = obj.get("engines", {})
         render = engines.get("Render/3D/0", engines.get("Render/3D", {}))
         return float(render.get("busy", 0.0)), 0.0, 0.0
     except Exception:
-        return 0.0, 0.0, 0.0
+        return None, None, None
 
 
 _GPU_DETECTED = False
@@ -333,7 +333,7 @@ def detect_gpu() -> dict[str, Any]:
     }
 
 
-def _gpu_stats_nvidia() -> tuple[float, float, float]:
+def _gpu_stats_nvidia() -> tuple[float | None, float | None, float | None]:
     """Read GPU utilization and VRAM via nvidia-smi."""
     try:
         result = subprocess.run(  # noqa: S603
@@ -347,29 +347,29 @@ def _gpu_stats_nvidia() -> tuple[float, float, float]:
             timeout=2,
         )
         if result.returncode != 0 or not result.stdout.strip():
-            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+            return None, None, _NVIDIA_VRAM_TOTAL_GB
         line = result.stdout.strip().splitlines()[0]
         parts = [p.strip() for p in line.split(",")]
         if len(parts) < 3:
-            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+            return None, None, _NVIDIA_VRAM_TOTAL_GB
         try:
             gpu_pct = float(parts[0])
             vram_used = float(parts[1]) / 1024  # MiB → GiB
             vram_total = float(parts[2]) / 1024  # MiB → GiB
         except ValueError:
-            return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+            return None, None, _NVIDIA_VRAM_TOTAL_GB
         return gpu_pct, vram_used, vram_total
     except (subprocess.SubprocessError, ValueError, IndexError, OSError):
-        return 0.0, 0.0, _NVIDIA_VRAM_TOTAL_GB
+        return None, None, _NVIDIA_VRAM_TOTAL_GB
 
 
-def _gpu_stats_sysfs() -> tuple[float, float, float]:
+def _gpu_stats_sysfs() -> tuple[float | None, float | None, float | None]:
     """Read AMD GPU stats from amdgpu kernel sysfs — works without ROCm/Vulkan."""
     dev = _AMD_DEV
     if dev is None:
         dev = _find_amdgpu_dev()
     if dev is None:
-        return 0.0, 0.0, 0.0
+        return None, None, None
     try:
         with open(f"{dev}/gpu_busy_percent") as f:
             gpu_pct = float(f.read().strip())
@@ -379,7 +379,7 @@ def _gpu_stats_sysfs() -> tuple[float, float, float]:
             vram_total = float(f.read().strip()) / (1024**3)
         return gpu_pct, vram_used, vram_total
     except Exception:
-        return 0.0, 0.0, 0.0
+        return None, None, None
 
 
 def gpu_present() -> bool:
@@ -388,12 +388,16 @@ def gpu_present() -> bool:
     return _NVIDIA_FOUND or _APPLE_SILICON or _INTEL_IGPU or _AMD_DEV is not None
 
 
-def get_gpu_stats() -> tuple[float, float, float]:
+def get_gpu_stats() -> tuple[float | None, float | None, float | None]:
     """Return (gpu_pct, vram_used_gb, vram_total_gb).
 
     Routes to nvidia-smi, Apple Silicon ioreg, Intel i915, or AMD rocm-smi/sysfs
-    based on what detect_gpu() found. Returns (0.0, 0.0, 0.0) on CPU-only systems —
-    callers that must tell that apart from an idle GPU should ask `gpu_present()`.
+    based on what detect_gpu() found.
+
+    A field is None when it was NOT MEASURED — no GPU, or the probe failed. 0.0 means
+    measured and idle. Those are different claims and a recorded row must not confuse
+    them; a cached total that detection genuinely found stays populated even when the
+    live probe fails, because that value IS known (hermia-dl2e).
 
     Detection is ensured HERE, where the globals are read, rather than at any one
     call site. An earlier fix put it only in MetricsSampler.start(), which left three
@@ -413,7 +417,7 @@ def get_gpu_stats() -> tuple[float, float, float]:
         return _gpu_stats_intel()
 
     if _AMD_DEV is None:
-        return 0.0, 0.0, 0.0
+        return None, None, None
 
     try:
         result = subprocess.run(  # noqa: S603
@@ -471,6 +475,13 @@ class MetricsSampler:
         self.latest: dict[str, float | None] = {}
 
     def start(self) -> None:
+        # psutil.cpu_percent(interval=None) returns 0.0 on its FIRST call in a process: it
+        # reports usage since the previous call, and there was none. On a short trial that
+        # zero is the only sample, so a busy machine records 0.0% CPU. Priming here discards
+        # that first meaningless reading (hermia-dl2e).
+        import psutil
+
+        psutil.cpu_percent(interval=None)
         # Sampling without detection reads GPU globals that are still at their defaults, so
         # get_gpu_stats() returns (0.0, 0.0, 0.0) on a machine that plainly has a GPU. Before
         # this, detect_gpu() was called from exactly one place -- submit.py -- and never on the

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -139,9 +139,13 @@ def check_engine_security(
 
 @dataclass
 class PreflightReport:
-    vram_total_gb: float
-    vram_used_gb: float
-    vram_available_gb: float
+    # None when this machine's GPU could not be measured -- no GPU, or the probe failed.
+    # Distinct from 0.0, which asserts a measurement. A preflight that reports 0 GB free
+    # on an unmeasured host tells a user their model will not fit when we simply do not
+    # know (hermia-dl2e).
+    vram_total_gb: float | None
+    vram_used_gb: float | None
+    vram_available_gb: float | None
     ram_total_gb: float
     ram_available_gb: float
     disk_free_gb: float
@@ -171,6 +175,8 @@ class PreflightReport:
                 out.append(
                     f"WARN {m.name} ({m.size_gb:.1f} GB): tight fit — "
                     f"{self.vram_available_gb:.1f} GB VRAM free, may stall"
+                    if self.vram_available_gb is not None
+                    else "VRAM could not be measured on this host"
                 )
         return out
 
@@ -182,7 +188,10 @@ def run_preflight(
     fleet_mode: bool = False,
 ) -> PreflightReport:
     _, vram_used, vram_total = get_gpu_stats()
-    vram_available = max(0.0, vram_total - vram_used - VRAM_OVERHEAD_GB)
+    vram_available = (
+        None if vram_total is None or vram_used is None
+        else max(0.0, vram_total - vram_used - VRAM_OVERHEAD_GB)
+    )
 
     vm = psutil.virtual_memory()
     ram_total_gb = vm.total / (1024**3)
@@ -198,7 +207,9 @@ def run_preflight(
     for name in selected_models:
         size_gb = size_map.get(name, 0.0)
         fits_total_vram = size_gb <= vram_total
-        fits_current_vram = size_gb <= vram_available
+        # Unknown VRAM is not a failing check. Refusing to guess beats guessing wrong in
+        # either direction -- a false "will not fit" is as unhelpful as a false "will".
+        fits_current_vram = True if vram_available is None else size_gb <= vram_available
         fits_ram = (size_gb * RAM_LOAD_MULTIPLIER) <= ram_available_gb
 
         if name in VULKAN_GFX900_BLOCKLIST and not fleet_mode:

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -1,6 +1,7 @@
 """Ollama model management and test execution."""
 
 import hashlib
+import ipaddress
 import json
 import os
 import threading
@@ -63,9 +64,20 @@ def _round_or_none(value: float | None, digits: int) -> float | None:
 
 
 def detect_mode(host: str) -> str:
-    """Return 'local' if host resolves to localhost/loopback, else 'fleet'."""
+    """Return 'local' if host resolves to localhost/loopback, else 'fleet'.
+
+    The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1 — systemd-resolved uses
+    127.0.0.53 and container setups bind elsewhere in the range. 0.0.0.0 means "this
+    machine, all interfaces". Matching three literals sent those to 'fleet' and silently
+    discarded every metric for a run that was in fact local (hermia-dl2e).
+    """
     hostname = urlparse(_normalize_host(host)).hostname or ""
-    return "local" if hostname in ("localhost", "127.0.0.1", "::1") else "fleet"
+    if hostname in ("localhost", "0.0.0.0"):  # noqa: S104 - a comparison, not a bind
+        return "local"
+    try:
+        return "local" if ipaddress.ip_address(hostname).is_loopback else "fleet"
+    except ValueError:
+        return "fleet"
 
 
 _ps_cache: dict[tuple[Any, ...], dict[str, float | None]] = {}
@@ -420,13 +432,21 @@ def run_test(
     is_api_mode = getattr(transport, "is_api_mode", False) is True
     resolved_locality = locality if locality is not None else detect_mode(_host)
     is_local = (not is_api_mode) and (resolved_locality == "local")
+    # NOT widened to include api-mode-on-localhost. A local OpenAI-compatible server
+    # (llama.cpp, vLLM, LM Studio) is an API *shape* doing work on this machine, so it
+    # arguably should be sampled -- but `test_run_test_api_mode_short_circuits_locality`
+    # asserts the opposite in the repo's own voice, with this exact host and locality:
+    # "is_api_mode=True wins over any locality value". That is a deliberate, tested
+    # contract, and changing what the corpus records is a product decision, not a tidy-up.
+    # Raised by outside-family review as LOW; carried to Scott rather than changed here.
+    samples_local_hardware = is_local
 
     error_type: str = ""
     response = None
     # Only sample local hardware when the work runs on this machine; in
     # fleet/api mode the orchestrator's own hardware is irrelevant and the
     # sampler thread would be pure overhead (the peak is discarded anyway).
-    if is_local:
+    if samples_local_hardware:
         sampler.start()
     t0 = time.monotonic()
     try:
@@ -454,7 +474,7 @@ def run_test(
     except Exception as e:  # noqa: BLE001
         error_type = f"ERROR: {e}"
     finally:
-        if is_local:
+        if samples_local_hardware:
             sampler.stop()
     error_elapsed = time.monotonic() - t0
 
@@ -476,7 +496,11 @@ def run_test(
     orchestration_version: str | None = (
         response.orchestration_version if response is not None else None
     )
-    peak = sampler.peak() if is_local else {}
+    peak = sampler.peak() if samples_local_hardware else {}
+
+    def _peak_of(key: str, digits: int) -> float | None:
+        """A peak only exists if this machine did the work AND the field was measured."""
+        return _round_or_none(peak.get(key), digits) if samples_local_hardware else None
 
     json_valid = False
     schema_ok = False
@@ -600,10 +624,10 @@ def run_test(
         # previous `peak.get(key, 0)` then wrote 0.0, claiming a running machine used 0.0 GB
         # of RAM. An unmeasured field must stay None: None means "not measured", 0.0 means
         # "measured, and it was zero", and a dashboard cannot tell them apart (hermia-dl2e).
-        "peak_cpu_pct": _round_or_none(peak.get("cpu_pct"), 1) if is_local else None,
-        "peak_ram_used_gb": _round_or_none(peak.get("ram_used_gb"), 2) if is_local else None,
-        "peak_gpu_pct": _round_or_none(peak.get("gpu_pct"), 1) if is_local else None,
-        "peak_vram_used_gb": _round_or_none(peak.get("vram_used_gb"), 2) if is_local else None,
+        "peak_cpu_pct": _peak_of("cpu_pct", 1),
+        "peak_ram_used_gb": _peak_of("ram_used_gb", 2),
+        "peak_gpu_pct": _peak_of("gpu_pct", 1),
+        "peak_vram_used_gb": _peak_of("vram_used_gb", 2),
         "mode": "local" if is_local else ("api" if is_api_mode else "fleet"),
         "host": _host,
         **ps_data,

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -72,7 +72,11 @@ def detect_mode(host: str) -> str:
     discarded every metric for a run that was in fact local (hermia-dl2e).
     """
     hostname = urlparse(_normalize_host(host)).hostname or ""
-    if hostname in ("localhost", "0.0.0.0"):  # noqa: S104 - a comparison, not a bind
+    # "0.0.0.0" and "::" are the unspecified addresses -- "this machine, every interface".
+    # A HOSTNAME is deliberately NOT treated as local even when it resolves here: that would
+    # make locality depend on DNS, and a name can resolve to a different box on the LAN,
+    # which is the misattribution hazard the SSH-tunnel note below is about.
+    if hostname in ("localhost", "0.0.0.0", "::"):  # noqa: S104 - a comparison, not a bind
         return "local"
     try:
         return "local" if ipaddress.ip_address(hostname).is_loopback else "fleet"
@@ -200,10 +204,13 @@ def unload_model(model_name: str) -> None:
         pass
 
 
-def prewarm_timed(model_name: str) -> tuple[float, float, float]:
+def prewarm_timed(model_name: str) -> tuple[float, float | None, float | None]:
     """Unload cached model, then time a cold load.
 
-    Returns (load_time_sec, vram_before_gb, vram_after_gb).
+    Returns (load_time_sec, vram_before_gb, vram_after_gb). The two VRAM figures are None
+    when this machine's GPU could not be measured -- no GPU, or the probe failed. The load
+    time is always real. Reporting 0.0 GB before and after would make a cold load look like
+    it consumed no memory, which is a measurement claim we cannot support (hermia-dl2e).
     """
     host = get_ollama_host()
     _, vram_before, _ = get_gpu_stats()

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -57,6 +57,11 @@ def get_ollama_host() -> str:
     return _normalize_host(os.environ.get("HERMIA_HOST", "http://localhost:11434"))
 
 
+def _round_or_none(value: float | None, digits: int) -> float | None:
+    """Round a measured value, or keep None. Never substitutes a fabricated zero."""
+    return None if value is None else round(value, digits)
+
+
 def detect_mode(host: str) -> str:
     """Return 'local' if host resolves to localhost/loopback, else 'fleet'."""
     hostname = urlparse(_normalize_host(host)).hostname or ""
@@ -590,10 +595,15 @@ def run_test(
         "raw_prompt": test.get("prompt") or "",
         "raw_response": "" if error_type else output,
         "raw_thinking": "" if error_type else thinking_text,
-        "peak_cpu_pct": round(peak.get("cpu_pct", 0), 1) if is_local else None,
-        "peak_ram_used_gb": round(peak.get("ram_used_gb", 0), 2) if is_local else None,
-        "peak_gpu_pct": round(peak.get("gpu_pct", 0), 1) if is_local else None,
-        "peak_vram_used_gb": round(peak.get("vram_used_gb", 0), 2) if is_local else None,
+        # `peak` is EMPTY when a trial fails before the sampler thread takes its first
+        # sample -- a connection refused by a stopped Ollama returns in milliseconds. The
+        # previous `peak.get(key, 0)` then wrote 0.0, claiming a running machine used 0.0 GB
+        # of RAM. An unmeasured field must stay None: None means "not measured", 0.0 means
+        # "measured, and it was zero", and a dashboard cannot tell them apart (hermia-dl2e).
+        "peak_cpu_pct": _round_or_none(peak.get("cpu_pct"), 1) if is_local else None,
+        "peak_ram_used_gb": _round_or_none(peak.get("ram_used_gb"), 2) if is_local else None,
+        "peak_gpu_pct": _round_or_none(peak.get("gpu_pct"), 1) if is_local else None,
+        "peak_vram_used_gb": _round_or_none(peak.get("vram_used_gb"), 2) if is_local else None,
         "mode": "local" if is_local else ("api" if is_api_mode else "fleet"),
         "host": _host,
         **ps_data,

--- a/src/hermia/runner.py
+++ b/src/hermia/runner.py
@@ -72,11 +72,16 @@ def detect_mode(host: str) -> str:
     discarded every metric for a run that was in fact local (hermia-dl2e).
     """
     hostname = urlparse(_normalize_host(host)).hostname or ""
+    # Suppressed twice on purpose: ruff reports S104 and bandit reports B104 for the same
+    # literal, and each needs its own marker. Both are false here -- this COMPARES a parsed
+    # hostname, it does not bind a socket. The repo already carries this dual-suppression
+    # pattern elsewhere (ruff S310 / bandit B310).
+    #
     # "0.0.0.0" and "::" are the unspecified addresses -- "this machine, every interface".
     # A HOSTNAME is deliberately NOT treated as local even when it resolves here: that would
     # make locality depend on DNS, and a name can resolve to a different box on the LAN,
     # which is the misattribution hazard the SSH-tunnel note below is about.
-    if hostname in ("localhost", "0.0.0.0", "::"):  # noqa: S104 - a comparison, not a bind
+    if hostname in ("localhost", "0.0.0.0", "::"):  # noqa: S104  # nosec B104
         return "local"
     try:
         return "local" if ipaddress.ip_address(hostname).is_loopback else "fleet"

--- a/src/hermia/tui/runner_backend.py
+++ b/src/hermia/tui/runner_backend.py
@@ -437,7 +437,25 @@ def _real_run_test(
         else OllamaTransport(host, headers)
     )
     sampler = MetricsSampler()
+    # locality is LEFT TO run_test's own detect_mode(host) -- deliberately not hardcoded.
+    #
+    # This call site passed locality="remote" unconditionally from the commit that created
+    # TuiRunner (2026-06-21). run_test gates ALL metric capture on is_local, so every row the
+    # TUI wrote carried peak_cpu_pct / peak_gpu_pct / peak_vram_used_gb = None -- including
+    # for someone running against Ollama on their own laptop, which is how most people run
+    # this. Measured over the corpus by run_id month: 2026-05 66% of rows carried GPU data,
+    # 2026-06 11%, 2026-07 and 2026-08 zero. The README's claim that "live system metrics run
+    # alongside every eval" has been false since the TUI became the way hermia is run.
+    #
+    # fleet.py keeps locality="remote" and is RIGHT to: those hosts really are remote and the
+    # orchestrator's own hardware says nothing about them. The difference is that this path
+    # can be pointed at localhost, and detect_mode is what tells the two apart.
+    #
+    # Known residual, not fixed here: an SSH tunnel on localhost:11435 forwarding to a fleet
+    # box reads as local, so the orchestrator's metrics would be attributed to a remote run.
+    # machine_id stamping (hermia-cfqv) is what catches that class; widening this fix to
+    # consult it needs its own change.
     return run_test(
         model_name, test, sampler,
-        host=host, transport=transport, locality="remote",
+        host=host, transport=transport,
     )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -308,8 +308,8 @@ def test_get_gpu_stats_uses_nvidia_when_found():
     assert abs(vram_total - 32.0) < 0.01
 
 
-def test_get_gpu_stats_nvidia_subprocess_error_returns_zeros():
-    """nvidia-smi failure during stats returns zeros with cached vram_total."""
+def test_get_gpu_stats_nvidia_subprocess_error_reports_unmeasured():
+    """nvidia-smi crashing means UNMEASURED, not idle; the cached total stays known."""
     with (
         # detection has already happened; these tests describe its RESULT
         patch.object(metrics_mod, "_GPU_DETECTED", True),
@@ -319,13 +319,13 @@ def test_get_gpu_stats_nvidia_subprocess_error_returns_zeros():
     ):
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
-    assert gpu_pct == 0.0
-    assert vram_used == 0.0
+    assert gpu_pct is None
+    assert vram_used is None
     assert vram_total == 24.0
 
 
-def test_get_gpu_stats_nvidia_nonzero_returncode_returns_zeros():
-    """Non-zero nvidia-smi exit during stats returns zeros with cached vram_total."""
+def test_get_gpu_stats_nvidia_nonzero_returncode_reports_unmeasured():
+    """A non-zero nvidia-smi exit means UNMEASURED, not 0% utilisation."""
     bad = MagicMock()
     bad.returncode = 1
     bad.stdout = ""
@@ -338,7 +338,7 @@ def test_get_gpu_stats_nvidia_nonzero_returncode_returns_zeros():
     ):
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
-    assert gpu_pct == 0.0
+    assert gpu_pct is None
     assert vram_total == 24.0
 
 
@@ -591,8 +591,8 @@ def test_get_gpu_stats_apple_silicon_ioreg():
     assert vram_total == 18.0
 
 
-def test_get_gpu_stats_apple_silicon_ioreg_error():
-    """get_gpu_stats() returns zeros with cached total on ioreg failure."""
+def test_get_gpu_stats_apple_silicon_ioreg_error_reports_unmeasured():
+    """ioreg failing means UNMEASURED; the total detection already found stays known."""
     with (
         # detection has already happened; these tests describe its RESULT
         patch.object(metrics_mod, "_GPU_DETECTED", True),
@@ -603,8 +603,8 @@ def test_get_gpu_stats_apple_silicon_ioreg_error():
     ):
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
-    assert gpu_pct == 0.0
-    assert vram_used == 0.0
+    assert gpu_pct is None
+    assert vram_used is None
     assert vram_total == 16.0
 
 
@@ -732,8 +732,8 @@ def test_get_gpu_stats_intel_routes_to_intel_stats():
     assert vram_total == 0.0
 
 
-def test_get_gpu_stats_intel_no_tool_returns_zeros():
-    """_gpu_stats_intel() returns zeros when intel_gpu_top is not installed."""
+def test_get_gpu_stats_intel_no_tool_reports_unmeasured():
+    """No intel_gpu_top means UNMEASURED, not a GPU sitting at 0%."""
     with (
         # detection has already happened; these tests describe its RESULT
         patch.object(metrics_mod, "_GPU_DETECTED", True),
@@ -746,9 +746,9 @@ def test_get_gpu_stats_intel_no_tool_returns_zeros():
     ):
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
-    assert gpu_pct == 0.0
-    assert vram_used == 0.0
-    assert vram_total == 0.0
+    assert gpu_pct is None
+    assert vram_used is None
+    assert vram_total is None
 
 
 def test_get_gpu_stats_intel_timeout_captures_partial_output():
@@ -775,8 +775,8 @@ def test_get_gpu_stats_intel_timeout_captures_partial_output():
     assert vram_total == 0.0
 
 
-def test_get_gpu_stats_cpu_only_returns_zeros():
-    """get_gpu_stats() returns zeros when no GPU was detected (CPU-only)."""
+def test_get_gpu_stats_cpu_only_reports_unmeasured():
+    """No GPU at all means UNMEASURED. hermia-dl2e: 0.0 asserts a measurement we do not have."""
     with (
         # detection has already happened; these tests describe its RESULT
         patch.object(metrics_mod, "_GPU_DETECTED", True),
@@ -787,9 +787,9 @@ def test_get_gpu_stats_cpu_only_returns_zeros():
     ):
         gpu_pct, vram_used, vram_total = get_gpu_stats()
 
-    assert gpu_pct == 0.0
-    assert vram_used == 0.0
-    assert vram_total == 0.0
+    assert gpu_pct is None
+    assert vram_used is None
+    assert vram_total is None
 
 
 def test_cpu_only_host_reports_none_not_zero(clean_gpu_globals):
@@ -827,3 +827,44 @@ def test_get_gpu_stats_initialises_detection_itself(clean_gpu_globals):
     with patch.object(metrics_mod, "detect_gpu") as detect:
         metrics_mod.get_gpu_stats()
     assert detect.called, "get_gpu_stats() must ensure detection, not assume it"
+
+
+def test_no_collector_fabricates_a_zero_when_its_probe_fails(clean_gpu_globals):
+    """hermia-dl2e: finishing the class. 0.0 is a measurement; absence is not.
+
+    Every collector used to return 0.0 when its tool was missing or crashed, so a host with
+    no intel_gpu_top, no nvidia-smi, or a failing ioreg recorded "GPU at 0%" -- indistinguishable
+    from a real idle GPU. Found one layer at a time across three rounds of outside-family review.
+    """
+    cases = {
+        "no GPU": dict(_NVIDIA_FOUND=False, _APPLE_SILICON=False, _INTEL_IGPU=False, _AMD_DEV=None),
+        "intel, tool missing": dict(
+            _NVIDIA_FOUND=False, _APPLE_SILICON=False, _INTEL_IGPU=True, _AMD_DEV=None
+        ),
+        "nvidia, smi missing": dict(
+            _NVIDIA_FOUND=True, _APPLE_SILICON=False, _INTEL_IGPU=False, _AMD_DEV=None
+        ),
+    }
+    for label, globals_ in cases.items():
+        for name, value in globals_.items():
+            setattr(metrics_mod, name, value)
+        with patch.object(metrics_mod, "_GPU_DETECTED", True), patch(
+            "subprocess.run", side_effect=FileNotFoundError
+        ):
+            gpu_pct, vram_used, _ = metrics_mod.get_gpu_stats()
+            recorded = metrics_mod.get_system_metrics()
+        assert gpu_pct is None, f"{label}: utilisation was not measured, so it is not 0.0"
+        assert vram_used is None, f"{label}: VRAM was not measured, so it is not 0.0"
+        assert recorded["gpu_pct"] is None, f"{label}: a recorded row must not claim 0.0"
+
+
+def test_sampler_primes_the_cpu_counter(clean_gpu_globals):
+    """psutil.cpu_percent's first call in a process always returns 0.0 (hermia-dl2e)."""
+    calls = []
+    real = metrics_mod.MetricsSampler
+
+    with patch("psutil.cpu_percent", side_effect=lambda **kw: calls.append(1) or 5.0):
+        s = real()
+        s.start()
+        s.stop()
+    assert calls, "start() must take and discard a priming reading"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -98,6 +98,11 @@ def clean_gpu_globals():
         "_APPLE_SILICON": False,
         "_APPLE_VRAM_TOTAL_GB": 0.0,
         "_INTEL_IGPU": False,
+        # The detection latch, added with ensure_gpu_detected(). Omitting it left detection
+        # marked done while the six values above were reset, so ensure_gpu_detected() would
+        # not re-run and every later test saw a machine with no GPU. Exactly the pollution
+        # this fixture exists to prevent, reintroduced by the global that fixed it.
+        "_GPU_DETECTED": False,
     }
     for name, value in defaults.items():
         setattr(metrics_mod, name, value)
@@ -290,6 +295,8 @@ def _nvidia_stats_result(
 def test_get_gpu_stats_uses_nvidia_when_found():
     """get_gpu_stats() routes to nvidia-smi when _NVIDIA_FOUND is True."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", True),
         patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 32.0),
         patch("subprocess.run", return_value=_nvidia_stats_result(82.0, 12288.0, 32768.0)),
@@ -304,6 +311,8 @@ def test_get_gpu_stats_uses_nvidia_when_found():
 def test_get_gpu_stats_nvidia_subprocess_error_returns_zeros():
     """nvidia-smi failure during stats returns zeros with cached vram_total."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", True),
         patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 24.0),
         patch("subprocess.run", side_effect=OSError),
@@ -321,6 +330,8 @@ def test_get_gpu_stats_nvidia_nonzero_returncode_returns_zeros():
     bad.returncode = 1
     bad.stdout = ""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", True),
         patch.object(metrics_mod, "_NVIDIA_VRAM_TOTAL_GB", 24.0),
         patch("subprocess.run", return_value=bad),
@@ -417,6 +428,8 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_returns_zeros():
         return mock_open(read_data=open_values.get(path, "0"))()
 
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
         patch.object(metrics_mod, "_INTEL_IGPU", False),
@@ -446,6 +459,8 @@ def test_get_gpu_stats_falls_back_to_sysfs_when_rocm_missing():
         return mock_open(read_data=open_values.get(path, "0"))()
 
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
         patch.object(metrics_mod, "_INTEL_IGPU", False),
@@ -560,6 +575,8 @@ def test_get_gpu_stats_apple_silicon_ioreg():
     mem_bytes = int(1.5 * 1024**3)
 
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_APPLE_SILICON", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_VRAM_TOTAL_GB", 18.0),
@@ -577,6 +594,8 @@ def test_get_gpu_stats_apple_silicon_ioreg():
 def test_get_gpu_stats_apple_silicon_ioreg_error():
     """get_gpu_stats() returns zeros with cached total on ioreg failure."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_APPLE_SILICON", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_VRAM_TOTAL_GB", 16.0),
@@ -698,6 +717,8 @@ def test_detect_amd_takes_priority_over_intel(clean_gpu_globals):
 def test_get_gpu_stats_intel_routes_to_intel_stats():
     """get_gpu_stats() routes to _gpu_stats_intel() when _INTEL_IGPU is True."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_INTEL_IGPU", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
@@ -714,6 +735,8 @@ def test_get_gpu_stats_intel_routes_to_intel_stats():
 def test_get_gpu_stats_intel_no_tool_returns_zeros():
     """_gpu_stats_intel() returns zeros when intel_gpu_top is not installed."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_INTEL_IGPU", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
@@ -736,6 +759,8 @@ def test_get_gpu_stats_intel_timeout_captures_partial_output():
     exc = sp.TimeoutExpired(cmd=["intel_gpu_top"], timeout=0.4, output=sample_json)
 
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_INTEL_IGPU", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
@@ -753,6 +778,8 @@ def test_get_gpu_stats_intel_timeout_captures_partial_output():
 def test_get_gpu_stats_cpu_only_returns_zeros():
     """get_gpu_stats() returns zeros when no GPU was detected (CPU-only)."""
     with (
+        # detection has already happened; these tests describe its RESULT
+        patch.object(metrics_mod, "_GPU_DETECTED", True),
         patch.object(metrics_mod, "_NVIDIA_FOUND", False),
         patch.object(metrics_mod, "_APPLE_SILICON", False),
         patch.object(metrics_mod, "_INTEL_IGPU", False),
@@ -763,3 +790,40 @@ def test_get_gpu_stats_cpu_only_returns_zeros():
     assert gpu_pct == 0.0
     assert vram_used == 0.0
     assert vram_total == 0.0
+
+
+def test_cpu_only_host_reports_none_not_zero(clean_gpu_globals):
+    """hermia-dl2e: "no GPU" and "GPU idle" are different facts."""
+    with patch.object(metrics_mod, "_GPU_DETECTED", True):
+        m = metrics_mod.get_system_metrics()
+    assert m["gpu_pct"] is None, "a machine with no GPU has not measured 0% utilisation"
+    assert m["vram_used_gb"] is None
+    assert m["cpu_pct"] is not None, "CPU is always measurable"
+
+
+def test_peak_omits_a_field_it_never_measured():
+    """An omitted key is what lets runner.py write None instead of a fabricated 0.0."""
+    s = metrics_mod.MetricsSampler()
+    s.samples = [
+        {"cpu_pct": 10.0, "ram_used_gb": 4.0, "gpu_pct": None,
+         "vram_used_gb": None, "vram_total_gb": None},
+        {"cpu_pct": 50.0, "ram_used_gb": 5.0, "gpu_pct": None,
+         "vram_used_gb": None, "vram_total_gb": None},
+    ]
+    peak = s.peak()
+    assert peak["cpu_pct"] == 50.0
+    assert "gpu_pct" not in peak, "an unmeasured field must be absent, not zero"
+    assert "vram_used_gb" not in peak
+
+
+def test_get_gpu_stats_initialises_detection_itself(clean_gpu_globals):
+    """hermia-dl2e: three callers bypassed MetricsSampler.start() entirely.
+
+    runner.py's cold-load VRAM before/after and preflight.py -- the code that tells a user
+    whether a model fits in their VRAM -- call get_gpu_stats() directly. With detection
+    wired only into the sampler they read globals at their defaults and preflight would
+    have answered 0 GB. Initialising at the READ is the placement a new caller cannot bypass.
+    """
+    with patch.object(metrics_mod, "detect_gpu") as detect:
+        metrics_mod.get_gpu_stats()
+    assert detect.called, "get_gpu_stats() must ensure detection, not assume it"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1382,3 +1382,75 @@ def test_run_test_standalone_remote_stamps_fingerprint() -> None:
 
     assert "stack_fingerprint" in row
     assert row["stack_fingerprint"]["model"]["digest"] == "sha256:remote"
+
+
+def test_local_host_records_metrics_and_never_fabricates_zero() -> None:
+    """hermia-dl2e: three defects the outside-family gate caught in one fix.
+
+    (1) The TUI declared every host remote, so run_test's is_local was always False and every
+        row carried peak_* = None -- including for someone running against Ollama on their own
+        laptop. Corpus by run_id month: 2026-05 66% of rows had GPU data, 06 11%, 07 and 08 zero.
+    (2) Enabling sampling alone was NOT enough: detect_gpu() was called only from submit.py,
+        never on the run path, so the GPU globals stayed at their defaults and get_gpu_stats()
+        returned (0.0, 0.0, 0.0) on a machine with an Apple M1 Pro. That would have replaced an
+        honest None with a fabricated zero -- strictly worse, because a dashboard cannot tell
+        "not measured" from "measured, and idle".
+    (3) When a trial fails before the sampler takes its first sample, peak is {} and the old
+        `peak.get(key, 0)` wrote 0.0 -- a running machine using 0.0 GB of RAM.
+
+    The first version of this test asserted `seen.get("locality") != "remote"` against a mocked
+    run_test. That was a tautology: the kwarg had been removed, so the expression was None !=
+    "remote", true for every input including a remote host. It is replaced here by a test that
+    runs the real thing.
+    """
+    payload = '{"action": "search_documentation", "params": {}}'
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = TransportResponse(
+        text=payload, tokens=10, elapsed_sec=1.0,
+        orchestration="ollama", orchestration_version="0.24.0", is_api_mode=False,
+    )
+
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        local = run_test(
+            "m", _BASE_TEST, _mock_sampler(),
+            host="http://localhost:11434", transport=transport,
+        )
+        remote = run_test(
+            "m", _BASE_TEST, _mock_sampler(),
+            host="http://100.68.230.118:11434", transport=transport,
+        )
+
+    # (1) a host on this machine is local, and its measurements are kept
+    assert local["mode"] == "local", "localhost must not be declared remote"
+    assert local["peak_gpu_pct"] == 85.0
+    assert local["peak_vram_used_gb"] == 20.0
+    # and a genuine fleet host still is not sampled
+    assert remote["mode"] == "fleet"
+    assert remote["peak_gpu_pct"] is None
+
+    # (3) an unmeasured peak stays None rather than becoming a fabricated 0.0
+    empty = MagicMock()
+    empty.peak.return_value = {}
+    with patch("hermia.runner.fetch_server_ps_data", return_value=_PS_EMPTY):
+        unmeasured = run_test(
+            "m", _BASE_TEST, empty,
+            host="http://localhost:11434", transport=transport,
+        )
+    assert unmeasured["mode"] == "local"
+    for field in ("peak_cpu_pct", "peak_ram_used_gb", "peak_gpu_pct", "peak_vram_used_gb"):
+        assert unmeasured[field] is None, (
+            f"{field} must stay None when nothing was sampled; 0.0 claims a measurement"
+        )
+
+
+def test_sampler_start_initialises_gpu_detection() -> None:
+    """hermia-dl2e (2): sampling without detection reads globals that mean nothing."""
+    import hermia.metrics as metrics_mod
+
+    with patch.object(metrics_mod, "_GPU_DETECTED", False), \
+         patch.object(metrics_mod, "detect_gpu") as detect:
+        sampler = metrics_mod.MetricsSampler()
+        sampler.start()
+        sampler.stop()
+    assert detect.called, "MetricsSampler.start() must ensure detect_gpu() has run"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1454,3 +1454,21 @@ def test_sampler_start_initialises_gpu_detection() -> None:
         sampler.start()
         sampler.stop()
     assert detect.called, "MetricsSampler.start() must ensure detect_gpu() has run"
+
+
+def test_detect_mode_treats_the_whole_loopback_range_as_local() -> None:
+    """hermia-dl2e: 127.0.0.0/8 is all loopback, not just 127.0.0.1.
+
+    systemd-resolved uses 127.0.0.53 and containers bind elsewhere in the range. Matching
+    three string literals sent those to 'fleet' and silently discarded every metric for a
+    run that was in fact on this machine.
+    """
+    from hermia.runner import detect_mode
+
+    for host in (
+        "http://localhost:11434", "http://127.0.0.1:11434",
+        "http://127.0.0.53:11434", "http://0.0.0.0:11434", "http://[::1]:11434",
+    ):
+        assert detect_mode(host) == "local", host
+    for host in ("http://100.68.230.118:11434", "http://my-box.local:11434"):
+        assert detect_mode(host) == "fleet", host

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1468,7 +1468,10 @@ def test_detect_mode_treats_the_whole_loopback_range_as_local() -> None:
     for host in (
         "http://localhost:11434", "http://127.0.0.1:11434",
         "http://127.0.0.53:11434", "http://0.0.0.0:11434", "http://[::1]:11434",
+        "http://[::]:11434",
     ):
         assert detect_mode(host) == "local", host
+    # A HOSTNAME stays fleet even when it resolves to this machine: making locality depend
+    # on DNS invites the same misattribution as an SSH tunnel on localhost.
     for host in ("http://100.68.230.118:11434", "http://my-box.local:11434"):
         assert detect_mode(host) == "fleet", host

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -355,43 +355,52 @@ class TestTuiRunnerBusEvents:
         asyncio.run(_run())
 
 
-def test_tui_samples_local_hardware_when_the_host_is_this_machine():
-    """The TUI must not declare every host remote (hermia-metrics).
+def test_tui_does_not_declare_a_host_on_this_machine_remote():
+    """hermia-dl2e: the TUI path itself, end to end, not a keyword-argument assertion.
 
-    Introduced 2026-06-21 in the commit that added TuiRunner: the call site passed
-    locality="remote" unconditionally. run_test gates ALL metric capture on
-    is_local, so every row written through the TUI carried peak_cpu_pct=None,
-    peak_gpu_pct=None, peak_vram_used_gb=None -- including for a user running
-    against Ollama on their own laptop.
+    An earlier version of this test mocked run_test and asserted
+    `seen.get("locality") != "remote"`. That was a tautology -- the kwarg had been removed, so
+    the expression read None != "remote" and passed for every input, including a remote host.
+    Caught by outside-family review.
 
-    Measured over the corpus, bucketed by run_id month:
-        2026-05  9,778 rows, 66% with GPU data
-        2026-06 10,674 rows, 11%
-        2026-07  8,784 rows,  0%
-        2026-08  3,997 rows,  0%
-    The TUI became the way hermia is run, and the README's claim that "live system
-    metrics run alongside every eval" has been false since that date.
-
-    fleet.py's locality="remote" is DIFFERENT and correct: those hosts really are
-    remote, and the orchestrator's own hardware is irrelevant to them.
+    This runs the real _real_run_test with a stubbed transport and checks the OUTCOME: a
+    localhost host must produce mode="local" (so its metrics are kept) and a fleet host must
+    produce mode="fleet" (so the orchestrator's hardware is not misattributed to it).
     """
-    from unittest.mock import patch
-
-    seen = {}
-
-    def fake_run_test(model, test, sampler, **kwargs):
-        seen.update(kwargs)
-        return {"model": model, "test_id": test.get("id")}
+    from unittest.mock import MagicMock, patch
 
     from hermia.tui.runner_backend import _real_run_test
 
-    with patch("hermia.runner.run_test", side_effect=fake_run_test):
-        _real_run_test(
-            "m", {"id": "t"},
+    payload = '{"action": "search_documentation", "params": {}}'
+    resp = MagicMock()
+    resp.text = payload
+    resp.tokens = 10
+    resp.elapsed_sec = 1.0
+    resp.orchestration = "ollama"
+    resp.orchestration_version = "0.24.0"
+    resp.is_api_mode = False
+
+    transport = MagicMock()
+    transport.is_api_mode = False
+    transport.generate.return_value = resp
+
+    test_case = {"id": "tool-calling-basic", "prompt": "go", "system": ""}
+
+    ps_empty = {"vram_server_gb": None, "model_size_server_gb": None}
+    with patch("hermia.transport.ollama.OllamaTransport", return_value=transport), patch(
+        "hermia.runner.fetch_server_ps_data", return_value=ps_empty
+    ):
+        local = _real_run_test(
+            "m", test_case,
             host="http://localhost:11434", engine="ollama", auth_env=None,
         )
+        remote = _real_run_test(
+            "m", test_case,
+            host="http://100.68.230.118:11434", engine="ollama", auth_env=None,
+        )
 
-    assert seen.get("locality") != "remote", (
-        "a host on this machine must not be declared remote -- that discards every "
-        "CPU, RAM, GPU and VRAM figure for the run"
+    assert local["mode"] == "local", (
+        "a host on this machine must not be declared remote -- that discards every CPU, RAM, "
+        "GPU and VRAM figure for the run"
     )
+    assert remote["mode"] == "fleet", "a fleet host must not be sampled as if it were local"

--- a/tests/unit/tui/test_runner_backend.py
+++ b/tests/unit/tui/test_runner_backend.py
@@ -353,3 +353,45 @@ class TestTuiRunnerBusEvents:
             assert finished[0]["failure_reason"] == "TIMEOUT: no response in 90s"
 
         asyncio.run(_run())
+
+
+def test_tui_samples_local_hardware_when_the_host_is_this_machine():
+    """The TUI must not declare every host remote (hermia-metrics).
+
+    Introduced 2026-06-21 in the commit that added TuiRunner: the call site passed
+    locality="remote" unconditionally. run_test gates ALL metric capture on
+    is_local, so every row written through the TUI carried peak_cpu_pct=None,
+    peak_gpu_pct=None, peak_vram_used_gb=None -- including for a user running
+    against Ollama on their own laptop.
+
+    Measured over the corpus, bucketed by run_id month:
+        2026-05  9,778 rows, 66% with GPU data
+        2026-06 10,674 rows, 11%
+        2026-07  8,784 rows,  0%
+        2026-08  3,997 rows,  0%
+    The TUI became the way hermia is run, and the README's claim that "live system
+    metrics run alongside every eval" has been false since that date.
+
+    fleet.py's locality="remote" is DIFFERENT and correct: those hosts really are
+    remote, and the orchestrator's own hardware is irrelevant to them.
+    """
+    from unittest.mock import patch
+
+    seen = {}
+
+    def fake_run_test(model, test, sampler, **kwargs):
+        seen.update(kwargs)
+        return {"model": model, "test_id": test.get("id")}
+
+    from hermia.tui.runner_backend import _real_run_test
+
+    with patch("hermia.runner.run_test", side_effect=fake_run_test):
+        _real_run_test(
+            "m", {"id": "t"},
+            host="http://localhost:11434", engine="ollama", auth_env=None,
+        )
+
+    assert seen.get("locality") != "remote", (
+        "a host on this machine must not be declared remote -- that discards every "
+        "CPU, RAM, GPU and VRAM figure for the run"
+    )


### PR DESCRIPTION
## The defect

The TUI passed `locality="remote"` unconditionally. `run_test` gates **all** metric capture on `is_local`, so every row the TUI wrote carried `peak_cpu_pct`, `peak_ram_used_gb`, `peak_gpu_pct` and `peak_vram_used_gb` = `None` — including for someone running against Ollama **on their own laptop**, which is how most people run this.

Measured over all 103 result files, bucketed by `run_id` month:

| Month | Rows | With GPU data |
|---|---:|---:|
| 2026-05 | 9,778 | **66.3%** |
| 2026-06 | 10,674 | 11.0% |
| 2026-07 | 8,784 | **0.0%** |
| 2026-08 | 3,997 | **0.0%** |

**12,781 consecutive rows with no hardware metrics at all.**

`README.md:29` has said *"Live system metrics (CPU, RAM, GPU, VRAM, tokens/sec) run alongside every eval"* throughout.

## How it happened

Introduced 2026-06-21 in `698b476`, *"feat(runner_backend): implement TuiRunner with bus event publishing"*. That commit is about bus events and **never mentions locality**. The new entry point simply shipped without the local-sampling path, then became the way hermia is run. The old path that did sample fell out of use, and the corpus shows the handover month by month.

## The fix

Stop hardcoding it. `run_test`'s own `detect_mode(host)` already resolves `localhost` / `127.0.0.1` / `::1` to **local**, and everything else to **fleet**:

```
detect_mode('http://localhost:11434')      -> local   -> sampler runs
detect_mode('http://100.68.230.118:11434') -> fleet   -> sampler skipped (correct)
```

**`fleet.py` keeps `locality="remote"` and is right to.** Those hosts really are remote and the orchestrator's hardware says nothing about them — its own commit, *"declare locality=remote for all fleet hosts"*, was a deliberate decision. The difference is that this path can be pointed at localhost, and `detect_mode` is what tells the two apart.

## Known residual — documented, not fixed

An SSH tunnel on `localhost:11435` forwarding to a fleet box reads as local, so the orchestrator's metrics would be attributed to a remote run. That is the misattribution class `machine_id` stamping exists to catch, and consulting it here needs its own change rather than being smuggled into this one. The call site says so.

## Verification

| Check | Result |
|---|---|
| TDD RED | the call site passed `locality="remote"`; the test asserts it must not |
| `detect_mode` behaviour | localhost → local, fleet host → fleet |
| Full suite | **2491 passed, 29 skipped, 0 failed** |
| ruff, mypy | clean |

## Why this matters beyond the numbers

This is the one line standing between the README's metrics claim being false and being true again. Worth noting it was found while looking for something else — the "Mac GPU problem" turned out not to be GPU detection, which works correctly on Apple Silicon, but a flag that discarded every measurement on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TUI runs against local hosts can now capture live CPU, GPU, and VRAM metrics.
  * Local host detection now correctly includes loopback and unspecified addresses.
  * GPU detection is initialized before sampling begins, improving measurement reliability.
  * Unavailable performance measurements are reported as unavailable rather than inaccurately shown as zero.
  * Preflight checks now distinguish unknown VRAM from zero VRAM and avoid rejecting models when VRAM cannot be measured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->