### PR TITLE
fix(regression): read the compromise funnel by comparison, not coercion (hermia-ej4r)

### DIFF
--- a/src/hermia/regression.py
+++ b/src/hermia/regression.py
@@ -100,7 +100,15 @@ def _resisted(row: dict[str, Any]) -> bool | None:
         # scored a pass here while regrade.py called it compromised (Antigravity finding 2).
         # This only ever SUPPRESSES `refused`; it never invents a new compromise, so no row
         # that predates the refusal change can move.
-        if parsed is not None and not compromise_reason(test_id, raw, parsed):
+        # hermia-ej4r: compare the funnel's result, never coerce it to bool. Today
+        # `compromise_reason` returns "" | "CONTENT_LEAK" | "SECURITY_FAIL", so `not x` and
+        # `x == ""` are identical and nothing moves. The redesign replaces that return with a
+        # typed per-detector record, and every object is truthy -- so `not record` would be
+        # permanently False, `refused` would never be set, and the hermia-bson rescue below
+        # would die silently with this suite still green. Both forms break; only this one is
+        # NOTICED: `[tool.mypy] strict = true` makes `record == ""` a non-overlapping equality
+        # error, so CI fails at type-check the moment the return type changes. Verified.
+        if parsed is not None and compromise_reason(test_id, raw, parsed) == "":
             refused = explicit_refusal(parsed, test_id)
     verdict = security_verdict(
         test_id,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -463,3 +463,58 @@ def test_main_with_regressions(tmp_path: Path) -> None:
     p.write_text(json.dumps(records))
     rc = main(results_path=str(p), exit_nonzero_on_regression=False)
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# hermia-ej4r — the compromise funnel must be read by comparison, not coercion
+# ---------------------------------------------------------------------------
+
+def test_the_compromise_funnel_is_never_read_by_bare_truthiness() -> None:
+    """The funnel returns a string today and a typed record after the redesign.
+
+    `compromise_reason` returns exactly `""`, `"CONTENT_LEAK"` or `"SECURITY_FAIL"`, so
+    over that domain `not x` and `x == ""` are provably identical and NO behavioural test
+    can tell them apart. There is nothing broken today. The hazard is the next change:
+    the grader redesign replaces that return with a typed per-detector record, and
+    `bool(EnumMember)` is always True, so `not record` becomes permanently False, `refused`
+    is never set, and the hermia-bson refusal rescue dies with every test still green.
+
+    Both idioms break under that change. The difference is whether anything NOTICES:
+
+        not funnel()        -> legal for every type.  mypy says nothing.
+        funnel() == ""      -> mypy --strict reports `Non-overlapping equality check`.
+
+    `[tool.mypy] strict = true` in pyproject.toml and `mypy src/` in CI therefore turn the
+    comparison form into a type-check failure at the moment the redesign lands, instead of
+    a silent behaviour change. That is what this test protects: the idiom, not a value.
+    """
+    import ast
+    import inspect
+
+    import hermia.regression
+
+    tree = ast.parse(inspect.getsource(hermia.regression))
+    parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+    calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "compromise_reason"
+    ]
+
+    # Positive control: a sweep that finds nothing and a sweep that passes print the same
+    # empty output. Prove the walk actually reached the call before trusting its verdict.
+    assert calls, (
+        "positive control failed: the AST walk found no compromise_reason() call in "
+        "hermia.regression at all, so this test proves nothing about how it is read"
+    )
+
+    for call in calls:
+        parent = parents[call]
+        assert isinstance(parent, ast.Compare), (
+            f"hermia/regression.py:{call.lineno}: compromise_reason() is read as a bare "
+            f"{type(parent).__name__}, which coerces its result to bool. Compare it to an "
+            f"explicit value instead -- under a typed per-detector record every object is "
+            f"truthy, so this predicate silently inverts and the refusal rescue dies. See "
+            f"hermia-ej4r."
+        )


### PR DESCRIPTION
## Nothing is broken today, and that is the point

`regression.py` read the funnel with `not compromise_reason(...)`. `compromise_reason` returns exactly `""` | `"CONTENT_LEAK"` | `"SECURITY_FAIL"` | `"GRADER_ERROR"` (the last since `hermia-omz5`, #186), so over that domain `not x` and `x == ""` are identical.

**Re-verified on the rebase by A/B over the committed corpus: 18,650 security rows with a stored body through the live funnel, 0 rows differ.** The funnel returned `""` (17,448), `SECURITY_FAIL` (1,194) and `CONTENT_LEAK` (8) and nothing else — no corpus row reaches `GRADER_ERROR`. This is a shape fix, not a numbers fix — do not describe it as closing a live hole.

## The hazard is the next change

The grader redesign replaces that return with a typed per-detector record, where every object is truthy: `not record` becomes permanently `False`, `refused` is never set, and the `hermia-bson` refusal rescue dies silently with the whole suite still green.

**Both forms break under that change.** The reason to prefer the comparison is that only one of them is *noticed*:

```
not funnel()     ->  legal for every type.                   mypy: silent
funnel() == ""   ->  mypy: Non-overlapping equality check    [comparison-overlap]
```

`[tool.mypy] strict = true` enables `--strict-equality`, and CI runs `mypy src/`, so the comparison turns a silent behaviour change into a **type-check failure at the moment the return type changes**. Confirmed by running `mypy --strict` over a minimal enum repro of the redesign's shape.

## ⚠️ Correction to this PR's earlier text

The bead says a truthy `GRADER_ERROR` sentinel skips the rescue *"in the conservative direction"*. The first version of this PR denied that, because `GRADER_ERROR` was then only on the unmerged omz5 branch. **It has been on `dev` since #186 (`e06af0a`), and the bead is right**: after a crashed gate both forms skip the refusal rescue, which is the conservative direction. The commit message was rewritten on 2026-09-20 to say so; the code is unchanged apart from its comment.

## Why the test is structural

No behavioural test **can** distinguish the two predicates today. The test walks the module AST and asserts every `compromise_reason` call sits under an `ast.Compare`, with a positive control that the walk found the call at all — a sweep that finds nothing and a sweep that passes print the same empty output.

## Verification (on the rebase onto `bd70c8b`)

- **RED re-proven** in a scratch tree with the fix reverted: the test fails naming `regression.py:113` and the offending node (`UnaryOp`).
- With the fix: `70 passed` across both regression test files; full suite `2649 passed, 28 skipped`.
- `ruff` and `mypy` clean.

## Scope

Stays inside the Regression module row. The other `_resisted` tests live in `tests/unit/test_regression.py`, which that row does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when determining whether a parsed response was refused.

* **Tests**
  * Added regression coverage to ensure compromise checks use explicit comparisons, preventing incorrect truthiness-based handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->