### PR TITLE
fix(metrics): an unprobed GPU is unknown, never a measurement of zero (hermia-j6a8)

### DIFF
--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -37,7 +37,12 @@ def _find_amdgpu_dev() -> str | None:
             try:
                 with open(vram_path) as f:
                     vram = int(f.read().strip())
-            except OSError:
+            except (OSError, ValueError):
+                # ValueError: the node can exist and be readable yet hold "" or junk (driver
+                # mid-reload, kernel exporting before populating). int("") escapes an
+                # OSError-only handler and crashes ENUMERATION, before the later VRAM read is
+                # ever reached. 0 here only deranks the card for the "most VRAM" sort; the
+                # card is still returned, which is the point.
                 vram = 0
             candidates.append((vram, dev))
         except OSError:
@@ -306,7 +311,7 @@ def detect_gpu() -> dict[str, Any]:
         try:
             with open(f"{_AMD_DEV}/mem_info_vram_total") as f:
                 amd_vram = int(f.read().strip()) / (1024**3)
-        except OSError:
+        except (OSError, ValueError):
             # hermia-j6a8: the card WAS found; only the measurement failed. Substituting
             # 0.0 here publishes a measurement of zero for hardware just identified as
             # present -- `mem_info_vram_total` can be absent, unreadable, or served by a
@@ -342,7 +347,15 @@ def detect_gpu() -> dict[str, Any]:
     # is still found; it is the AMD and Intel paths that have no Windows implementation.)
     # Reaching this point on such a platform means NOT PROBED, which is a different fact from
     # NO GPU PRESENT, and collapsing the two is what let a real card be reported as absent.
-    probed = sys.platform != "win32"
+    # The predicate is "does a probe for every vendor exist on THIS platform", not "is this
+    # Windows". `_find_amdgpu_dev` globs /sys/class/drm, which is Linux sysfs -- it cannot
+    # find a card on macOS either. An Intel Mac with a discrete AMD GPU (Mac Pro, 2019 16",
+    # any eGPU) therefore lands here exactly as Scott's Windows box did, and an earlier
+    # version of this fix would still have published it as vendor='none' -> 'local:cpu' ->
+    # system RAM. Caught by the outside-family gate, which was right: a Windows-shaped fix
+    # for a platform-coverage bug reproduced the bug one platform over.
+    # Linux is the only platform where nvidia, AMD and Intel are all genuinely probed.
+    probed = sys.platform == "linux"
     return {
         "found": False,
         "vendor": "none" if probed else "unknown",

--- a/src/hermia/metrics.py
+++ b/src/hermia/metrics.py
@@ -256,8 +256,10 @@ def detect_gpu() -> dict[str, Any]:
     Tries NVIDIA first (via nvidia-smi), then Apple Silicon (via ioreg/sysctl),
     then AMD (via sysfs), then Intel iGPU (via i915/system_profiler).
     Returns a dict with keys: found (bool), vendor (str), card (str),
-    dev_path (str), vram_total_gb (float).
-    vendor is one of: nvidia, apple, amd, intel, none.
+    dev_path (str), vram_total_gb (float | None -- None means NOT MEASURED, never 0.0).
+    vendor is one of: nvidia, apple, amd, intel, none, unknown.
+    "none" asserts no GPU is present; "unknown" means no probe for this platform
+    could run, so hermia is not entitled to make that assertion (hermia-j6a8).
     """
     global _AMD_DEV, _NVIDIA_FOUND, _NVIDIA_VRAM_TOTAL_GB  # noqa: PLW0603
     global _APPLE_SILICON, _APPLE_VRAM_TOTAL_GB, _INTEL_IGPU  # noqa: PLW0603
@@ -300,17 +302,22 @@ def detect_gpu() -> dict[str, Any]:
     if _AMD_DEV is not None:
         _INTEL_IGPU = False
         card = _AMD_DEV.split("/sys/class/drm/")[-1].split("/")[0]
+        amd_vram: float | None
         try:
             with open(f"{_AMD_DEV}/mem_info_vram_total") as f:
-                vram_total_gb = int(f.read().strip()) / (1024**3)
+                amd_vram = int(f.read().strip()) / (1024**3)
         except OSError:
-            vram_total_gb = 0.0
+            # hermia-j6a8: the card WAS found; only the measurement failed. Substituting
+            # 0.0 here publishes a measurement of zero for hardware just identified as
+            # present -- `mem_info_vram_total` can be absent, unreadable, or served by a
+            # driver mid-reload. None says "not measured", which is the true statement.
+            amd_vram = None
         return {
             "found": True,
             "vendor": "amd",
             "card": card,
             "dev_path": _AMD_DEV,
-            "vram_total_gb": vram_total_gb,
+            "vram_total_gb": amd_vram,
             "compute_cap": 0.0,
         }
 
@@ -327,9 +334,25 @@ def detect_gpu() -> dict[str, Any]:
         }
 
     _INTEL_IGPU = False
+    # hermia-j6a8: "there is no GPU" is a CLAIM, and on some platforms we are not entitled
+    # to make it. The AMD probe is `glob('/sys/class/drm/card*/device/uevent')` and the Intel
+    # probe is equally POSIX, so on Windows neither can see a card that is physically
+    # present -- confirmed on real hardware 2026-09-12, where a 16 GB RX 7800 XT arrived here
+    # and was published as vendor='none'. (nvidia-smi does run on Windows, so an NVIDIA card
+    # is still found; it is the AMD and Intel paths that have no Windows implementation.)
+    # Reaching this point on such a platform means NOT PROBED, which is a different fact from
+    # NO GPU PRESENT, and collapsing the two is what let a real card be reported as absent.
+    probed = sys.platform != "win32"
     return {
-        "found": False, "vendor": "none", "card": "",
-        "dev_path": "", "vram_total_gb": 0.0, "compute_cap": 0.0,
+        "found": False,
+        "vendor": "none" if probed else "unknown",
+        "card": "",
+        "dev_path": "",
+        # Never 0.0. A zero here is a measurement claim about hardware nobody measured --
+        # the same fabrication hermia-dl2e removed from the collectors in PR #180. Absence
+        # of a measurement is None.
+        "vram_total_gb": None,
+        "compute_cap": 0.0,
     }
 
 

--- a/src/hermia/preflight.py
+++ b/src/hermia/preflight.py
@@ -206,7 +206,12 @@ def run_preflight(
     checks: list[ModelCheck] = []
     for name in selected_models:
         size_gb = size_map.get(name, 0.0)
-        fits_total_vram = size_gb <= vram_total
+        # hermia-iqf4: the same rule the next line already applies to `fits_current_vram`.
+        # get_gpu_stats returns None for a field it did not measure -- a CPU-only host, an
+        # unprobed platform, an AMD card whose sysfs value is unreadable -- and comparing a
+        # float to None raises. `vram_available` two lines up guards for exactly this and
+        # this line did not, so a preflight on any GPU-less machine crashed outright.
+        fits_total_vram = True if vram_total is None else size_gb <= vram_total
         # Unknown VRAM is not a failing check. Refusing to guess beats guessing wrong in
         # either direction -- a false "will not fit" is as unhelpful as a false "will".
         fits_current_vram = True if vram_available is None else size_gb <= vram_available

--- a/src/hermia/submit.py
+++ b/src/hermia/submit.py
@@ -187,15 +187,27 @@ def compute_unified_memory_gb(gpu_info: dict[str, Any]) -> float | None:
     to reject the submission.
     """
     vendor: str = gpu_info.get("vendor", "none")
-    vram: float = gpu_info.get("vram_total_gb", 0.0)
+    vram: float | None = gpu_info.get("vram_total_gb")
 
     try:
+        # hermia-j6a8: "unknown" means no probe for this platform could run -- not that the
+        # machine has no GPU. The guard below deliberately refuses to substitute system RAM
+        # for a discrete card, but it is keyed on the vendor being KNOWN, and this is the
+        # failure mode where it is not. Without this branch a Windows box with a 16 GB card
+        # publishes its system RAM instead: a plausible number of the wrong quantity, and
+        # indistinguishable from a genuine CPU-only host. Confirmed on hardware 2026-09-12.
+        if vendor == "unknown":
+            return None
         if vendor in ("nvidia", "amd"):
             # Discrete GPUs do NOT share system RAM. If VRAM detection failed
-            # (vram == 0.0), report None rather than a misleading system-RAM
-            # figure — let the server decide how to handle the missing value.
-            return float(vram) if vram > 0.0 else None
-        if vendor == "apple" and vram > 0.0:
+            # (vram is None, or 0.0 on an older row), report None rather than a
+            # misleading system-RAM figure — let the server decide how to handle
+            # the missing value. The None check is explicit rather than left to
+            # the handler below: a TypeError swallowed by `except Exception`
+            # produces the right answer for the wrong reason, and would stop
+            # doing so the moment that handler is narrowed.
+            return float(vram) if vram is not None and vram > 0.0 else None
+        if vendor == "apple" and vram is not None and vram > 0.0:
             # Apple Silicon: unified memory == measured VRAM when available.
             return float(vram)
         # Apple w/o measured VRAM, Intel iGPU, and CPU-only systems: total

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,7 +1,9 @@
 """Unit tests for MetricsSampler and GPU detection."""
 
 import json
+import sys
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -868,3 +870,81 @@ def test_sampler_primes_the_cpu_counter(clean_gpu_globals):
         s.start()
         s.stop()
     assert calls, "start() must take and discard a priming reading"
+
+
+# ---------------------------------------------------------------------------
+# hermia-j6a8 — an unprobed GPU is UNKNOWN, never zero
+# ---------------------------------------------------------------------------
+
+def _no_gpu_anywhere(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every probe come up empty, as they all do on Windows for a non-NVIDIA card."""
+    monkeypatch.setattr(metrics_mod, "_detect_nvidia", lambda: (False, "", 0.0, 0.0))
+    monkeypatch.setattr(metrics_mod, "_detect_apple_silicon", lambda: (False, "", 0.0))
+    monkeypatch.setattr(metrics_mod, "_find_amdgpu_dev", lambda: None)
+    monkeypatch.setattr(metrics_mod, "_detect_intel_igpu", lambda: (False, ""))
+
+
+def test_unprobed_platform_reports_unknown_not_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows, "no GPU" is a claim hermia is not entitled to make.
+
+    Confirmed on real hardware 2026-09-12: a 16 GB RX 7800 XT reported vendor='none'.
+    The AMD probe is `glob('/sys/class/drm/card*/device/uevent')` -- Linux sysfs -- and the
+    Intel probe is equally POSIX, so on Windows neither can find a card that is physically
+    present. nvidia-smi DOES work on Windows, so an NVIDIA card is still detected; it is
+    specifically the AMD and Intel paths that have no Windows implementation. An empty
+    result there means NOT PROBED, which is a different fact from NO GPU PRESENT.
+    """
+    _no_gpu_anywhere(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "win32")
+    info = metrics_mod.detect_gpu()
+    assert info["vendor"] == "unknown", (
+        "a platform with no AMD/Intel probe must not claim there is no GPU"
+    )
+    assert info["found"] is False
+
+
+def test_unprobed_platform_does_not_fabricate_a_vram_measurement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """0.0 GB is a MEASUREMENT. None is the absence of one. They are not interchangeable."""
+    _no_gpu_anywhere(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert metrics_mod.detect_gpu()["vram_total_gb"] is None
+
+
+def test_genuinely_gpu_less_posix_host_still_reports_none_vendor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On Linux every probe is implemented, so an empty result IS evidence of no GPU.
+
+    This is the negative control for the test above: the fix must not turn every
+    CPU-only host into "unknown", which would destroy a real signal.
+    """
+    _no_gpu_anywhere(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "linux")
+    info = metrics_mod.detect_gpu()
+    assert info["vendor"] == "none"
+    assert info["vram_total_gb"] is None, "absent VRAM is still not a measurement of zero"
+
+
+def test_found_amd_card_with_unreadable_vram_reports_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same fabrication, one layer down: the card IS found, the measurement is not.
+
+    `mem_info_vram_total` can be absent or unreadable (permissions, a kernel that does not
+    export it, a driver mid-reload). The except arm used to substitute 0.0, publishing a
+    measurement of zero for a card hermia had just successfully identified.
+    """
+    monkeypatch.setattr(metrics_mod, "_detect_nvidia", lambda: (False, "", 0.0, 0.0))
+    monkeypatch.setattr(metrics_mod, "_detect_apple_silicon", lambda: (False, "", 0.0))
+    # A real device path whose mem_info_vram_total does not exist -> the except arm.
+    dev = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
+    dev.mkdir(parents=True)
+    monkeypatch.setattr(metrics_mod, "_find_amdgpu_dev", lambda: str(dev))
+
+    info = metrics_mod.detect_gpu()
+
+    assert info["found"] is True, "positive control: the card must still be detected"
+    assert info["vendor"] == "amd"
+    assert info["vram_total_gb"] is None, "an unreadable measurement is not a measurement of 0"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -884,7 +884,9 @@ def _no_gpu_anywhere(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(metrics_mod, "_detect_intel_igpu", lambda: (False, ""))
 
 
-def test_unprobed_platform_reports_unknown_not_none(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unprobed_platform_reports_unknown_not_none(
+    monkeypatch: pytest.MonkeyPatch, clean_gpu_globals: None
+) -> None:
     """On Windows, "no GPU" is a claim hermia is not entitled to make.
 
     Confirmed on real hardware 2026-09-12: a 16 GB RX 7800 XT reported vendor='none'.
@@ -904,7 +906,7 @@ def test_unprobed_platform_reports_unknown_not_none(monkeypatch: pytest.MonkeyPa
 
 
 def test_unprobed_platform_does_not_fabricate_a_vram_measurement(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, clean_gpu_globals: None
 ) -> None:
     """0.0 GB is a MEASUREMENT. None is the absence of one. They are not interchangeable."""
     _no_gpu_anywhere(monkeypatch)
@@ -913,7 +915,7 @@ def test_unprobed_platform_does_not_fabricate_a_vram_measurement(
 
 
 def test_genuinely_gpu_less_posix_host_still_reports_none_vendor(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, clean_gpu_globals: None
 ) -> None:
     """On Linux every probe is implemented, so an empty result IS evidence of no GPU.
 
@@ -927,8 +929,27 @@ def test_genuinely_gpu_less_posix_host_still_reports_none_vendor(
     assert info["vram_total_gb"] is None, "absent VRAM is still not a measurement of zero"
 
 
+def test_intel_mac_with_discrete_amd_gpu_is_unknown_not_none(
+    monkeypatch: pytest.MonkeyPatch, clean_gpu_globals: None
+) -> None:
+    """macOS has no /sys/class/drm either, so the AMD probe is as blind there as on Windows.
+
+    Found by the outside-family review gate on the first version of this fix, which keyed
+    on `sys.platform != "win32"` and so still published an Intel Mac with a discrete AMD
+    card (Mac Pro, 2019 16-inch, any eGPU) as vendor='none' -> 'local:cpu' -> system RAM.
+    That is the exact defect this bead exists to remove, reproduced one platform over.
+    """
+    _no_gpu_anywhere(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    info = metrics_mod.detect_gpu()
+    assert info["vendor"] == "unknown", (
+        "the AMD sysfs probe cannot run on darwin, so 'no GPU' is not a claim we can make"
+    )
+    assert info["vram_total_gb"] is None
+
+
 def test_found_amd_card_with_unreadable_vram_reports_none(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, clean_gpu_globals: None
 ) -> None:
     """Same fabrication, one layer down: the card IS found, the measurement is not.
 
@@ -948,3 +969,46 @@ def test_found_amd_card_with_unreadable_vram_reports_none(
     assert info["found"] is True, "positive control: the card must still be detected"
     assert info["vendor"] == "amd"
     assert info["vram_total_gb"] is None, "an unreadable measurement is not a measurement of 0"
+
+
+def test_amd_vram_file_that_is_empty_or_garbage_does_not_crash_detection(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, clean_gpu_globals: None
+) -> None:
+    """`int("")` raises ValueError, which an `except OSError` does not catch.
+
+    The file can exist and be readable yet hold nothing useful -- a driver mid-reload, a
+    kernel that exports the node before populating it. The original except arm named only
+    OSError, so this escaped as an unhandled crash out of detect_gpu() rather than being
+    recorded as an unmeasured value. Found by the outside-family gate.
+    """
+    dev = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
+    dev.mkdir(parents=True)
+    monkeypatch.setattr(metrics_mod, "_detect_nvidia", lambda: (False, "", 0.0, 0.0))
+    monkeypatch.setattr(metrics_mod, "_detect_apple_silicon", lambda: (False, "", 0.0))
+    monkeypatch.setattr(metrics_mod, "_find_amdgpu_dev", lambda: str(dev))
+
+    for garbage in ("", "   ", "not-a-number", "12.5GB"):
+        (dev / "mem_info_vram_total").write_text(garbage, encoding="utf-8")
+        info = metrics_mod.detect_gpu()
+        assert info["found"] is True, f"card must still be found for {garbage!r}"
+        assert info["vram_total_gb"] is None, f"{garbage!r} is not a measurement"
+
+
+def test_amd_enumeration_survives_a_garbage_vram_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, clean_gpu_globals: None
+) -> None:
+    """The same flaw sits one level earlier, in _find_amdgpu_dev's ranking read.
+
+    It crashes during card ENUMERATION, before detect_gpu() reaches the VRAM read at all,
+    so fixing only the later site would leave the earlier one live.
+    """
+    drm = tmp_path / "sys" / "class" / "drm"
+    dev = drm / "card0" / "device"
+    dev.mkdir(parents=True)
+    (dev / "uevent").write_text("DRIVER=amdgpu\n", encoding="utf-8")
+    (dev / "mem_info_vram_total").write_text("", encoding="utf-8")
+    monkeypatch.setattr(metrics_mod.glob, "glob", lambda _p: [str(dev / "uevent")])
+
+    assert metrics_mod._find_amdgpu_dev() == str(dev), (
+        "a card with an unreadable VRAM value still exists and must still be enumerated"
+    )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -934,10 +934,18 @@ def test_intel_mac_with_discrete_amd_gpu_is_unknown_not_none(
 ) -> None:
     """macOS has no /sys/class/drm either, so the AMD probe is as blind there as on Windows.
 
-    Found by the outside-family review gate on the first version of this fix, which keyed
-    on `sys.platform != "win32"` and so still published an Intel Mac with a discrete AMD
-    card (Mac Pro, 2019 16-inch, any eGPU) as vendor='none' -> 'local:cpu' -> system RAM.
-    That is the exact defect this bead exists to remove, reproduced one platform over.
+    Found by the outside-family review gate on the first version of this fix, which keyed on
+    `sys.platform != "win32"` and so still published a darwin host reaching this fallback as
+    vendor='none' -> 'local:cpu' -> system RAM -- the exact defect this bead exists to remove,
+    reproduced one platform over.
+
+    ⚠️ SCOPE, narrowed after a SECOND gate pass called out the original wording. This proves
+    only what it mocks: a darwin host where every probe came up empty. It does NOT prove the
+    2019 16-inch MacBook Pro case its first docstring claimed, because that machine has an
+    Intel UHD 630 alongside its discrete AMD card, `_detect_intel_igpu` matches ANY darwin
+    display whose model contains "Intel", and it is checked BEFORE this fallback -- so such a
+    machine exits at vendor='intel' and never reaches the code under test. That shadowing is
+    a real, separate defect (hermia-mont) and this test must not be read as covering it.
     """
     _no_gpu_anywhere(monkeypatch)
     monkeypatch.setattr(sys, "platform", "darwin")

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -285,3 +285,36 @@ def test_ollama_security_survives_non_json_body():
     with patch("requests.get", return_value=r):
         warns = check_ollama_security("http://x:11434", fleet_mode=True)
     assert not any("CVE-2026-7482" in w for w in warns)
+
+
+# ---------------------------------------------------------------------------
+# hermia-iqf4 — unmeasured VRAM must not crash the preflight
+# ---------------------------------------------------------------------------
+
+def test_preflight_survives_a_host_where_vram_was_never_measured(tmp_path: Path) -> None:
+    """get_gpu_stats returns None for a field it did not measure, and says so in its docstring.
+
+    `run_preflight` guards `vram_available` for that case on one line and then compares
+    `size_gb <= vram_total` on the next, which raises TypeError. Every test in this file
+    used `_mock_gpu(total=8.0)`, so no test ever passed None through and the crash was
+    invisible. Found by the outside-family gate on hermia-j6a8; the crash itself arrived
+    with PR #180, which widened get_gpu_stats to `| None`.
+
+    Unknown VRAM is not a FAILING check -- the comment three lines below the crash already
+    says exactly that about `fits_current_vram`. Refusing to guess beats guessing wrong.
+    """
+    with patch("hermia.preflight.get_gpu_stats", return_value=(None, None, None)), \
+         _mock_ram(available_gb=64.0), _mock_disk():
+        report = run_preflight(
+            selected_models=["llama3.2:latest"],
+            model_list=[{"name": "llama3.2:latest", "size": 2_000_000_000}],
+            results_dir=tmp_path,
+        )
+
+    assert len(report.models) == 1
+    check = report.models[0]
+    assert check.skip is False, "a model must not be skipped because VRAM is unknown"
+    assert "VRAM" not in check.reason, (
+        f"an unmeasured VRAM must not produce a VRAM-based reason: {check.reason!r}"
+    )
+    assert report.vram_total_gb is None, "the report must carry the absence, not a zero"

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -700,3 +700,56 @@ def test_submit_command_no_results_file_exits_1(
     with pytest.raises(SystemExit) as exc:
         submit_command(results_path=None, dry_run=False, yes=True)
     assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# hermia-j6a8 — an unprobed GPU must not become a system-RAM figure
+# ---------------------------------------------------------------------------
+
+def test_unknown_vendor_does_not_fall_back_to_system_ram() -> None:
+    """The existing guard is keyed on the vendor being KNOWN; Windows fails the other way.
+
+    `compute_unified_memory_gb` already refuses to substitute system RAM for a discrete GPU
+    whose VRAM probe failed -- its own comment says so. But that branch is reached only when
+    the vendor is 'nvidia' or 'amd'. On Windows the AMD probe cannot run at all, so the
+    vendor is not known, control falls through to the CPU-only branch, and the machine
+    publishes total system RAM as its memory figure -- a plausible number of the wrong
+    quantity, indistinguishable from a genuine CPU-only host.
+
+    Confirmed on real hardware 2026-09-12 with a 16 GB RX 7800 XT.
+    """
+    assert compute_unified_memory_gb({"vendor": "unknown", "vram_total_gb": None}) is None
+
+
+def test_discrete_gpu_with_unmeasured_vram_is_none_not_zero() -> None:
+    """vram_total_gb is now None rather than 0.0 when nothing was measured.
+
+    Previously this arrived as 0.0 and was caught by `vram > 0.0`. With None that comparison
+    would raise, and the bare `except Exception` would return None by ACCIDENT rather than by
+    decision. Pin the decision.
+    """
+    assert compute_unified_memory_gb({"vendor": "amd", "vram_total_gb": None}) is None
+
+
+def test_genuine_cpu_only_host_still_reports_system_ram() -> None:
+    """Negative control: the fix must not blind hermia to real CPU-only machines.
+
+    A POSIX host where every probe ran and found nothing is genuinely GPU-less, and system
+    RAM is the meaningful figure there. That behaviour is deliberate and must survive.
+    """
+    result = compute_unified_memory_gb({"vendor": "none", "vram_total_gb": None})
+    assert result is not None
+    assert result > 0.0
+
+
+def test_unprobed_host_is_not_classified_as_cpu_only() -> None:
+    """The most user-visible consequence of the old fabrication.
+
+    vendor='none' maps to 'local:cpu'. Before hermia-j6a8 a Windows machine with a 16 GB
+    discrete card arrived here as 'none' and was published as a CPU-only host -- the
+    taxonomy value used to interpret every result row from that machine. 'unknown' falls
+    through to 'local:other', which is the honest answer: not a CPU host, and not a class
+    we can name.
+    """
+    assert compute_host_class({"vendor": "unknown", "card": ""}) == "local:other"
+    assert compute_host_class({"vendor": "none", "card": ""}) == "local:cpu"


### PR DESCRIPTION
## Confirmed on real hardware

The first time hermia ran natively on Windows, a 16 GB RX 7800 XT was published as `vendor='none'`, `vram_total_gb=0.0`.

The AMD probe globs `/sys/class/drm/card*/device/uevent` and the Intel probe is equally POSIX, so on Windows neither can see a card that is physically present. (`nvidia-smi` **does** run on Windows, so an NVIDIA card is still found.) Reaching the terminal fallback there means **not probed** — a different fact from **no GPU present**, and collapsing the two published a real card as absent.

## Three defects, and the second is the one that hurts

1. **`vendor='none'` asserts there is no GPU.** Now `'unknown'` where no probe could run. `compute_host_class` maps `'none'` to `local:cpu`, so the Windows box was being classified **CPU-only** — the taxonomy value used to interpret every row it produces.

2. **The existing safety net was keyed on the wrong condition.** `compute_unified_memory_gb` already refuses to substitute system RAM for a discrete card — its own comment says so — but only when the vendor is *known*. The Windows failure mode is the vendor being *unknown*, so control reached the CPU-only branch and the machine submitted **total system RAM**: a plausible number of the wrong quantity.

3. **`0.0` GB is a measurement claim about hardware nobody measured** — the same fabrication `hermia-dl2e` removed from the collectors in #180. Now `None` in the terminal fallback **and** in the AMD branch, where a found card with an unreadable `mem_info_vram_total` used to report zero.

## Two Antigravity passes, and the second one earned its keep

**Pass 1** found that my fix was *Windows-shaped for a platform-coverage bug*, and so reproduced the bug one platform over: `probed = sys.platform != "win32"` assumes every non-Windows OS is fully probed, but `/sys/class/drm` does not exist on macOS either. The predicate is now `== "linux"`, the only platform where nvidia, AMD and Intel are all genuinely probed. It also found a `ValueError` escaping an `OSError`-only handler at **two** sites, and that my four new tests skipped the `clean_gpu_globals` fixture the other 21 tests use.

**Pass 2, on the remediated diff, found that one of my tests was over-claiming.** It said it covered a 2019 16-inch MacBook Pro; that machine's Intel iGPU shadows its discrete AMD card and is matched first, so the test passed only because it mocked the Intel probe away. Docstring narrowed to what it proves; the real defect filed as `hermia-mont`.

## Verified, then filed rather than fixed

| Bead | Why not here |
|---|---|
| `hermia-mont` — *an Intel iGPU shadows a discrete AMD card on macOS* | same shape, different route; no Intel Mac to verify on |
| `hermia-gq0g` — *every AMD GPU is classified `local:vulkan/amd`* | `card` holds the DRM node name `card0`, never the model. Pre-existing; the rdna3/rdna2/instinct branches are dead code on real hardware |
| `hermia-fkce` — *discrete Intel Arc reports 0.0 and publishes host RAM* | a probe ran and gave a wrong value for one hardware class; no Arc machine |
| `hermia-xqqj` — *`detect_gpu()` returns `dict[str, Any]`* | unlike #180, mypy could **not** enumerate callers here; the sweep was manual and the tests do that work |

`hermia-iqf4` (*run_preflight crashes where VRAM was not measured*) **is** fixed here — flagged CRITICAL by both passes and inside the permitted module row. Agy blamed this diff; proven pre-existing by running the same reproduction against `origin/dev` and getting a byte-identical `TypeError`. It arrived with #180.

## A deliberate trade, documented not fixed

Windows CPU-only hosts now classify as `local:other` with no memory figure rather than `local:cpu` with system RAM. The two cases are indistinguishable from inside the process; one error is a lie and the other is an absence, and this project ranks absence above a plausible wrong number.

## Verification

Every change TDD, each RED proven before its fix — including negative controls keeping a genuinely GPU-less POSIX host on `'none'` + system RAM, and a found-but-unmeasured AMD card on `found=True`.

Suite: `2511 passed, 29 skipped, 0 failed`. `ruff` and `mypy` clean.

## Scope

Crosses into `src/hermia/submit.py`, outside the Metrics module boundary row. **Approved by Scott before any code was written.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPU detection when VRAM information is unavailable or unreadable; systems are no longer incorrectly reported as having zero VRAM.
  - Prevented preflight checks from failing when total VRAM cannot be measured.
  - Unknown GPU platforms are now distinguished from systems confirmed to have no GPU.
  - Prevented unavailable discrete-GPU VRAM from being incorrectly replaced with system memory.
  - CPU-only systems continue to use system memory for capacity calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->